### PR TITLE
Fixed bug of active? for Azure SQL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test/profile/output/*
 .rvmrc
 .rbenv-version
 .idea
+*.iml
 coverage/*
 .flooignore
 .floo

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -137,7 +137,7 @@ module ActiveRecord
       def active?
         case @connection_options[:mode]
         when :dblib
-          return @connection.active?
+          return @connection.active? unless @connection_options[:azure]
         end
         raw_connection_do('SELECT 1')
         true


### PR DESCRIPTION
I'm poor at English.
If you can't understand what I mean, please let me know.

-----

Azure SQL close the client connection every 5min.
active? method of TinyTds::Client can't diagnose it.

This is a specification of Azure SQL.
http://blogs.msdn.com/b/bartr/archive/2010/06/18/sql-azure-connection-retry.aspx

As a result, adapter needs execute SQL because of correct checking.