### PR TITLE
Add support for SQL Server's filtered indices

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -252,6 +252,10 @@ module ActiveRecord
         true
       end
 
+      def supports_partial_index?
+        @database_year >= 2008
+      end
+
       def supports_explain?
         true
       end


### PR DESCRIPTION
SQL Server 2008 onwards support partial/filtered indices.[1] Let's support them!

[1] http://technet.microsoft.com/en-us/library/cc280372%28v=sql.100%29.aspx
