### PR TITLE
Use fully qualified database name when retrieving column definitions …

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -39,6 +39,10 @@ module ActiveRecord
             server ? quote(server) : server
           end
 
+          def fully_qualified_database_quoted
+            [server_quoted, database_quoted].compact.join(SEPARATOR)
+          end
+
           def to_s
             quoted
           end

--- a/test/cases/utils_test_sqlserver.rb
+++ b/test/cases/utils_test_sqlserver.rb
@@ -86,6 +86,14 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
       SQLServer::Utils.extract_identifiers('[obj.name].[foo]').quoted.must_equal '[obj.name].[foo]'
     end
 
+    it 'can return fully qualified quoted table name' do
+      name = SQLServer::Utils.extract_identifiers('[server.name].[database].[schema].[object]')
+      name.fully_qualified_database_quoted.must_equal '[server.name].[database]'
+
+      name = SQLServer::Utils.extract_identifiers('server.database.schema.object')
+      name.fully_qualified_database_quoted.must_equal '[server].[database]'
+    end
+
   end
 
 end


### PR DESCRIPTION
…to support linked servers.

We have to retrieve data from SQL Server 2008. Since that doesn't work with the latest activerecord-sqlserver-adapter and we do have the possibility of using a SQL Server 2012 instance, we've configured the 2012 database engine to be able to execute queries/commands against the 2008 instance. This can be achieved by adding the 2008 server as a ["linked server"](https://msdn.microsoft.com/en-us/library/ms188279(v=sql.110).aspx) in the 2012 instance.

However, querying a linked server requires using the fully qualified database name:
```
select * from [server].[database].[dbo].[table]
```

In the current master, using a linked server fails with the following error:
```TinyTds::Error: Invalid object name 'database.INFORMATION_SCHEMA.COLUMNS'```
when retrieving the table definition of a linked server.

This pull request should fix that by using the fully qualified database name.

An example of a model that uses a linked server is:
```
class LinkedServerTest < ActiveRecord::Base
  self.table_name = "[server].table.dbo.linked_server_test"
  
  # Setting the table alias used in Arel is necessary since otherwise the
  # fully qualified table name is used in the select_list of the select clause,
  # causing SQL Server to complain about the maximum number of prefixes.
  self.arel_table.table_alias = "linked_server_test"
end
```
