### PR TITLE
Error as supported version not mentioned for sql server 2014. 

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       VERSION                     = File.read(File.expand_path('../../../../VERSION', __FILE__)).strip
       ADAPTER_NAME                = 'SQLServer'.freeze
       DATABASE_VERSION_REGEXP     = /Microsoft SQL Server\s+"?(\d{4}|\w+)"?/
-      SUPPORTED_VERSIONS          = [2005, 2008, 2010, 2011, 2012]
+      SUPPORTED_VERSIONS          = [2005, 2008, 2010, 2011, 2012, 2014]
 
       attr_reader :database_version, :database_year, :spid, :product_level, :product_version, :edition
 
@@ -65,7 +65,7 @@ module ActiveRecord
                            if @database_version =~ /Azure/i
                              @sqlserver_azure = true
                              @database_version.match(/\s-\s([0-9.]+)/)[1]
-                             year = 2012
+                             year = 2012 || 2014
                            else
                              year = DATABASE_VERSION_REGEXP.match(@database_version)[1]
                              year == 'Denali' ? 2011 : year.to_i
@@ -202,6 +202,10 @@ module ActiveRecord
 
       def sqlserver_2012?
         @database_year == 2012
+        end
+
+      def sqlserver_2014?
+        @database_year == 2014
       end
 
       def sqlserver_azure?


### PR DESCRIPTION
Error as supported version not mentioned for 2014. After all test case scenerio tested each and every api fir sql server 2014 working fine.
Submitted the patch for the same. Error is as follows -:
NotImplementedError: Currently, only 2005, 2008, 2010, 2011, and 2012 are supported. We got back Microsoft SQL Server 2014 - 12.0.2000.8 (X64)
    Feb 20 2014 20:04:26
    Copyright (c) Microsoft Corporation
##     Standard Edition (64-bit) on Windows NT 6.3 <X64> (Build 9600: ) (Hypervisor)

These are the current supported version mentioned in sqlserver_adapter.rb => SUPPORTED_VERSION = [2005, 2008, 2010, 2011, 2012]

Using in my production environment for past 2 weeks. Didn't get any complain till now :+1: 
