### PR TITLE
Make connections reloadable

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -160,6 +160,10 @@ module ActiveRecord
         do_execute 'IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION'
       end
 
+      def requires_reloading?
+        true
+      end
+
       # === Abstract Adapter (Misc Support) =========================== #
 
       def tables_with_referential_integrity


### PR DESCRIPTION
- For environments that set `config.caches_classes = false`, this will
  cause connections in the pool to reload between requests.
- Fixes an exception that is raised when a connection is idle for too
  long. See #402 

See relevant lines in ActiveRecord:
- https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railtie.rb#L154
- https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L447
- https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L415
