### PR TITLE
IDENTITY_INSERT error on Table with no IDENTITY column

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -355,7 +355,7 @@ module ActiveRecord
         end
 
         def identity_column(table_name)
-          schema_cache.columns[table_name].detect(&:is_identity?)
+          schema_cache.columns[table_name].detect { |c| c.is_identity? != 0 }
         end
 
       end


### PR DESCRIPTION
Hi.  I get the following error when using the :odbc mode with a table that has a primary key but no IDENTITY column.  

```
IDENTITY_INSERT could not be turned OFF for table [TheTableName] (ActiveRecord::ActiveRecordError)
```

is_identity? seems to return a Fixnum with a value of 0 or 1.  The issue seems to be caused both values evaluating as true.  is_identity?.nil? is always false regardless of whether is_identity? returns 0 or 1.  The issue was observed on Ruby 1.9.3 running on Windows 7 64bit connecting to a local SQL Server 2008 R2 database using the adapter's odbc mode (needed to get integrated security working using the Windows user account the ruby process was running under).  
