### PR TITLE
Avoid the N' prefix on non-utf8 columns

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -47,21 +47,31 @@ module ActiveRecord
           end
         end
 
+        def quote(value, column = nil)
+          # records are quoted as their primary key
+          return value.quoted_id if value.respond_to?(:quoted_id)
+
+          if column
+            value = column.cast_type.type_cast_for_database(value)
+          end
+
+          _quote(value, column)
+        end
 
         private
 
-        def _quote(value)
+        def _quote(value, column = nil)
           case value
           when Type::Binary::Data
             "0x#{value.hex}"
           when String, ActiveSupport::Multibyte::Chars
-            if value.is_utf8?
-              "#{QUOTED_STRING_PREFIX}#{super}"
+            if (column && column.is_utf8?) || (column.nil?  && value.is_utf8?)
+              "#{QUOTED_STRING_PREFIX}#{super(value)}"
             else
-              super
+              super(value)
             end
           else
-            super
+            super(value)
           end
         end
 


### PR DESCRIPTION
This is related to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/447 and #124. 

As @RayBeaumont suggests:
> The use of the N nvarchar prefix in the where clause causes a type mismatch when the query is executed and results in table scans which, on large queries, cripples the performance.

My PR addresses removing the N' quoting when the column of the where clause is **not** a `NVARCHAR/NTEXT/NCHAR`.

We would need to keep an eye on the `quote` method once rails-5 goes out of beta since they are changing how column casting works there.

I'd like to add some tests but I've been unable to set up the environment for testing so far...