### PR TITLE
Pass tds_version to TinyTds::Client.new

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -420,6 +420,7 @@ module ActiveRecord
                           :username      => config[:username],
                           :password      => config[:password],
                           :database      => config[:database],
+                          :tds_version   => config[:tds_version],
                           :appname       => appname,
                           :login_timeout => login_timeout,
                           :timeout       => timeout,


### PR DESCRIPTION
I had some troubles with encoding. SQL Server 2005, encoding cp1251. I tried to use `tsql`, it worked. Then I checked version, and found that it worked with tds version 4.2 by default. So I tried to initialize TinyTds::Client with tds_version 42, and it worked fine too. Then, when I put `tds_version: '42'` into `config/database.yml`, it did not work, and I found that this option was not passed to TinyTds::Client.new. This small patch is intended to fix this issue.
