### PR TITLE
Add to_s method to SQLServer::Type::Char::Data object

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/char.rb
@@ -24,6 +24,10 @@ module ActiveRecord
               "'#{@value}'"
             end
 
+            def to_s
+              @value
+            end
+
           end
 
         end


### PR DESCRIPTION
@metaskills with the latest introduction of SQLServer::Type::Char::Data object one of the active record serializers that my app is using stopped working.

I chased the issue down to https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/type/string.rb#L35 where active record calls `value.to_s`.

Since `value` is of type `ActiveRecord::ConnectionAdapters::SQLServer::Type::Char::Data` it was not doing what is expected. 

Since the object doesn't have the `to_s` implementation it was returning a flat `"#<ActiveRecord::ConnectionAdapters::SQLServer::Type::Char::Data:0x000000044a0fe8>"` string, instead of returning the actual value from the database, breaking the serializer.

This PR adds just that, `to_s` implementation. Thoughts?