### PR TITLE
Fix bug where database names with dots would get improperly quoted.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -128,7 +128,7 @@ module ActiveRecord
         def use_database(database=nil)
           return if sqlserver_azure?
           database ||= @connection_options[:database]
-          do_execute "USE #{quote_table_name(database)}" unless database.blank?
+          do_execute "USE #{quote_database_name(database)}" unless database.blank?
         end
         
         def user_options
@@ -267,7 +267,7 @@ module ActiveRecord
           retry_count = 0
           max_retries = 1
           begin
-            do_execute "DROP DATABASE #{quote_table_name(database)}"
+            do_execute "DROP DATABASE #{quote_database_name(database)}"
           rescue ActiveRecord::StatementInvalid => err
             if err.message =~ /because it is currently in use/i
               raise if retry_count >= max_retries
@@ -284,9 +284,9 @@ module ActiveRecord
 
         def create_database(database, collation=@connection_options[:collation])
           if collation
-            do_execute "CREATE DATABASE #{quote_table_name(database)} COLLATE #{collation}"
+            do_execute "CREATE DATABASE #{quote_database_name(database)} COLLATE #{collation}"
           else
-            do_execute "CREATE DATABASE #{quote_table_name(database)}"
+            do_execute "CREATE DATABASE #{quote_database_name(database)}"
           end
         end
 

--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -49,6 +49,10 @@ module ActiveRecord
           quote_column_name(name)
         end
 
+        def quote_database_name(name)
+          schema_cache.quote_name(name, false)
+        end
+
         def substitute_at(column, index)
           if column.respond_to?(:sql_type) && column.sql_type == 'timestamp'
             nil

--- a/lib/active_record/connection_adapters/sqlserver/schema_cache.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_cache.rb
@@ -65,14 +65,22 @@ module ActiveRecord
           return @view_information[key] if @view_information.key? key
           @view_information[key] = connection.send(:view_information, table_name)
         end
-        
-        def quote_name(name)
+
+        def quote_name(name, split_on_dots = true)
           return @quoted_names[name] if @quoted_names.key? name
-          @quoted_names[name] = name.to_s.split('.').map{ |n| n =~ /^\[.*\]$/ ? n : "[#{n.to_s.gsub(']', ']]')}]" }.join('.')
+
+          @quoted_names[name] = if split_on_dots
+                                  name.to_s.split('.').map{ |n| quote_name_part(n) }.join('.')
+                                else
+                                  quote_name_part(name.to_s)
+                                end
         end
-        
-        
+
         private
+
+        def quote_name_part(part)
+          part =~ /^\[.*\]$/ ? part : "[#{part.to_s.gsub(']', ']]')}]"
+        end
         
         def table_name_key(table_name)
           Utils.unqualify_table_name(table_name)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -494,11 +494,11 @@ module ActiveRecord
 
       def remove_database_connections_and_rollback(database=nil)
         database ||= current_database
-        do_execute "ALTER DATABASE #{quote_table_name(database)} SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
+        do_execute "ALTER DATABASE #{quote_database_name(database)} SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
         begin
           yield
         ensure
-          do_execute "ALTER DATABASE #{quote_table_name(database)} SET MULTI_USER"
+          do_execute "ALTER DATABASE #{quote_database_name(database)} SET MULTI_USER"
         end if block_given?
       end
 

--- a/test/cases/database_statements_test_sqlserver.rb
+++ b/test/cases/database_statements_test_sqlserver.rb
@@ -19,6 +19,15 @@ class DatabaseStatementsTestSqlserver < ActiveRecord::TestCase
     database_name = @connection.select_value "SELECT name FROM master.dbo.sysdatabases WHERE name = 'activerecord_unittest3'"
     assert_equal nil, database_name
   end
+
+  should 'create/use/drop database with name with dots' do
+    @connection.create_database 'activerecord.unittest'
+    database_name = @connection.select_value "SELECT name FROM master.dbo.sysdatabases WHERE name = 'activerecord.unittest'"
+    assert_equal 'activerecord.unittest', database_name
+    @connection.use_database 'activerecord.unittest'
+    @connection.use_database 'master'
+    @connection.drop_database 'activerecord.unittest'
+  end
  
   context 'with collation' do
     teardown do


### PR DESCRIPTION
A sample DB name of part1.part2 would be quoted as [part1].[part2] instead of [part1.part2]
