### PR TITLE
Type::Char::Data should be compared against it's string value

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/char.rb
@@ -29,6 +29,10 @@ module ActiveRecord
             end
             alias_method :to_str, :to_s
 
+            def ==(other)
+              self.to_s == other.to_s
+            end
+            alias_method :eql?, :==
           end
 
         end


### PR DESCRIPTION
Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/487 

An optional different solution to the same problem could be:

``` ruby
module ActiveRecord
  module ConnectionAdapters
    module SQLServer
      module Type
        class String < ActiveRecord::Type::String

          def changed_in_place?(raw_old_value, new_value)
            if raw_old_value.is_a?(Char::Data) && new_value.is_a?(::String)
              raw_old_value.to_s != new_value
            else
              super
            end
          end
        end
      end
    end
  end
end
```

However, I think the PR's proposed code is more elegant and makes more sense. @metaskills thoughts?
