### PR TITLE
Add linked server support to queries/commands

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -216,7 +216,7 @@ module ActiveRecord
         end
 
         def sql_for_insert(sql, pk, id_value, sequence_name, binds)
-          sql = if pk && self.class.use_output_inserted
+          sql = if pk && self.class.use_output_inserted && !remote_server?
             quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
             sql.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"
           else

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -220,7 +220,11 @@ module ActiveRecord
         end
 
         def column_definitions(table_name)
-          identifier  = SQLServer::Utils.extract_identifiers(table_name)
+          if remote_server?
+            identifier  = SQLServer::Utils.extract_identifiers("#{database_prefix}#{table_name}")
+          else
+            identifier  = SQLServer::Utils.extract_identifiers(table_name)
+          end
           database    = identifier.fully_qualified_database_quoted
           view_exists = schema_cache.view_exists?(table_name)
           view_tblnm  = table_name_or_views_table_name(table_name) if view_exists

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -43,6 +43,10 @@ module ActiveRecord
             [server_quoted, database_quoted].compact.join(SEPARATOR)
           end
 
+          def fully_qualified?
+            parts.compact.size == 4
+          end
+
           def to_s
             quoted
           end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -181,6 +181,14 @@ module ActiveRecord
         @sqlserver_azure
       end
 
+      def remote_server?
+        !!database_prefix and SQLServer::Utils.extract_identifiers(@connection_options[:database_prefix]).fully_qualified?
+      end
+
+      def database_prefix
+        @connection_options[:database_prefix]
+      end
+
       def version
         self.class::VERSION
       end

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -13,6 +13,14 @@ module Arel
 
       # SQLServer ToSql/Visitor (Overides)
 
+      def visit_Arel_Attributes_Attribute o, collector
+        join_name = o.relation.table_alias ||
+          ActiveRecord::ConnectionAdapters::SQLServer::Utils.extract_identifiers(
+            o.relation.name
+          ).object_quoted
+        collector << "#{quote_table_name join_name}.#{quote_column_name o.name}"
+      end
+
       def visit_Arel_Nodes_BindParam o, collector
         collector.add_bind(o) { |i| "@#{i-1}" }
       end

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -416,5 +416,25 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   end
 
+  describe 'remote_server?' do
+    after do
+      connection.instance_variable_get(:@connection_options).delete(:database_prefix)
+    end
+
+    it 'should return false if database_prefix is not configured' do
+      assert_equal false, connection.remote_server?
+    end
+
+    it 'should return true if database_prefix has been set' do
+      connection.instance_variable_get(:@connection_options)[:database_prefix] = "server.database.schema."
+      assert_equal true, connection.remote_server?
+    end
+
+    it 'should return false if database_prefix has been set incorrectly' do
+      connection.instance_variable_get(:@connection_options)[:database_prefix] = "server.database.schema"
+      assert_equal false, connection.remote_server?
+    end
+  end
+
 end
 

--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -1,0 +1,58 @@
+require 'cases/helper_sqlserver'
+
+class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
+  it 'should use fully qualified table name in select from clause' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]"
+    assert_equal expected_sql, table.project(Arel.star).to_sql
+  end
+
+  it 'should not use fully qualified table name in select projections' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    expected_sql = "SELECT [table].[name] FROM [my.server].[db].[schema].[table]"
+    assert_equal expected_sql, table.project(table[:name]).to_sql
+  end
+
+  it 'should not use fully qualified table name in where clause' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
+    assert_equal expected_sql, table.project(Arel.star).where(table[:id].eq(42)).to_sql
+  end
+
+  it 'should not use fully qualified table name in order clause' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]  ORDER BY [table].[name]"
+    assert_equal expected_sql, table.project(Arel.star).order(table[:name]).to_sql
+  end
+
+  it 'should use table name in select projections' do
+    table = Arel::Table.new(:table)
+    expected_sql = "SELECT [table].[name] FROM [table]"
+    assert_equal expected_sql, table.project(table[:name]).to_sql
+  end
+
+  it 'should use fully qualified table name in insert statement' do
+    manager = Arel::InsertManager.new(Arel::Table.engine)
+    manager.into Arel::Table.new("[my.server].db.schema.table")
+    manager.values = manager.create_values [Arel.sql('*')], %w{ a }
+    expected_sql = "INSERT INTO [my.server].[db].[schema].[table] VALUES (*)"
+    assert_equal expected_sql, manager.to_sql
+  end
+
+  it 'should use fully qualified table name in update statement' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    manager = Arel::UpdateManager.new(Arel::Table.engine)
+    manager.table(table).where(table[:id].eq(42))
+    manager.set([[table[:name], "Bob"]])
+    expected_sql = "UPDATE [my.server].[db].[schema].[table] SET [name] = N'Bob' WHERE [table].[id] = 42"
+    assert_equal expected_sql, manager.to_sql
+  end
+
+  it 'should use fully qualified table name in delete statement' do
+    table = Arel::Table.new("[my.server].db.schema.table")
+    manager = Arel::DeleteManager.new(Arel::Table.engine)
+    manager.from(table).where(table[:id].eq(42))
+    expected_sql = "DELETE FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
+    assert_equal expected_sql, manager.to_sql
+  end
+end

--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -1,58 +1,70 @@
 require 'cases/helper_sqlserver'
 
 class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
-  it 'should use fully qualified table name in select from clause' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]"
-    assert_equal expected_sql, table.project(Arel.star).to_sql
+  describe 'local server' do
+    it 'should use table name in select projections' do
+      table = Arel::Table.new(:table)
+      expected_sql = "SELECT [table].[name] FROM [table]"
+      assert_equal expected_sql, table.project(table[:name]).to_sql
+    end
   end
 
-  it 'should not use fully qualified table name in select projections' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    expected_sql = "SELECT [table].[name] FROM [my.server].[db].[schema].[table]"
-    assert_equal expected_sql, table.project(table[:name]).to_sql
-  end
+  describe 'remote server' do
+    before do
+      connection.instance_variable_get(:@connection_options)[:database_prefix] = "[my.server].db.schema."
+    end
 
-  it 'should not use fully qualified table name in where clause' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
-    assert_equal expected_sql, table.project(Arel.star).where(table[:id].eq(42)).to_sql
-  end
+    after do
+      connection.instance_variable_get(:@connection_options).delete(:database_prefix)
+    end
 
-  it 'should not use fully qualified table name in order clause' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]  ORDER BY [table].[name]"
-    assert_equal expected_sql, table.project(Arel.star).order(table[:name]).to_sql
-  end
+    it 'should use fully qualified table name in select from clause' do
+      table = Arel::Table.new(:table)
+      expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]"
+      assert_equal expected_sql, table.project(Arel.star).to_sql
+    end
 
-  it 'should use table name in select projections' do
-    table = Arel::Table.new(:table)
-    expected_sql = "SELECT [table].[name] FROM [table]"
-    assert_equal expected_sql, table.project(table[:name]).to_sql
-  end
+    it 'should not use fully qualified table name in select projections' do
+      table = Arel::Table.new(:table)
+      expected_sql = "SELECT [table].[name] FROM [my.server].[db].[schema].[table]"
+      assert_equal expected_sql, table.project(table[:name]).to_sql
+    end
 
-  it 'should use fully qualified table name in insert statement' do
-    manager = Arel::InsertManager.new(Arel::Table.engine)
-    manager.into Arel::Table.new("[my.server].db.schema.table")
-    manager.values = manager.create_values [Arel.sql('*')], %w{ a }
-    expected_sql = "INSERT INTO [my.server].[db].[schema].[table] VALUES (*)"
-    assert_equal expected_sql, manager.to_sql
-  end
+    it 'should not use fully qualified table name in where clause' do
+      table = Arel::Table.new(:table)
+      expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
+      assert_equal expected_sql, table.project(Arel.star).where(table[:id].eq(42)).to_sql
+    end
 
-  it 'should use fully qualified table name in update statement' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    manager = Arel::UpdateManager.new(Arel::Table.engine)
-    manager.table(table).where(table[:id].eq(42))
-    manager.set([[table[:name], "Bob"]])
-    expected_sql = "UPDATE [my.server].[db].[schema].[table] SET [name] = N'Bob' WHERE [table].[id] = 42"
-    assert_equal expected_sql, manager.to_sql
-  end
+    it 'should not use fully qualified table name in order clause' do
+      table = Arel::Table.new(:table)
+      expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]  ORDER BY [table].[name]"
+      assert_equal expected_sql, table.project(Arel.star).order(table[:name]).to_sql
+    end
 
-  it 'should use fully qualified table name in delete statement' do
-    table = Arel::Table.new("[my.server].db.schema.table")
-    manager = Arel::DeleteManager.new(Arel::Table.engine)
-    manager.from(table).where(table[:id].eq(42))
-    expected_sql = "DELETE FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
-    assert_equal expected_sql, manager.to_sql
+    it 'should use fully qualified table name in insert statement' do
+      manager = Arel::InsertManager.new(Arel::Table.engine)
+      manager.into Arel::Table.new(:table)
+      manager.values = manager.create_values [Arel.sql('*')], %w{ a }
+      expected_sql = "INSERT INTO [my.server].[db].[schema].[table] VALUES (*)"
+      assert_equal expected_sql, manager.to_sql
+    end
+
+    it 'should use fully qualified table name in update statement' do
+      table = Arel::Table.new(:table)
+      manager = Arel::UpdateManager.new(Arel::Table.engine)
+      manager.table(table).where(table[:id].eq(42))
+      manager.set([[table[:name], "Bob"]])
+      expected_sql = "UPDATE [my.server].[db].[schema].[table] SET [name] = N'Bob' WHERE [table].[id] = 42"
+      assert_equal expected_sql, manager.to_sql
+    end
+
+    it 'should use fully qualified table name in delete statement' do
+      table = Arel::Table.new(:table)
+      manager = Arel::DeleteManager.new(Arel::Table.engine)
+      manager.from(table).where(table[:id].eq(42))
+      expected_sql = "DELETE FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
+      assert_equal expected_sql, manager.to_sql
+    end
   end
 end

--- a/test/cases/utils_test_sqlserver.rb
+++ b/test/cases/utils_test_sqlserver.rb
@@ -86,6 +86,25 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
       SQLServer::Utils.extract_identifiers('[obj.name].[foo]').quoted.must_equal '[obj.name].[foo]'
     end
 
+    it 'should indicate if a name is fully qualitified' do
+      SQLServer::Utils.extract_identifiers('object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('schema.object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('database.schema.object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('database.object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('server...object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('server.database..object').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('server.database.schema.object').fully_qualified?.must_equal true
+      SQLServer::Utils.extract_identifiers('server.database.schema.').fully_qualified?.must_equal true
+      SQLServer::Utils.extract_identifiers('[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[schema].[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[database].[schema].[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[database].[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[server.name]...[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[server.name].[database]..[obj.name]').fully_qualified?.must_equal false
+      SQLServer::Utils.extract_identifiers('[server.name].[database].[schema].[obj.name]').fully_qualified?.must_equal true
+      SQLServer::Utils.extract_identifiers('[server.name].[database].[schema].').fully_qualified?.must_equal true
+    end
+
     it 'can return fully qualified quoted table name' do
       name = SQLServer::Utils.extract_identifiers('[server.name].[database].[schema].[object]')
       name.fully_qualified_database_quoted.must_equal '[server.name].[database]'


### PR DESCRIPTION
Building on #426, this pull request fixes SELECT queries on linked servers. In addition, it is not necessary (and probably not desirable) to explicitly set the Arel table_alias for a model (causing other statements to break).

So, this should actually work:

```
class LinkedServerTest < ActiveRecord::Base
  self.table_name = "[server].table.dbo.linked_server_test"
end
```