### PR TITLE
[Rails5] Ensure date/time columns are not nil on create/update. Take 2.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -77,6 +77,10 @@ module ActiveRecord
             "0x#{value.hex}"
           when ActiveRecord::Type::SQLServer::Char::Data
             value.quoted
+          when ActiveRecord::Type::SQLServer::Date::Data,
+               ActiveRecord::Type::SQLServer::DateTime::Data,
+               ActiveRecord::Type::SQLServer::DateTime2::Data
+            value.quoted
           when String, ActiveSupport::Multibyte::Chars
             "#{QUOTED_STRING_PREFIX}#{super}"
           else
@@ -93,6 +97,10 @@ module ActiveRecord
           when String, ActiveSupport::Multibyte::Chars, Type::Binary::Data
             _quote(value)
           when ActiveRecord::Type::SQLServer::Char::Data
+            value.quoted
+          when ActiveRecord::Type::SQLServer::Date::Data,
+               ActiveRecord::Type::SQLServer::DateTime::Data,
+               ActiveRecord::Type::SQLServer::DateTime2::Data
             value.quoted
           else super
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/date.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/date.rb
@@ -10,12 +10,31 @@ module ActiveRecord
 
           def serialize(value)
             return unless value.present?
-            return value if value.acts_like?(:string)
-            value.to_s(:_sqlserver_dateformat)
+            return value if value.is_a?(Data)
+            Data.new(super)
+          end
+
+          def deserialize(value)
+            return value.value if value.is_a?(Data)
+            super
           end
 
           def type_cast_for_schema(value)
-            serialize(value).inspect
+            serialize(value).quoted
+          end
+
+          class Data
+
+            attr_reader :value
+
+            def initialize(value)
+              @value = value
+            end
+
+            def quoted
+              Utils.quote_string_single @value.to_s(:_sqlserver_dateformat)
+            end
+
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -12,16 +12,40 @@ module ActiveRecord
 
           def serialize(value)
             return super unless value.acts_like?(:time)
-            value = zone_conversion(value)
-            datetime = value.to_s(:_sqlserver_datetime)
-            "#{datetime}".tap do |v|
-              fraction = quote_fractional(value)
-              v << ".#{fraction}" unless fraction.to_i.zero?
-            end
+            Data.new super, self
+          end
+
+          def deserialize(value)
+            datetime = value.is_a?(Data) ? value.value : super
+            return unless datetime
+            zone_conversion(datetime)
           end
 
           def type_cast_for_schema(value)
-            serialize(value).inspect
+            serialize(value).quoted
+          end
+
+          def quoted(value)
+            datetime = value.to_s(:_sqlserver_datetime)
+            datetime = "#{datetime}".tap do |v|
+              fraction = quote_fractional(value)
+              v << ".#{fraction}" unless fraction.to_i.zero?
+            end
+            Utils.quote_string_single(datetime)
+          end
+
+          class Data
+
+            attr_reader :value, :type
+
+            def initialize(value, type)
+              @value, @type = value, type
+            end
+
+            def quoted
+              type.quoted(@value)
+            end
+
           end
 
           private
@@ -29,7 +53,7 @@ module ActiveRecord
           def cast_value(value)
             value = value.acts_like?(:time) ? value : super
             return unless value
-            cast_fractional(value)
+            apply_seconds_precision(value)
           end
 
           def zone_conversion(value)

--- a/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
@@ -23,6 +23,11 @@ module ActiveRecord
 
           private
 
+          def fast_string_to_time(string)
+            dateformat = ::Time::DATE_FORMATS[:_sqlserver_dateformat]
+            ::Time.strptime string, "#{dateformat} %H:%M:%S.%N %:z"
+          end
+
           def zone_conversion(value)
             value
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
           private
 
-          def cast_fractional(value)
+          def apply_seconds_precision(value)
             value.change usec: 0
           end
 

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -30,7 +30,7 @@ module ActiveRecord
             value = value.acts_like?(:time) ? value : super
             return if value.blank?
             value = value.change year: 2000, month: 01, day: 01
-            cast_fractional(value)
+            apply_seconds_precision(value)
           end
 
           def fractional_scale

--- a/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
@@ -7,7 +7,7 @@ module ActiveRecord
 
           private
 
-          def cast_fractional(value)
+          def apply_seconds_precision(value)
             return value if !value.respond_to?(fractional_property) || value.send(fractional_property).zero?
             frac_seconds = if fractional_scale == 0
                              0


### PR DESCRIPTION
Creating or updating records resets the attributes by mapping the hash using ActiveRecord's `Attribute#forgetting_assignment` method. This method essentiall mimics the reload by setting the attributes to FromDatabase using the FromUser value "for the database".

https://github.com/rails/rails/commit/07723c23

This is a problem for us because the `value_for_database` for date time objects are strings that can not be re-parsed due to SQL Server's time formats. For example, a date of August 18th 2016 would be formatted as '08-19-2016' and fail deserialize:

``` ruby
ActiveModel::Type::Date.new.deserialize('08-19-2016') # => nil
```

Both ActiveModel's date and time types rescue `Date.parse` methods of `new_date` and `new_time` with nil. It was suggested that we use Data classes for our time types and we may explore that after this commit which essentially prepends a new `forgetting_assignment` method that checks the type. If it is a SQL Server date/time, it will just convert that value object to a FromDatabase using the existing value.

cc @sgrif