### PR TITLE
Lost engine context

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -166,7 +166,7 @@ module Arel
         if Arel::Table === core.from
           core.from
         elsif Arel::Nodes::SqlLiteral === core.from
-          Arel::Table.new(core.from)
+          Arel::Table.new(core.from, Transaction)
         elsif Arel::Nodes::JoinSource === core.source
           Arel::Nodes::SqlLiteral === core.source.left ? Arel::Table.new(core.source.left, @engine) : core.source.left
         end


### PR DESCRIPTION
When you create new arel table and the mssql engine is secondary (main database is running on postgres for example), you loose context (queries than tries to run on primary connection and fails)

also on line 171 you have reference to @engine, which in Arel 6.0.0 (on my installation) is nil (and it also fails, but maybe i am missing something there)