### PR TITLE
Disabling transactions on ddl operations

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -242,7 +242,7 @@ module ActiveRecord
       end
       
       def supports_ddl_transactions?
-        @supports_ddl_transactions ||= false
+        @supports_ddl_transactions ||= true
       end
       
       def disable_ddl_transactions


### PR DESCRIPTION
Some operations like the creation of fulltext catalogs cannot run inside transactions, meaning that i cannot put these operations on my migrations if "supports_ddl_transactions" always returns true.
