### PR TITLE
Update regex for `RecordNotUnique` exception

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -389,7 +389,7 @@ module ActiveRecord
       
       def translate_exception(e, message)
         case message
-        when /cannot insert duplicate key .* with unique index/i
+        when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message,e)
         when /conflicted with the foreign key constraint/i
           InvalidForeignKey.new(message,e)


### PR DESCRIPTION
Fixes issue #256

`TinyTds::Error: Violation of UNIQUE KEY constraint '<constraint_name>'. Cannot insert duplicate key in object ...` does not match the regex for `RecordNotUnique` exception.

Tested using TinyTDS version 7.1
