### PR TITLE
Use proper module for the sqlserver_connection method consistent with…

### DIFF
--- a/lib/active_record/sqlserver_base.rb
+++ b/lib/active_record/sqlserver_base.rb
@@ -1,7 +1,6 @@
 module ActiveRecord
-  class Base
-
-    def self.sqlserver_connection(config) #:nodoc:
+  module ConnectionHandling
+    def sqlserver_connection(config) #:nodoc:
       config = config.symbolize_keys
       config.reverse_merge! mode: :dblib
       mode = config[:mode].to_s.downcase.underscore.to_sym
@@ -17,6 +16,5 @@ module ActiveRecord
       end
       ConnectionAdapters::SQLServerAdapter.new(nil, logger, nil, config.merge(mode: mode))
     end
-
   end
 end


### PR DESCRIPTION
… how other adapters work.

This also allows you to execute stored procedures from a class without having to inherit from `ActiveRecord::Base` (for instance, because there is no table to map to):

```
class NoTableModel
  extend ActiveRecord::ConnectionHandling
  include ActiveRecord::Core

  self.configurations = Rails.configuration.database_configuration
  self.establish_connection("#{Rails.env}_some_database".to_sym)

  def self.execute_procedure(*args)
    self.connection_pool.with_connection { |conn| conn.execute_procedure(*args) }
  end
end
```