### PR TITLE
Here's the revised patch and semi-integrated test

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -67,7 +67,15 @@ module ActiveRecord
 
         def quoted_datetime(value)
           if value.acts_like?(:time)
-            value.is_a?(Date) ? quoted_value_acts_like_time_filter(value).to_time.xmlschema.to(18) : quoted_value_acts_like_time_filter(value).iso8601(3).to(22)
+            time_zone_qualified_value = quoted_value_acts_like_time_filter(value)
+            if value.is_a?(Date)
+              time_zone_qualified_value.to_time.xmlschema.to(18)
+            else
+              if value.is_a?(ActiveSupport::TimeWithZone)
+                time_zone_qualified_value = time_zone_qualified_value.to_time
+              end
+              time_zone_qualified_value.iso8601(3).to(22)
+            end
           else
             quoted_date(value)
           end


### PR DESCRIPTION
- Adds test for Quoting module's #quote and #quoted_datetime
  methods when integrated with the adapter
- Includes test for ActiveSupport::TimeWithZone wrapping Time and DateTime
