### PR TITLE
Correct SQL syntax error when creating temporary table

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -15,13 +15,18 @@ module ActiveRecord
         end
 
         def visit_TableDefinition(o)
+          table_name = o.name
+          table_name = "##{table_name}" if o.temporary
+          table_name = quote_table_name(table_name)
           if o.as
-            table_name = quote_table_name(o.temporary ? "##{o.name}" : o.name)
             projections, source = @conn.to_sql(o.as).match(%r{SELECT\s+(.*)?\s+FROM\s+(.*)?}).captures
             select_into = "SELECT #{projections} INTO #{table_name} FROM #{source}"
           else
-            o.instance_variable_set :@as, nil
-            super
+            create_sql = "CREATE TABLE "
+            create_sql << "#{table_name} "
+            create_sql << "(#{o.columns.map { |c| accept c }.join(', ')}) "
+            create_sql << "#{o.options}"
+            create_sql
           end
         end
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -438,5 +438,23 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   end
 
+  describe 'temporary table' do
+
+    let(:base_table_name) { SstTempTable.table_name.gsub(/^#/, '') }
+
+    after do
+      begin
+        connection.drop_table(SstTempTable.table_name)
+      rescue ActiveRecord::StatementInvalid
+      end
+    end
+
+    it 'creates a temporary table' do
+      connection.create_table(base_table_name, :temporary => true)
+      assert_equal 0, SstTempTable.count
+    end
+
+  end
+
 end
 

--- a/test/models/sqlserver/temp_table.rb
+++ b/test/models/sqlserver/temp_table.rb
@@ -1,0 +1,3 @@
+class SstTempTable < ActiveRecord::Base
+  self.table_name = '#sst_temp_table'
+end


### PR DESCRIPTION
When creating a temporary table, this code:

    connection.create_table("foo", :temporary => true)

causes invalid SQL to be issued to SqlServer:

```
ActiveRecord::StatementInvalid: TinyTds::Error: Unknown object type 'TEMPORARY' used in a CREATE, DROP, or ALTER statement.: CREATE TEMPORARY TABLE [sst_temp_table] ([id] int NOT NULL IDENTITY(1,1) PRIMARY KEY)
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:300:in `do'
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:300:in `raw_connection_do'
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:253:in `block in do_execute'
    /home/wayne/.rvm/gems/ruby-2.2.2/bundler/gems/rails-104468f026e2/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:472:in `block in log'
    /home/wayne/.rvm/gems/ruby-2.2.2/bundler/gems/rails-104468f026e2/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/wayne/.rvm/gems/ruby-2.2.2/bundler/gems/rails-104468f026e2/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:466:in `log'
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:253:in `do_execute'
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:14:in `execute'
    /home/wayne/.rvm/gems/ruby-2.2.2/bundler/gems/rails-104468f026e2/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:208:in `create_table'
    /home/wayne/aux/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/schema_statements.rb:21:in `create_table'
    /home/wayne/aux/activerecord-sqlserver-adapter/test/cases/adapter_test_sqlserver.rb:453:in `block (2 levels) in <class:AdapterTestSQLServer>'
```

This pull request causes the creation of a temporary table to succeed.

The use case for this PR is to make the [temping gem](https://github.com/jpignata/temping) work with SqlServer.  This PR is necessary for that, but not sufficient: The temping gem will need some changes as well if it is to work with SqlServer.