### PR TITLE
Filter table constraints with matching table schema to column.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -264,6 +264,7 @@ module ActiveRecord
             FROM #{database}.INFORMATION_SCHEMA.COLUMNS columns
             LEFT OUTER JOIN #{database}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC
               ON TC.TABLE_NAME = columns.TABLE_NAME
+              AND TC.TABLE_SCHEMA = columns.TABLE_SCHEMA
               AND TC.CONSTRAINT_TYPE = N'PRIMARY KEY'
             LEFT OUTER JOIN #{database}.INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU
               ON KCU.COLUMN_NAME = columns.COLUMN_NAME

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -164,4 +164,12 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
     db_uuid.must_match(acceptable_uuid)
   end
 
+  # with similar table definition in two schemas
+
+  it 'returns the correct primary columns' do
+    connection = ActiveRecord::Base.connection
+    assert_equal 'field_1', connection.columns('test.sst_schema_test_mulitple_schema').detect(&:is_primary?).name
+    assert_equal 'field_2', connection.columns('test2.sst_schema_test_mulitple_schema').detect(&:is_primary?).name
+  end
+
 end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -204,4 +204,20 @@ ActiveRecord::Schema.define do
     )
   NATURALPKTABLESQLINOTHERSCHEMA
 
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_mulitple_schema' and TABLE_SCHEMA = 'test') DROP TABLE test.sst_schema_test_mulitple_schema"
+  execute <<-SCHEMATESTMULTIPLESCHEMA
+    CREATE TABLE test.sst_schema_test_mulitple_schema(
+      field_1 int NOT NULL PRIMARY KEY,
+      field_2 int,
+    )
+  SCHEMATESTMULTIPLESCHEMA
+  execute "IF NOT EXISTS(SELECT * FROM sys.schemas WHERE name = 'test2') EXEC sp_executesql N'CREATE SCHEMA test2'"
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_mulitple_schema' and TABLE_SCHEMA = 'test2') DROP TABLE test2.sst_schema_test_mulitple_schema"
+  execute <<-SCHEMATESTMULTIPLESCHEMA
+    CREATE TABLE test2.sst_schema_test_mulitple_schema(
+      field_1 int,
+      field_2 int NOT NULL PRIMARY KEY,
+    )
+  SCHEMATESTMULTIPLESCHEMA
+
 end


### PR DESCRIPTION
The following fix will correctly load column definitions across multiple schemas with similar table structures.  It is also significantly faster to load if using lots of schemas with similar structures/constraints.
