### PR TITLE
Based on experience from #ossdatacamp - provides a more useful error …

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -277,6 +277,7 @@ module ActiveRecord
       end
 
       def dblib_connect(config)
+        raise "Username should be of the format user@short-name" unless config[:username] =~ /\S+@[A-z\-]+$/
         TinyTds::Client.new(
           dataserver: config[:dataserver],
           host: config[:host],


### PR DESCRIPTION
…message when the username is anything other than user@short-name

I didn't understand that the username needed to be user@short-name, and the error messages I was getting when I did just `username` or `user@test.database.windows.net` weren't informative.