### PR TITLE
Fix to the #remove_default_constraint method

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -250,7 +250,7 @@ module ActiveRecord
 
         def remove_default_constraint(table_name, column_name)
           # If their are foreign keys in this table, we could still get back a 2D array, so flatten just in case.
-          select_all("EXEC sp_helpconstraint '#{quote_string(table_name)}','nomsg'").flatten.select do |row|
+          execute_procedure("sp_helpconstraint '#{quote_string(table_name)}','nomsg'").flatten.select do |row|
             row['constraint_type'] == "DEFAULT on column #{column_name}"
           end.each do |row|
             do_execute "ALTER TABLE #{quote_table_name(table_name)} DROP CONSTRAINT #{row['constraint_name']}"


### PR DESCRIPTION
This fix addresses an issue with the _remove_default_constraint_ method in the SchemaStatements module. When a database table has both default constraints and foreign key constraints, the return of both constraint tables (by the **sp_helpconstraint** procedure) break the filtering by constraint name that this method expects to be able to perform successfully. This will break migrations that remove columns with default constraints.

By changing the execution of the stored procedure from **select_all** to **execute_procedure** the results are returned in a way that the filtering works as expected.

Hat-tip to gicappa/activerecord-sqlserver-adapter@88e8c876c08792ac487b6031e12ffc2d981c5e44
