### PR TITLE
Handle using transactions and resetting isolation level correctly when `READ_COMMITTED_SNAPSHOT` is set to `ON`

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -14,7 +14,15 @@ module ActiveRecord
       def current_isolation_level
         return unless sqlserver?
         level = connection.user_options_isolation_level
-        level.blank? ? 'READ COMMITTED' : level.upcase
+
+        # When READ_COMMITTED_SNAPSHOT is set to ON,
+        # user_options_isolation_level will be equal to 'read committed
+        # snapshot' which is not a valid isolation level
+        if level.blank? || level == 'read committed snapshot'
+          'READ COMMITTED'
+        else
+          level.upcase
+        end
       end
 
     end


### PR DESCRIPTION
## What

I found on a set up when:

```
SET ALLOW_SNAPSHOT_ISOLATION ON
SET READ_COMMITTED_SNAPSHOT ON
```

That you'd get the error: `TinyTds::Error: Incorrect syntax near 'SNAPSHOT'.: SET TRANSACTION ISOLATION LEVEL READ COMMITTED SNAPSHOT`.  This occurs because after running the transaction, the adapter is attempting to set the isolation level to `connection.user_options_isolation_level` which is actually `read committed snapshot` which is not valid.

I wasn't able to run the entire test suite on my setup but was able to get a fail, fix, pass for this specific issue.
