### PR TITLE
bug fix: multiline queries do not raise error when explained

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -23,7 +23,7 @@ module ActiveRecord
               executesql_args = executesql.split(', ')
               found_args = executesql_args.reject! { |arg| arg =~ SQLSERVER_PARAM_MATCHER }
               executesql_args.pop if found_args && executesql_args.many?
-              executesql = executesql_args.join(', ').strip.match(/N'(.*)'/)[1]
+              executesql = executesql_args.join(', ').strip.match(/N'(.*)'/m)[1]
               Utils.unquote_string(executesql)
             else
               sql

--- a/test/cases/showplan_test_sqlserver.rb
+++ b/test/cases/showplan_test_sqlserver.rb
@@ -12,6 +12,12 @@ class ShowplanTestSqlserver < ActiveRecord::TestCase
       assert plan.starts_with?("EXPLAIN for: SELECT [cars].* FROM [cars] WHERE [cars].[id] = 1")
       assert plan.include?("Clustered Index Seek"), 'make sure we do not showplan the sp_executesql'
     end
+
+    should 'from multiline statement' do
+      plan = Car.where("\n id = 1 \n").explain
+      assert plan.starts_with?("EXPLAIN for: SELECT [cars].* FROM [cars] WHERE (\n id = 1 \n)")
+      assert plan.include?("Clustered Index Seek"), 'make sure we do not showplan the sp_executesql'
+    end
     
     should 'from prepared statement' do
       plan = capture_logger do


### PR DESCRIPTION
# Statement:

```
"SELECT [cars].* FROM [cars] WHERE (\n id = 1 \n)"
```
# Exception:

```
test: Unprepare previously prepared SQL should from multiline statement. (ShowplanTestSqlserver):
NoMethodError: undefined method `[]' for nil:NilClass
    /Users/cr/git_repositories/github/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb:26:in `unprepare_sqlserver_statement'
    /Users/cr/git_repositories/github/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb:11:in `block in exec_explain'
    /Users/cr/git_repositories/github/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb:11:in `map'
    /Users/cr/git_repositories/github/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb:11:in `exec_explain'
    /Users/cr/.rvm/gems/ruby-1.9.3-p194@sqlserver-adapter/bundler/gems/rails-0ff738a6f491/activerecord/lib/active_record/relation.rb:147:in `explain'
    test/cases/showplan_test_sqlserver.rb:17:in `block (2 levels) in <class:ShowplanTestSqlserver>'
    /Users/cr/.rvm/gems/ruby-1.9.3-p194@sqlserver-adapter/gems/shoulda-2.10.3/lib/shoulda/context.rb:362:in `call'
    /Users/cr/.rvm/gems/ruby-1.9.3-p194@sqlserver-adapter/gems/shoulda-2.10.3/lib/shoulda/context.rb:362:in `block in create_test_from_should_hash'
    /Users/cr/.rvm/gems/ruby-1.9.3-p194@sqlserver-adapter/gems/mocha-0.9.8/lib/mocha/integration/mini_test/version_131_and_above.rb:26:in `run'
```
