### PR TITLE
Superclass mismatch for class Ordering

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -6,7 +6,7 @@ module Arel
 
     # Extending the Ordering class to be comparrison friendly which allows us to call #uniq on a
     # collection of them. See SelectManager#order for more details.
-    class Ordering < Arel::Nodes::Binary
+    class Ordering < Arel::Nodes::Unary
       def hash
         expr.hash
       end


### PR DESCRIPTION
I'm not sure if this is the proper fix or not, but I was continually getting the following back trace when trying to start rails 3.1.rc4 with activerecord-sqlserver-adapter 3.1.0.rc2. (I also tried with rails 3-1-stable and the adapter straight from source, with the same error):

```
/Users/jeff/.rvm/gems/ruby-1.9.2-p180@add-drop/bundler/gems/activerecord-sqlserver-adapter-b05af6152505/lib/arel/visitors/sqlserver.rb:9:in `<module:Nodes>': superclass mismatch for class Ordering (TypeError)
    from /Users/jeff/.rvm/gems/ruby-1.9.2-p180@add-drop/bundler/gems/activerecord-sqlserver-adapter-b05af6152505/lib/arel/visitors/sqlserver.rb:5:in `<module:Arel>'
    from /Users/jeff/.rvm/gems/ruby-1.9.2-p180@add-drop/bundler/gems/activerecord-sqlserver-adapter-b05af6152505/lib/arel/visitors/sqlserver.rb:3:in `<top (required)>'
    from /Users/jeff/.rvm/gems/ruby-1.9.2-p180@add-drop/bundler/gems/activerecord-sqlserver-adapter-b05af6152505/lib/active_record/connection_adapters/sqlserver_adapter.rb:1:in `require'
```

I checked the superclass of Arel::Nodes::Ordering and found (for Arel 2.1.3) that it is Arel::Nodes::Unary, not Arel::Nodes::Binary. Once I made that switch, Rails started without any problems and I was able to connect to SQL Server.

You can also cause this error by simply opening irb and doing:

```
require 'arel'
require 'activerecord-sqlserver-adapter'
```

Again, I'm not 100% sure this is the proper fix, but it is what I needed to do to get this gem working with rails 3.1rc4.
