### PR TITLE
Fix Configure Connection related readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,23 +149,21 @@ ActiveRecord::ConnectionAdapters::SQLServerAdapter.auto_connect = false
 
 #### Configure Connection & App Name
 
-We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes. Also, TinyTDS supports and application name when it logs into SQL Server. This can be used to identify the connection in SQL Server's activity monitor. By default it will use the `appname` from your database.yml file or a lowercased version of your Rails::Application name. It is now possible to define a `configure_application_name` method that can give you per instance details. Below shows how you might use this to get the process id and thread id of the current connection.
+We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes. Also, TinyTDS supports an application name when it logs into SQL Server. This can be used to identify the connection in SQL Server's activity monitor. By default it will use the `appname` from your database.yml file or a lowercased version of your Rails::Application name. It is now possible to define a `configure_application_name` method that can give you per instance details. Below shows how you might use this to get the process id and thread id of the current connection.
 
 ```ruby
 module ActiveRecord
-  class Base
-    module ConnectionAdapters
-      class SQLServerAdapter < AbstractAdapter
+  module ConnectionAdapters
+    class SQLServerAdapter < AbstractAdapter
 
-        def configure_connection
-          do_execute "SET TEXTSIZE #{64.megabytes}"
-        end
-
-        def configure_application_name
-          "myapp_#{$$}_#{Thread.current.object_id}".to(29)
-        end
-
+      def configure_connection
+        do_execute "SET TEXTSIZE #{64.megabytes}"
       end
+
+      def configure_application_name
+        "myapp_#{$$}_#{Thread.current.object_id}".to(29)
+      end
+
     end
   end
 end


### PR DESCRIPTION
In the README you have the `configure_connection` method being defined in `ActiveRecord::Base::ConnectionAdapters::SqlServerAdapter`. I believe this should be `ActiveRecord::ConnectionAdapters::SqlServerAdapter`.

However, even with the corrected name spacing, as far as I can tell, this doesn't actually work. When I set up an initializer like this:

``` ruby
module ActiveRecord
  module ConnectionAdapters
    class SQLServerAdapter < AbstractAdapter
      def configure_connection
        do_execute "set concat_null_yields_null on"
      end
    end
  end  
end
```

I get 

```
ActiveRecord::StatementInvalid (NoMethodError: undefined method `instrument' for nil:NilClass: set concat_null_yields_null on):

activesupport (3.1.1) lib/active_support/whiny_nil.rb:48:in `method_missing'
activerecord (3.1.1) lib/active_record/connection_adapters/abstract_adapter.rb:239:in `log'
activerecord-sqlserver-adapter (3.1.2) lib/active_record/connection_adapters/sqlserver/database_statements.rb:264:in `do_execute'
config/initializers/sqlserver_options.rb:5:in `configure_connection'
activerecord-sqlserver-adapter (3.1.2) lib/active_record/connection_adapters/sqlserver_adapter.rb:430:in `connect'
activerecord-sqlserver-adapter (3.1.2) lib/active_record/connection_adapters/sqlserver_adapter.rb:193:in `initialize'
activerecord-sqlserver-adapter (3.1.2) lib/active_record/connection_adapters/sqlserver_adapter.rb:34:in `new'
activerecord-sqlserver-adapter (3.1.2) lib/active_record/connection_adapters/sqlserver_adapter.rb:34:in `sqlserver_connection'
activerecord (3.1.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:304:in `new_connection'
...snip...
```

This is with Rails 3.1.1, TinyTDS 0.4.5, and activerecord-sqlserver-adapter 3.1.2. I also I created a completely fresh app to test this with, and got the same results.

The error is coming from here: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L252

Which leads me to believe this is happening because `connect` is called before `super`, here: https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/lib/active_record/connection_adapters/sqlserver_adapter.rb#L193, so `@instrumenter` hasn't been initialized yet.
