### PR TITLE
Avoid retrieving all rows from information_schema tables

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -15,12 +15,12 @@ module ActiveRecord
           return false if table_name.blank?
           unquoted_table_name = Utils.unqualify_table_name(table_name)
           table_name_column = lowercase_schema_reflection_sql('TABLE_NAME')
-          select_value %Q{
+          super || select_value(%Q{
                          SELECT #{table_name_column}
                          FROM    INFORMATION_SCHEMA.TABLES
                          WHERE   (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW') AND
-                         #{table_name_column} = '#{table_name}'
-                         }
+                         #{table_name_column} = '#{unquoted_table_name}'
+                         })
         end
 
         def indexes(table_name, name = nil)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -14,7 +14,13 @@ module ActiveRecord
         def table_exists?(table_name)
           return false if table_name.blank?
           unquoted_table_name = Utils.unqualify_table_name(table_name)
-          super || tables.include?(unquoted_table_name) || views.include?(unquoted_table_name)
+          table_name_column = lowercase_schema_reflection_sql('TABLE_NAME')
+          select_value %Q{
+                         SELECT #{table_name_column}
+                         FROM    INFORMATION_SCHEMA.TABLES
+                         WHERE   (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW') AND
+                         #{table_name_column} = '#{table_name}'
+                         }
         end
 
         def indexes(table_name, name = nil)


### PR DESCRIPTION
We narrow the search space using a where clause in the query. It is
useful for databases where the number of tables are huge.