### PR TITLE
Include table schema in dumps

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         end
 
         def tables(table_type = 'BASE TABLE')
-          select_values "SELECT #{lowercase_schema_reflection_sql('TABLE_NAME')} FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} ORDER BY TABLE_NAME", 'SCHEMA'
+          select_values "SELECT #{lowercase_schema_reflection_sql('TABLE_SCHEMA + \'.\' + TABLE_NAME')} FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} ORDER BY TABLE_NAME", 'SCHEMA'
         end
 
         def table_exists?(table_name)


### PR DESCRIPTION
- Tables which are not part of the default schema (usually "dbo") are
  properly included in the dump
- `rake db:schema:dump` now produces statements like `create_table
  "dbo.User"
