### PR TITLE
Fixing SQL generation for queries selecting COUNT(DISTINCT...) w/ ORDER_BY

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -60,6 +60,9 @@ module Arel
         groups = core.groups
         orders = o.orders.uniq
 
+        # split out any projections that may have > 1 specified (comma-separated)
+        projections = projections.each_with_object(',').map(&:split).flatten
+
         select_frags = projections.map do |x|
           frag = projection_to_sql_remove_distinct(x, core, a)
           # Remove the table specifier

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -76,6 +76,9 @@ module Arel
 
         projection_list = projections.map { |x| projection_to_sql_remove_distinct(x, core, a) }.join(', ')
 
+        # strip aliases from projection list for PARTITION BY value expression
+        partitions = projection_list.gsub(/\s+AS\s+[^,]*/i, '')
+
         sql = [
           ('SELECT'),
           (visit(core.set_quantifier, a) if core.set_quantifier && !o.offset),
@@ -90,7 +93,7 @@ module Arel
                   ("ORDER BY #{orders.map { |x| visit(x, a) }.join(', ')}" unless orders.empty?),
                 (') AS __order'),
                 (', ROW_NUMBER() OVER ('),
-                  ("PARTITION BY #{projection_list}" if !orders.empty?),
+                  ("PARTITION BY #{partitions}" if !orders.empty?),
                   (" ORDER BY #{orders.map { |x| visit(x, a) }.join(', ')}" unless orders.empty?),
                 (') AS __joined_row_num')
               ].join('')

--- a/test/cases/finder_test_sqlserver.rb
+++ b/test/cases/finder_test_sqlserver.rb
@@ -34,6 +34,23 @@ class FinderTest < ActiveRecord::TestCase
     )
   end
 
+  def test_multiple_select_with_count_distinct_and_order
+    posts = Post.joins(:authors)
+                .select('COUNT(DISTINCT authors.id) as total')
+                .select('title as x, body as y')
+                .group(:title, :body)
+                .order(:title).to_a
+
+    # quick sanity check, known number of records were returned
+    assert_equal(3, posts.size)
+
+    # the defined aliases should be present
+    post = posts.first
+    assert_respond_to(post, :total)
+    assert_respond_to(post, :x)
+    assert_respond_to(post, :y)
+  end
+
   def test_coerced_exists_does_not_select_columns_without_alias
     assert_sql(/SELECT TOP \(1\) 1 AS one FROM \[topics\]/i) do
       Topic.exists?


### PR DESCRIPTION
Issue #306, and PR #329 broke compatibility with a couple of queries we were using.  Two regressions were introduced.

First, if the `COUNT(DISTINCT)` had an alias applied to it, the alias would be used in the `PARTITION BY` value expression, which was invalid SQL, [according to the Transact-SQL docs](http://msdn.microsoft.com/en-us/library/ms189461.aspx) it cannot use aliases.

Second, if the query (already having a COUNT(DISTINCT) and order clause) itself used a `select` call like this:

    Model.select('COUNT(DISTINCT)...')
         .select('something as x, something_else as y')
         ....
         .order(:something)

the outer select would lose some of the aliased columns due to the regex used when stripping out the aliases into `select_frags`.

Added a test to verify this, the issues are intertwined so it's just one test.

Thanks for the great gem!