### PR TITLE
Check SQL version using the product version rather than the year

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/supported_versions.rb
+++ b/lib/active_record/connection_adapters/sqlserver/supported_versions.rb
@@ -1,0 +1,21 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module Sqlserver
+      module SupportedVersions
+        SUPPORTED_VERSIONS = [9, 10, 11] # 2005, 2008, 2012
+
+        # Raises a NotImplementedError if the product_version is not supported.
+        def ensure_supported_version(product_version, database_version)
+          unless supports_version?(product_version)
+            raise NotImplementedError, "Currently, only #{SUPPORTED_VERSIONS.to_sentence} are supported. We got back #{database_version}."
+          end
+        end
+
+        # Returns true if the product version is supported.
+        def supports_version?(product_version)
+          SUPPORTED_VERSIONS.include?(product_version.to_i)
+        end
+      end
+    end
+  end
+end

--- a/test/cases/supported_versions_test_sqlserver.rb
+++ b/test/cases/supported_versions_test_sqlserver.rb
@@ -1,0 +1,24 @@
+require 'cases/sqlserver_helper'
+
+class SupportedVersionsTestSqlserver < ActiveRecord::TestCase
+
+  class TestSupportedVersions
+    include ActiveRecord::ConnectionAdapters::Sqlserver::SupportedVersions
+  end
+
+  should 'allow SQL Server 2005, 2008, and 2012' do
+    assert_true TestSupportedVersions.new.supports_version?('9')  # SQL Server 2005
+    assert_true TestSupportedVersions.new.supports_version?('10') # SQL Server 2008
+    assert_true TestSupportedVersions.new.supports_version?('11') # SQL Server 2012
+  end
+
+  should 'not support an invalid version' do
+    assert_false TestSupportedVersions.new.supports_version?('Foo')
+  end
+
+  should 'raise an error if the version is unsupported' do
+    assert_raise(NotImplementedError) {
+      TestSupportedVersions.new.ensure_supported_version('8')
+    }
+  end
+end


### PR DESCRIPTION
 * Adds a new module for the version checking code
 * Changes the version check to look at the product rather than the year
 * Changes the adapter to use the new version checking method

This is more or less the same PR as https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/248

The caveats mentioned in the original PR still apply. Specifically, I still don't have a SQL Server instance to actually run the tests, and the meaning of database_year on the adapter is ambiguous.

Sorry about the lack of testing; I hope it still turns out to be useful.