### PR TITLE
allow running sql batch with a given isolation level

### DIFF
--- a/lib/active_record/sqlserver_base.rb
+++ b/lib/active_record/sqlserver_base.rb
@@ -18,5 +18,24 @@ module ActiveRecord
       ConnectionAdapters::SQLServerAdapter.new(nil, logger, nil, config.merge(mode: mode))
     end
 
+    # Runs a batch of sql statements with an isolation_level
+    #
+    # For example:
+    #
+    #   ActiveRecord::Base.with_isolation_level(:read_uncommitted) do
+    #     Posts.where(id: 10).first
+    #   end
+    #
+    # This example will change the select query with :read_uncommitted isolation level
+    #
+    def self.with_isolation_level(isolation_level)
+      old_isolation_level_str = connection.user_options_isolation_level.to_s
+      isolation_level_str = connection.transaction_isolation_levels.fetch(isolation_level)
+      connection.execute "SET TRANSACTION ISOLATION LEVEL #{isolation_level_str}"
+      yield
+    ensure
+      connection.execute "SET TRANSACTION ISOLATION LEVEL #{old_isolation_level_str}"
+    end
+
   end
 end

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -48,6 +48,16 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
     end
   end
 
+  it 'allow executing sql statements with a given isolation_level' do
+    begin
+      Ship.transaction(isolation: :read_committed) do
+        Ship.with_isolation_level(:read_uncommitted) do
+          connection.user_options_isolation_level.to_s.must_equal 'read uncommitted'
+        end
+      end
+      connection.user_options_isolation_level.to_s.must_equal 'read committed'
+    end
+  end
 
   protected
 


### PR DESCRIPTION
The following patch should allow running a batch of sql statements with a given isolation level.
