### PR TITLE
self.enable_default_unicode_types = true does not work, using Class Varia

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -171,7 +171,7 @@ module ActiveRecord
                      :log_info_schema_queries, :enable_default_unicode_types, :auto_connect,
                      :cs_equality_operator, :lowercase_schema_reflection
       
-      self.enable_default_unicode_types = true
+      @@enable_default_unicode_types = true
       
       
       def initialize(logger,config)


### PR DESCRIPTION
self.enable_default_unicode_types = true does not work, using Class Variable.

Fresh project, no config/initializer file is creating varchar fields instead of nvarchar fields.
