### PR TITLE
The config hash might be a HashWithIndifferentAccess, which no longer has the method symbolize_keys!

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -17,7 +17,7 @@ module ActiveRecord
   class Base
     
     def self.sqlserver_connection(config) #:nodoc:
-      config = config.dup.symbolize_keys!
+      config = config.symbolize_keys
       config.reverse_merge! :mode => :odbc, :host => 'localhost', :username => 'sa', :password => ''
       mode = config[:mode].to_s.downcase.underscore.to_sym
       case mode


### PR DESCRIPTION
I found this problem while working in conjunction with the octopus gem: https://github.com/tchandy/octopus
