### PR TITLE
Populate the spid attribute on connect and reset it on disconnect for dblib

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -176,7 +176,7 @@ module ActiveRecord
       DATABASE_VERSION_REGEXP     = /Microsoft SQL Server\s+"?(\d{4}|\w+)"?/
       SUPPORTED_VERSIONS          = [2005,2008,2010,2011].freeze
       
-      attr_reader :database_version, :database_year
+      attr_reader :database_version, :database_year, :spid
       
       cattr_accessor :native_text_database_type, :native_binary_database_type, :native_string_database_type,
                      :log_info_schema_queries, :enable_default_unicode_types, :auto_connect,
@@ -269,6 +269,7 @@ module ActiveRecord
       end
 
       def disconnect!
+        @spid = nil
         case @connection_options[:mode]
         when :dblib
           @connection.close rescue nil
@@ -399,6 +400,7 @@ module ActiveRecord
                           :encoding      => encoding,
                           :azure         => config[:azure]
                         }).tap do |client|
+                          @spid = client.execute("SELECT @@spid").first.values.first
                           if config[:azure]
                             client.execute("SET ANSI_NULLS ON").do
                             client.execute("SET CURSOR_CLOSE_ON_COMMIT OFF").do

--- a/test/cases/connection_test_sqlserver.rb
+++ b/test/cases/connection_test_sqlserver.rb
@@ -11,7 +11,6 @@ class ConnectionTestSqlserver < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.connection
   end
   
-  
   should 'affect rows' do
     topic_data = { 1 => { "content" => "1 updated" }, 2 => { "content" => "2 updated" } }
     updated = Topic.update(topic_data.keys, topic_data.values)
@@ -91,6 +90,17 @@ class ConnectionTestSqlserver < ActiveRecord::TestCase
     
     setup do
       assert @connection.active?
+    end
+    
+    if connection_mode_dblib?
+      should 'set spid on connect' do
+        assert @connection.spid.kind_of?(Fixnum)
+      end
+    
+      should 'reset spid on disconnect!' do
+        @connection.disconnect!
+        assert @connection.spid.nil?
+      end
     end
     
     should 'be able to disconnect and reconnect at will' do


### PR DESCRIPTION
This is useful for debugging client connections.
