### PR TITLE
prevent downstream nil exception when view_definition is nil.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -352,7 +352,7 @@ module ActiveRecord
 
         def views_real_column_name(table_name, column_name)
           view_definition = schema_cache.view_information(table_name)[:VIEW_DEFINITION]
-          match_data = view_definition.match(/([\w-]*)\s+as\s+#{column_name}/im)
+          match_data = view_definition.match(/([\w-]*)\s+as\s+#{column_name}/im) rescue nil
           match_data ? match_data[1] : column_name
         end
 


### PR DESCRIPTION
Fixes #330. it looks like there is more than one way to collect column names, but I'm not sure what 'real' column names are in the context of [schema_statements.rb#L253](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/lib/active_record/connection_adapters/sqlserver/schema_statements.rb#L253).  Is my fix ok, or does it mask other issues?
