### PR TITLE
improve case comparision performace

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-spec-rails'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'nokogiri'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake'
 end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Run a Ruby REPL.
+ 
+set -e
+ 
+cd $(dirname "$0")/..
+PRY_PATH=$(which pry)
+echo $PRY_PATH
+ 
+if [ -x $PRY_PATH ] 
+then
+  exec bundle exec $PRY_PATH -Ilib -r activerecord-sqlserver-adapter -r console
+else
+  red='\033[0;31m'
+  NC='\033[0m'
+  echo "${red}Pry was not found or not executable. Make sure \`which pry\` returns an executable.${NC}"
+ 
+fi

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -87,6 +87,22 @@ module ActiveRecord
           Arel::Nodes::Bin.new(node)
         end
 
+        def case_sensitive_comparison(table, attribute, column, value)
+          if column.case_sensitive?
+            table[attribute].eq(value)
+          else
+            super
+          end
+        end
+
+        def case_insensitive_comparison(table, attribute, column, value)
+          if column.case_sensitive?
+            super
+          else
+            table[attribute].eq(value)
+          end
+        end
+
         # === SQLServer Specific ======================================== #
 
         def execute_procedure(proc_name, *variables)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         def columns(table_name, _name = nil)
           return [] if table_name.blank?
           column_definitions(table_name).map do |ci|
-            sqlserver_options = ci.slice :ordinal_position, :is_primary, :is_identity, :default_function, :table_name
+            sqlserver_options = ci.slice :ordinal_position, :is_primary, :is_identity, :default_function, :table_name, :collation
             cast_type = lookup_cast_type(ci[:type])
             new_column ci[:name], ci[:default_value], cast_type, ci[:type], ci[:null], sqlserver_options
           end
@@ -233,6 +233,7 @@ module ActiveRecord
             columns.NUMERIC_SCALE AS numeric_scale,
             columns.NUMERIC_PRECISION AS numeric_precision,
             columns.DATETIME_PRECISION AS datetime_precision,
+            columns.COLLATION_NAME AS collation,
             columns.ordinal_position,
             CASE
               WHEN columns.DATA_TYPE IN ('nchar','nvarchar','char','varchar') THEN columns.CHARACTER_MAXIMUM_LENGTH

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -40,6 +40,14 @@ module ActiveRecord
         @sql_type =~ /real/i
       end
 
+      def collation
+        @sqlserver_options[:collation]
+      end
+
+      def case_sensitive?
+        collation && !collation.match(/_CI/)
+      end
+
     end
   end
 end

--- a/lib/console.rb
+++ b/lib/console.rb
@@ -1,0 +1,3 @@
+Pry.config.prompt = lambda do |context, nesting, pry| 
+  "[sqlserver] #{context} > "
+end


### PR DESCRIPTION
Case specific queries does not take in to account database column collation, therefore, the generated queries force an index scan. I noticed the problem while using uniqueness validator which specifically either does a case sensitive or case insensitive comparison (I didn't find a way to make it use default database casing). 

For a column with case insensitive collation, `SQL_Latin1_General_CP1_CI_AS`, uniqueness validator generates the following queries.

`validates :title, uniqueness: true` generates `SELECT  1 AS one FROM [articles] WHERE [articles].[title] = N''t1'' COLLATE Latin1_General_CS_AS_WS   ORDER BY [articles].[id] ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY`

while `validates :title, uniqueness: {:case_sensitive => false}` generates `SELECT  1 AS one FROM [articles] WHERE LOWER([articles].[title]) = LOWER(N''t1'')  ORDER BY [articles].[id] ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY` 

both causes index scan, for a large table, this cause a lot io.

MySQL adapter detects column collation and generates queries which does not cause table scan, I ported the same behavior to sqlserver-adapter in this PR. It will be great if you guys can provide some feedback, if this approach seems ok then I'll add some tests also.
