### PR TITLE
[Rails5] Ensure date/time columns are not nil on create/update.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute.rb
@@ -1,0 +1,22 @@
+require 'active_record/attribute'
+
+module ActiveRecord
+  class Attribute
+
+    SQLSERVER_DATE_TIME_TYPES = [
+      Type::SQLServer::Date,
+      Type::SQLServer::DateTime,
+      Type::SQLServer::Time
+    ].freeze
+
+    prepend Module.new {
+      def forgetting_assignment
+        case type
+        when *SQLSERVER_DATE_TIME_TYPES then with_value_from_database(value)
+        else super
+        end
+      end
+    }
+
+  end
+end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -8,6 +8,7 @@ require 'active_record/connection_adapters/sqlserver/core_ext/explain_subscriber
 require 'active_record/connection_adapters/sqlserver/core_ext/attribute_methods'
 require 'active_record/connection_adapters/sqlserver/version'
 require 'active_record/connection_adapters/sqlserver/type'
+require 'active_record/connection_adapters/sqlserver/core_ext/attribute'
 require 'active_record/connection_adapters/sqlserver/database_limits'
 require 'active_record/connection_adapters/sqlserver/database_statements'
 require 'active_record/connection_adapters/sqlserver/database_tasks'


### PR DESCRIPTION
Creating or updating records resets the attributes by mapping the hash using ActiveRecord's `Attribute#forgetting_assignment` method. This method essentiall mimics the reload by setting the attributes to FromDatabase using the FromUser value "for the database".

https://github.com/rails/rails/commit/07723c23

This is a problem for us because the `value_for_database` for date time objects are strings that can not be re-parsed due to SQL Server's time formats. For example, a date of August 18th 2016 would be formatted as '08-19-2016' and fail deserialize:

``` ruby
ActiveModel::Type::Date.new.deserialize('08-19-2016') # => nil
```

Both ActiveModel's date and time types rescue `Date.parse` methods of `new_date` and `new_time` with nil. It was suggested that we use Data classes for our time types and we may explore that after this commit which essentially prepends a new `forgetting_assignment` method that checks the type. If it is a SQL Server date/time, it will just convert that value object to a FromDatabase using the existing value.

cc @sgrif @dpulliam
