### PR TITLE
Version file will be kept in gem, because it is used at runtime

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email         = "ken@metaskills.net"
   s.homepage      = "http://github.com/rails-sqlserver/activerecord-sqlserver-adapter"
   
-  s.files         = Dir['CHANGELOG', 'MIT-LICENSE', 'README.rdoc', 'lib/**/*' ]
+  s.files         = Dir['CHANGELOG', 'MIT-LICENSE', 'README.rdoc', 'VERSION', 'lib/**/*' ]
   s.require_path  = 'lib'
   s.rubyforge_project = 'activerecord-sqlserver-adapter'
   


### PR DESCRIPTION
Otherwise the following exception occurs when starting the webserver:

``` ruby
  /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/active_record/connection_adapters/sqlserver_adapter.rb:180:in `read': No such file or directory - /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/VERSION (Errno::ENOENT)
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/active_record/connection_adapters/sqlserver_adapter.rb:180:in `<class:SQLServerAdapter>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/active_record/connection_adapters/sqlserver_adapter.rb:171:in `<module:ConnectionAdapters>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/active_record/connection_adapters/sqlserver_adapter.rb:54:in `<module:ActiveRecord>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/active_record/connection_adapters/sqlserver_adapter.rb:20:in `<top (required)>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `block in require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/activerecord-sqlserver-adapter-3.2.7/lib/activerecord-sqlserver-adapter.rb:1:in `<top (required)>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:68:in `require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:66:in `each'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:66:in `block in require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:55:in `each'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler/runtime.rb:55:in `require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.1.4/lib/bundler.rb:119:in `require'
    from /Users/cr/git_repositories/sfv_webclient/config/application.rb:9:in `<top (required)>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/railties-3.2.6/lib/rails/commands.rb:53:in `require'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/railties-3.2.6/lib/rails/commands.rb:53:in `block in <top (required)>'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/railties-3.2.6/lib/rails/commands.rb:50:in `tap'
    from /Users/cr/.rvm/gems/ruby-1.9.3-p194@sfv_webclient/gems/railties-3.2.6/lib/rails/commands.rb:50:in `<top (required)>'
    from script/rails:5:in `require'
    from script/rails:5:in `<main>'
```
