### PR TITLE
There was a reference to db_name_with_period when it should have been just db_name

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -185,15 +185,15 @@ module ActiveRecord
               AND KCU.CONSTRAINT_NAME = TC.CONSTRAINT_NAME
               AND KCU.CONSTRAINT_CATALOG = TC.CONSTRAINT_CATALOG
               AND KCU.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA
-            INNER JOIN #{db_name_with_period}.sys.schemas AS s
+            INNER JOIN #{db_name}.sys.schemas AS s
               ON s.name = columns.TABLE_SCHEMA
               AND s.schema_id = s.schema_id
-            INNER JOIN #{db_name_with_period}.sys.objects AS o
+            INNER JOIN #{db_name}.sys.objects AS o
               ON s.schema_id = o.schema_id
               AND o.is_ms_shipped = 0
               AND o.type IN ('U', 'V')
               AND o.name = columns.TABLE_NAME
-            INNER JOIN #{db_name_with_period}.sys.columns AS c
+            INNER JOIN #{db_name}.sys.columns AS c
               ON o.object_id = c.object_id
               AND c.name = columns.COLUMN_NAME
             WHERE columns.TABLE_NAME = @0


### PR DESCRIPTION
It was generating a sql statement that looked like...

db_name..sys.table_name

instead of

db_name.sys.table_name
