### PR TITLE
Type::Char::Data inherits from String

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/char.rb
@@ -14,7 +14,7 @@ module ActiveRecord
             Data.new(super)
           end
 
-          class Data
+          class Data < ::String
 
             def initialize(value)
               @value = value.to_s


### PR DESCRIPTION
Hi,

thanks for this gem, it helped me a lot with my projects that use Microsoft SQL!!

I'm currently working on a Rails project using activerecord v4.2.6, and when updating the sql server gem version to 4.2.15 some things started to break. I noticed that tables that contain `char` or `varchar` columns throw the following exception when trying to update a record:

`TypeError: can't cast ActiveRecord::ConnectionAdapters::SQLServer::Type::Char::Data to varchar`

For instance, I have a `Countries` table with the following schema:

`Country(id: integer, code: varchar, name: varchar, date_format: varchar, currency_id: char, created_at: datetime, updated_at: datetime)`

When building a new instance of a country and saving I'm getting the above exception:

```shell
$: c = Country.new code: 'AU', name: 'Australia', date_format: 'DD-MM-YYYY', currency_id: 'AU$'
$: c.save!
TypeError: can't cast ActiveRecord::ConnectionAdapters::SQLServer::Type::Char::Data to varchar
	from /home/ubuntu/.rvm/gems/ruby-2.2.3@companies_api/gems/activerecord-4.2.6/lib/active_record/connection_adapters/abstract/quoting.rb:34:in `rescue in type_cast'
	from /home/ubuntu/.rvm/gems/ruby-2.2.3@companies_api/gems/activerecord-4.2.6/lib/active_record/connection_adapters/abstract/quoting.rb:23:in `type_cast'
...
```

While debugging the code, I noticed that `activerecord-4.2.6/lib/active_record/connection_adapters/abstract/quoting.rb` calls the method `_type_cast` which compares the `Type::Char::Data` value to some data types. Correct me if I'm wrong, but the `Type::Char::Data` should not be typecasted, should it? Check [here](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L126).

Forcing `Data` to inherit from `String` seems to solve the issue. However, if you think it's too intrusive, what would you think of overriding [`types_which_need_no_typecasting`](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L95)?

Any thoughts? Thanks!