### PR TITLE
Explain queries without placeholders

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -21,8 +21,10 @@ module ActiveRecord
             if sql.starts_with?(SQLSERVER_STATEMENT_PREFIX)
               executesql = sql.from(SQLSERVER_STATEMENT_PREFIX.length)
               executesql_args = executesql.split(', ')
-              executesql_args.reject! { |arg| arg =~ SQLSERVER_PARAM_MATCHER }
-              executesql_args.pop if executesql_args.many?
+              has_sqlserver_params = executesql_args.reject! { |arg| arg =~ SQLSERVER_PARAM_MATCHER }
+              if has_sqlserver_params
+                executesql_args.pop if executesql_args.many?
+              end
               executesql = executesql_args.join(', ').strip.match(/N'(.*)'/)[1]
               Utils.unquote_string(executesql)
             else


### PR DESCRIPTION
our application has specific queries, which don't have any "@XX" placeholders. The current explain codes drops part of the query string after the last comma, which results in a very invalid query or even exceptions.

The patch only removes the last segment if there are placeholders in the sql.

I'm not sure if this works for every case but it does for our application.
