### PR TITLE
Handle statements that cannot be retried on a new database connection by not reconnecting. 

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -50,7 +50,7 @@ module ActiveRecord
         end
 
         def commit_db_transaction
-          do_execute "COMMIT TRANSACTION"
+          disable_auto_reconnect { do_execute "COMMIT TRANSACTION" }
         end
 
         def rollback_db_transaction
@@ -58,14 +58,14 @@ module ActiveRecord
         end
 
         def create_savepoint
-          do_execute "SAVE TRANSACTION #{current_savepoint_name}"
+          disable_auto_reconnect { do_execute "SAVE TRANSACTION #{current_savepoint_name}" }
         end
 
         def release_savepoint
         end
 
         def rollback_to_savepoint
-          do_execute "ROLLBACK TRANSACTION #{current_savepoint_name}"
+          disable_auto_reconnect { do_execute "ROLLBACK TRANSACTION #{current_savepoint_name}" }
         end
 
         def add_limit_offset!(sql, options)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -477,6 +477,13 @@ module ActiveRecord
         end
       end
       
+      def disable_auto_reconnect
+        old_auto_connect, self.class.auto_connect = self.class.auto_connect, false
+        yield
+      ensure
+        self.class.auto_connect = old_auto_connect
+      end
+      
       def auto_reconnected?
         return false unless auto_connect
         @auto_connecting = true


### PR DESCRIPTION
For example, retrying commit_db_transaction on a new connection would result in:
The COMMIT TRANSACTION request has no corresponding BEGIN TRANSACTION.: COMMIT TRANSACTION
