### PR TITLE
Set @config on SQLServerAdapter initialize...

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -196,6 +196,7 @@ module ActiveRecord
       def initialize(connection, logger, pool, config)
         super(connection, logger, pool)
         # AbstractAdapter Responsibility
+        @config = config
         @schema_cache = Sqlserver::SchemaCache.new self
         @visitor = Arel::Visitors::SQLServer.new self
         # Our Responsibility


### PR DESCRIPTION
When using DbCharmer with Rails 3.2.2 it would throw the following exception if @config was not set:

ActiveRecord::StatementInvalid: RuntimeError: Can't find connection configuration!: EXEC sp_executesql N'SELECT @@version'
    from /Users/xxx/.rvm/gems/ruby-1.9.3-p125@xxx/bundler/gems/db-charmer-6eb3ec4d3fa8/lib/db_charmer/rails3/abstract_adapter/connection_name.rb:27:in `connection_name'

I'm not sure if this mandatory but other adapters (SQLiteAdapter and AbstractMysqlAdapter) are both setting this instance variable.
