### PR TITLE
Get the table names with table schema when not "dbo.".

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         end
 
         def tables(table_type = 'BASE TABLE')
-          select_values "SELECT #{lowercase_schema_reflection_sql('TABLE_NAME')} FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} ORDER BY TABLE_NAME", 'SCHEMA'
+          select_values "SELECT concat((case TABLE_SCHEMA when 'dbo' then null else CONCAT(TABLE_SCHEMA, '.') end), TABLE_NAME) FROM INFORMATION_SCHEMA.TABLES #{"WHERE TABLE_TYPE = '#{table_type}'" if table_type} ORDER BY TABLE_NAME", 'SCHEMA'
         end
 
         def data_source_exists?(table_name)


### PR DESCRIPTION
After I set the ActiveRecord::Base.table_name_prefix for my application. 
During the rails startup the adapter complained about pending migrations. 
The reason was that it searched for "schema_name.schema_migration" but the method "tables" returned them without the table schema name.

So I change the query in the tables method.

I hope my contribution is helpful.
Thanks for your work!!
