### PR TITLE
change database version extraction

### DIFF
--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -55,14 +55,9 @@ class AdapterTestSqlserver < ActiveRecord::TestCase
     context 'for database version' do
       
       setup do
-        @version_regexp = ActiveRecord::ConnectionAdapters::SQLServerAdapter::DATABASE_VERSION_REGEXP
         @supported_version = ActiveRecord::ConnectionAdapters::SQLServerAdapter::SUPPORTED_VERSIONS
         @sqlserver_2005_string = "Microsoft SQL Server 2005 - 9.00.3215.00 (Intel X86)"
         @sqlserver_2008_string = "Microsoft SQL Server 2008 (RTM) - 10.0.1600.22 (Intel X86)"
-      end
-      
-      should 'return a string from #database_version that matches class regexp' do
-        assert_match @version_regexp, @connection.database_version
       end
       
       should 'return a 4 digit year fixnum for #database_year' do


### PR DESCRIPTION
So I left database_year & database_version.
But now database_year is defined not from full version but from major version. Because of that I removed regexp & changed a bit methods sqlserver_2008? and sqlserver_2005? 
Also method supports_sqlserver_2008? added. Sql Server 2011 isn't Sql Server 2008, but has also types date & time. !supports_sqlserver_2008? can be used instead of sqlserver_2005?
