### PR TITLE
Views related fixes for structure dump and load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test/profile/output/*
 coverage/*
 .flooignore
 .floo
+.vagrant/
+Vagrantfile

--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -71,8 +71,17 @@ module ActiveRecord
         # defncopy appears to truncate definition output in some circumstances
         # Also create view needs to be the first operation in the batch.
         File.open(filename, 'a') { |file|
-          connection.select_all("select definition, o.type from sys.objects as o join sys.sql_modules as m on m.object_id = o.object_id where o.type = 'V'").each do |row|
-            file.puts "\r\nGO\r\n#{row['definition']}"
+          connection.send(:views).each do |v|
+            view_info = connection.send(:view_information, v)
+            file.puts "\r\nGO\r\n#{view_info[:VIEW_DEFINITION]}"
+          end
+        }
+
+        # Export any routines (stored procedures, functions, etc.)
+        File.open(filename, 'a') { |file|
+          connection.send(:routines).each do |r|
+            routine_info = connection.send(:routine_information, r)
+            file.puts "\r\nGO\r\n#{routine_info[:ROUTINE_DEFINITION]}"
           end
           file.puts "\r\nGO\r\n"
         }

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -416,5 +416,24 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   end
 
+
+  describe 'routines' do
+
+    it 'return an array' do
+      assert_instance_of Array, connection.send(:routines)
+    end
+
+    it 'sst_routines_1 routine must exist' do
+      connection.send(:routines).must_include 'sst_routine_1'
+    end
+
+    it 'allow the connection#routine_information method to return data on the routine' do
+      routine_info = connection.send(:routine_information,'sst_routine_2')
+      assert_equal('sst_routine_2', routine_info['ROUTINE_NAME'])
+      assert_match(/CREATE FUNCTION sst_routine_2/, routine_info['ROUTINE_DEFINITION'])
+    end
+
+  end
+
 end
 

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -113,6 +113,16 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
       t.text_basic :background2
       t.timestamps null: false
     end
+
+    connection.execute <<-CUSTOMERSVIEW
+      CREATE VIEW users_view AS
+        SELECT name FROM users
+    CUSTOMERSVIEW
+
+    connection.execute <<-PROCEDUREDEF
+      CREATE PROCEDURE users_procedure AS
+        SELECT 1
+    PROCEDUREDEF
   end
 
   after do
@@ -122,7 +132,6 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
   it 'dumps structure and accounts for defncopy oddities' do
     db_tasks.structure_dump configuration, filename
     filedata.wont_match %r{\AUSE.*\z}
-    filedata.wont_match %r{\AGO.*\z}
     filedata.must_match %r{email\s+nvarchar\(4000\)}
     filedata.must_match %r{background1\s+nvarchar\(max\)}
     filedata.must_match %r{background2\s+text\s+}
@@ -130,11 +139,21 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
 
   it 'can load dumped structure' do
     db_tasks.structure_dump configuration, filename
+
     filedata.must_match %r{CREATE TABLE dbo\.users}
+    filedata.must_match %r{CREATE PROCEDURE users_procedure}
+    filedata.must_match %r{CREATE VIEW users_view}
+
     db_tasks.purge(configuration)
     connection.tables.wont_include 'users'
+    connection.send(:routines).wont_include 'users_procedure'
+    connection.send(:views).wont_include 'users_view'
+
     db_tasks.load_schema_for configuration, :sql, filename
+
     connection.tables.must_include 'users'
+    connection.send(:routines).must_include 'users_procedure'
+    connection.send(:views).must_include 'users_view'
   end
 
 end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -144,6 +144,24 @@ ActiveRecord::Schema.define do
       FROM sst_string_defaults
   STRINGDEFAULTSBIGVIEW
 
+  # Routines
+
+  execute "IF EXISTS (SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME = 'sst_routine_1') DROP PROCEDURE sst_routine_1"
+  execute <<-PROCEDUREDEF
+    CREATE PROCEDURE sst_routine_1 AS
+      SELECT 1
+  PROCEDUREDEF
+
+  execute "IF EXISTS (SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME = 'sst_routine_2') DROP FUNCTION sst_routine_2"
+  execute <<-FUNCDEF
+    CREATE FUNCTION sst_routine_2 ()
+    RETURNS int
+    AS
+    BEGIN
+      RETURN 1
+    END
+  FUNCDEF
+
   # Another schema.
 
   create_table :sst_schema_columns, force: true do |t|


### PR DESCRIPTION
This patch addresses 2 issues I have with structure dumping and loading:
- defncopy (at least the versions I have available) seems to truncate the definition of a view
- CREATE VIEW needs to be the first statement in a batch, this adds some very simple batch support by splitting the sql by GO and sending the commands separately

I'm not sure if these are the "correct" fixes, but it seems to be working for me at present. I'm happy to refactor as required.

As an aside I'm also having an issue with defncopy not pulling through auto-generating identities correctly. if you guys are happy with this pull request and don't tell me not to I'll be creating a new patch that completely removes defncopy from the equation to fix the identities problem.
