### PR TITLE
Fix for Issue #306 - DISTINCT + TOP + ORDER BY Associated Table

### DIFF
--- a/test/cases/finder_test_sqlserver.rb
+++ b/test/cases/finder_test_sqlserver.rb
@@ -10,33 +10,29 @@ class FinderTestSqlserver < ActiveRecord::TestCase
 end
 
 class FinderTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :posts
+  fixtures :authors, :author_addresses, :posts, :categorizations
   COERCED_TESTS = [
     :test_exists_does_not_select_columns_without_alias,
     :test_string_sanitation,
-    :test_take_and_first_and_last_with_integer_should_use_sql_limit,
-    :test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
-
+    :test_take_and_first_and_last_with_integer_should_use_sql_limit
   ]
 
   include SqlserverCoercedTest
 
 
-  # TODO This test passes in rails 4.0.0 but not 4.0.1-2
-  def test_coerced_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
-   p =  Post.all.merge!(includes: { authors: :author_address },
-      order: 'author_addresses.id DESC ',
-      limit: 2)
-   # ar_version = Gem.loaded_specs['activerecord'].version.version
-   # arel_to_png(p, "#{ar_version}")
-    count = p.to_a.size
-    #puts "*****#{ActiveRecord::SQLCounter.log_all.join("\n\n")}"
-    assert_equal 2, count
-
-     assert_equal 3, Post.all.merge!(includes: { author: :author_address, authors: :author_address},
-                              order: 'author_addresses_authors.id DESC ', limit: 3).to_a.size
+  def test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct_and_offset
+    # Based on test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct
+    # and issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/306
+    assert_equal(
+      posts(:welcome, :thinking),
+      Post.all.merge!(
+        :includes => { authors: :author_address },
+        :order => ['authors.name DESC'],
+        :limit => 2,
+        :offset => 1
+      ).to_a
+    )
   end
-
 
   def test_coerced_exists_does_not_select_columns_without_alias
     assert_sql(/SELECT TOP \(1\) 1 AS one FROM \[topics\]/i) do


### PR DESCRIPTION
Fixed selecting `DISTINCT` rows from a table when ordering by a column that is not part of the `SELECT` list where the join creates at least one extra row.

While previously the test suite combined with Rails 4.0.0 looked like it worked, the constructed SQL would return incorrect values for `FinderTest#test_find_with_order_on_included_associations_with_construct_finder_sql_for_association_limiting_and_is_distinct`. By using a `GROUP BY` and `MAX()`/`MIN()` in the `ORDER BY` with no `DISTINCT` call, the order of the returned rows was not necessarily correct.

With Rails 4.0.1, a related bug was fixed that introduces a new method, `columns_for_distinct`. Unfortunately by adding the columns from the `ORDER BY` clause to the `SELECT` list, the `DISTINCT` nature of the queries was altered. This combined with a test limiting the results to only 2 records, exposed the bug.

From testing various SQL constructs to solve the issue, I ended up determining that to properly return a single value from the related table used in the `ORDER BY`, a query with a subquery utilizing `ROW_NUMBER()` and `DENSE_RANK()` was needed. The `ROW_NUMBER()` was partitioned over the originally requested columns, and then the outer query would filter the results to just the first row of each partition. `DENSE_RANK()` was used to generate a proper ordering of the partitions in relation
to each other.

In the process I also determined that extra code, plus an extra test, was necessary to ensure that when such a construct was generated using both a limit and offset, that the results would be correct also.

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/306 for further discussion, plus example queries and results.

These changes have been tested against Rails:
- 4.0.0
- 4.0.1
- 4.0.5
