### PR TITLE
Allow named parameters in stored procedures

### DIFF
--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -20,6 +20,21 @@ class ExecuteProcedureTestSqlserver < ActiveRecord::TestCase
     assert_equal 'TABLE', table_info['TABLE_TYPE'], "Table Info: #{table_info.inspect}"
   end
   
+
+  should 'take named parameter arguments' do
+    tables = @klass.execute_procedure :sp_tables, :table_name => 'tables', :table_owner => 'sys'
+    table_info = tables.first
+    assert_equal 1, tables.size
+    assert_equal (ENV['ARUNIT_DB_NAME'] || 'activerecord_unittest'), table_info['TABLE_QUALIFIER'], "Table Info: #{table_info.inspect}"
+    assert_equal 'VIEW', table_info['TABLE_TYPE'], "Table Info: #{table_info.inspect}"
+  end
+
+  should 'prevent complex parameter names' do
+    assert_raise(ActiveRecord::StatementInvalid) do
+      @klass.execute_procedure(:sp_tables, 'sql_server_chronics; declare @x int; set @x' => 0)
+    end
+  end
+
   should 'allow multiple result sets to be returned' do
     results1, results2 = @klass.execute_procedure('sp_helpconstraint','accounts')
     assert_instance_of Array, results1


### PR DESCRIPTION
This change allows calling stored procedures with named parameters, e.g: 

``` ruby
execute_procedure :my_procedure, param_1: 'foo', param_2: 'bar'
execute_procedure :my_procedure, param_2: 'bar', param_1: 'foo'
execute_procedure :my_procedure, param_2: 'bar'
```

all work fine (assuming `@param_1` has a default value in the last example).

This is helpful when you need to call a dynamically call a procedure but don't know or don't care about the exact order of the procedure's parameters.

I've prevented SQL injection in parameter names by forcing parameter names to not contain spaces. If that doesn't feel robust enough for protection, I'd be happy to brainstorm other options.

I've added tests for this and the full test suite is passing.
