### PR TITLE
filter tables by current schema

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         end
 
         def tables(table_type = 'BASE TABLE')
-          select_values "SELECT #{lowercase_schema_reflection_sql('TABLE_NAME')} FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} ORDER BY TABLE_NAME", 'SCHEMA'
+          select_values "SELECT #{lowercase_schema_reflection_sql('TABLE_NAME')} FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} #{(table_type ? "AND " : "WHERE ")} TABLE_SCHEMA=SCHEMA_NAME() ORDER BY TABLE_NAME", 'SCHEMA'
         end
 
         def table_exists?(table_name)


### PR DESCRIPTION
We have a number of rails services talking to the same database and are using schema objects to logically partition the database. This is accomplished by setting the default schema for the independent database users that each service uses. Everything works great, except that when doing a db:schema:dump (for example, after a db:migrate) - the schema.rb file picks up all tables from all schemas.

This is a small change that filters the tables list by the session's current schema - there might be a better way to approach this - if you can think of one, let me know!