### PR TITLE
Patch for issue #167 problem with exists? on queries using an offset.

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -156,7 +156,7 @@ module Arel
         [ ("SELECT" if !windowed),
           (visit(core.set_quantifier) if core.set_quantifier),
           (visit(o.limit) if o.limit && !windowed),
-          (projections.map{ |x| visit(x) }.join(', ')),
+          (projections.map{ |x| v = visit(x); v == "1" ? "1 AS [__wrp]" : v }.join(', ')),
           (source_with_lock_for_select_statement(o)),
           ("WHERE #{core.wheres.map{ |x| visit(x) }.join ' AND ' }" unless core.wheres.empty?),
           ("GROUP BY #{groups.map { |x| visit x }.join ', ' }" unless groups.empty?),

--- a/test/cases/offset_and_limit_test_sqlserver.rb
+++ b/test/cases/offset_and_limit_test_sqlserver.rb
@@ -20,14 +20,18 @@ class OffsetAndLimitTestSqlserver < ActiveRecord::TestCase
   
   context 'When selecting with offset' do
 
-    should 'have limit (top) of 2147483647 if only offset is passed' do
+    should 'have limit (top) of 9223372036854775807 if only offset is passed' do
       assert_sql(/SELECT TOP \(9223372036854775807\) \[__rnt\]\.\* FROM.*WHERE \[__rnt\]\.\[__rn\] > \(1\)/) { Book.all(:offset=>1) }
     end
 
+    should 'support calling exists?' do
+      assert Book.offset(3).exists?
+    end
   end
   
   context 'When selecting with limit and offset' do
     
+
     should 'work with fully qualified table and columns in select' do 
       books = Book.all :select => 'books.id, books.name', :limit => 3, :offset => 5
       assert_equal Book.all[5,3].map(&:id), books.map(&:id)


### PR DESCRIPTION
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/167

Summary:

calling exists? on a model that has an offset fails, because there is an unnamed column that is created in rails to select "1" in exists?.  This is problematic for us, since SQL Server doesn't like unnamed columns in subqueries, and we have to use subqueries to manage offset.

This fix is something of a hack, essentially checking if the node that we are visiting is "1", and appending a column alias.

There has been a proposal to fix this in rails:

Rails Issue:  https://github.com/rails/rails/issues/1623

Pull Request to Rails:  https://github.com/rails/rails/pull/2062

I've got mixed feelings about this.  It's obviously easier to fix this in rails, but until the pull request is accepted, I'd rather not have to play catch up to maintain a monkey-patched version of rails.

Also open to the possibility that there is a better place to fix this.
