### PR TITLE
All date/times use Data type cast wrapper.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -62,9 +62,9 @@ module ActiveRecord
 
         def quoted_date(value)
           if value.acts_like?(:date)
-            Type::Date.new.serialize(value)
+            Type::Date.new.serialize(value).quoted
           else value.acts_like?(:time)
-            Type::DateTime.new.serialize(value)
+            Type::DateTime.new.serialize(value).quoted
           end
         end
 
@@ -75,11 +75,7 @@ module ActiveRecord
           case value
           when Type::Binary::Data
             "0x#{value.hex}"
-          when ActiveRecord::Type::SQLServer::Char::Data
-            value.quoted
-          when ActiveRecord::Type::SQLServer::Date::Data,
-               ActiveRecord::Type::SQLServer::DateTime::Data,
-               ActiveRecord::Type::SQLServer::DateTime2::Data
+          when ActiveRecord::Type::SQLServer::Data
             value.quoted
           when String, ActiveSupport::Multibyte::Chars
             "#{QUOTED_STRING_PREFIX}#{super}"
@@ -94,14 +90,12 @@ module ActiveRecord
             "NULL"
           when Symbol
             _quote(value.to_s)
-          when String, ActiveSupport::Multibyte::Chars, Type::Binary::Data
+          when String, ActiveSupport::Multibyte::Chars
             _quote(value)
-          when ActiveRecord::Type::SQLServer::Char::Data
-            value.quoted
-          when ActiveRecord::Type::SQLServer::Date::Data,
-               ActiveRecord::Type::SQLServer::DateTime::Data,
-               ActiveRecord::Type::SQLServer::DateTime2::Data
-            value.quoted
+          when Type::Binary::Data
+            _quote(value)
+          when ActiveRecord::Type::SQLServer::Data
+            _quote(value)
           else super
           end
         end

--- a/lib/active_record/connection_adapters/sqlserver/type.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type.rb
@@ -1,5 +1,6 @@
 require 'active_record/type'
 # Behaviors
+require 'active_record/connection_adapters/sqlserver/type/data'
 require 'active_record/connection_adapters/sqlserver/type/time_value_fractional'
 # Exact Numerics
 require 'active_record/connection_adapters/sqlserver/type/integer'

--- a/lib/active_record/connection_adapters/sqlserver/type/char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/char.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           def serialize(value)
             return if value.nil?
             return value if value.is_a?(Data)
-            Data.new(super)
+            Data.new super, self
           end
 
           def sqlserver_type
@@ -20,22 +20,9 @@ module ActiveRecord
             end
           end
 
-          class Data
-
-            def initialize(value)
-              @quoted_id = value.respond_to?(:quoted_id)
-              @value = @quoted_id ? value.quoted_id : value.to_s
-            end
-
-            def quoted
-              @quoted_id ? @value : "'#{Utils.quote_string(@value)}'"
-            end
-
-            def to_s
-              @value
-            end
-            alias_method :to_str, :to_s
-
+          def quoted(value)
+            return value.quoted_id if value.respond_to?(:quoted_id)
+            Utils.quote_string_single(value)
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver/type/data.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/data.rb
@@ -1,0 +1,26 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module Type
+        class Data
+
+          attr_reader :value, :type
+
+          def initialize(value, type)
+            @value, @type = value, type
+          end
+
+          def quoted
+            type.quoted(@value)
+          end
+
+          def to_s
+            @value
+          end
+          alias_method :to_str, :to_s
+
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/sqlserver/type/date.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/date.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           def serialize(value)
             return unless value.present?
             return value if value.is_a?(Data)
-            Data.new(super)
+            Data.new super, self
           end
 
           def deserialize(value)
@@ -23,18 +23,9 @@ module ActiveRecord
             serialize(value).quoted
           end
 
-          class Data
-
-            attr_reader :value
-
-            def initialize(value)
-              @value = value
-            end
-
-            def quoted
-              Utils.quote_string_single @value.to_s(:_sqlserver_dateformat)
-            end
-
+          def quoted(value)
+            date = value.to_s(:_sqlserver_dateformat)
+            Utils.quote_string_single(date)
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -34,20 +34,6 @@ module ActiveRecord
             Utils.quote_string_single(datetime)
           end
 
-          class Data
-
-            attr_reader :value, :type
-
-            def initialize(value, type)
-              @value, @type = value, type
-            end
-
-            def quoted
-              type.quoted(@value)
-            end
-
-          end
-
           private
 
           def cast_value(value)

--- a/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
@@ -8,17 +8,17 @@ module ActiveRecord
             :datetimeoffset
           end
 
-          def serialize(value)
-            return super unless value.acts_like?(:time)
-            value.to_s :_sqlserver_datetimeoffset
-          end
-
           def type_cast_for_schema(value)
             serialize(value).inspect
           end
 
           def sqlserver_type
             "datetimeoffset(#{precision.to_i})"
+          end
+
+          def quoted(value)
+            datetime = value.to_s(:_sqlserver_datetimeoffset)
+            Utils.quote_string_single(datetime)
           end
 
           private

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -8,21 +8,24 @@ module ActiveRecord
 
           def serialize(value)
             return super unless value.acts_like?(:time)
-            time = value.to_s(:_sqlserver_time)
-            "#{time}".tap do |v|
-              fraction = quote_fractional(value)
-              v << ".#{fraction}" unless fraction.to_i.zero?
-            end
+            Data.new super, self
           end
 
           def type_cast_for_schema(value)
-            serialize(value).inspect
+            serialize(value).quoted
           end
 
           def sqlserver_type
             "time(#{precision.to_i})"
           end
 
+          def quoted(value)
+            time = value.to_s(:_sqlserver_time).tap do |v|
+              fraction = quote_fractional(value)
+              v << ".#{fraction}" unless fraction.to_i.zero?
+            end
+            Utils.quote_string_single(time)
+          end
 
           private
 

--- a/lib/active_record/connection_adapters/sqlserver/type/uuid.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/uuid.rb
@@ -16,8 +16,17 @@ module ActiveRecord
             'uniqueidentifier'.freeze
           end
 
+          def serialize(value)
+            return unless value
+            Data.new super, self
+          end
+
           def cast(value)
             value.to_s[ACCEPTABLE_UUID, 0]
+          end
+
+          def quoted(value)
+            Utils.quote_string_single(value) if value
           end
 
         end

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -117,9 +117,10 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
     assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(char_col: value.new).first }
     assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(varchar_col: value.new).first }
     # Using our custom char type data.
-    data = ActiveRecord::Type::SQLServer::Char::Data
-    assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(char_col: data.new('T')).first }
-    assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(varchar_col: data.new('T')).first }
+    type = ActiveRecord::Type::SQLServer::Char
+    data = ActiveRecord::Type::SQLServer::Data
+    assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(char_col: data.new('T', type.new)).first }
+    assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(varchar_col: data.new('T', type.new)).first }
     # Taking care of everything.
     assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(char_col: 'T').first }
     assert_sql(/@0 = 'T'/) { SSTestDatatypeMigration.where(varchar_col: 'T').first }


### PR DESCRIPTION
This moves all date/time types to use the data wrapper method. This work also creates a generic Data wrapper that simply delegates to a #quoted method on each type. This way our existing logic of parsing and casting our types is completely visible in each type class.

This work also removes some duplication we had done in `_quote` form `_type_cast`. 

cc @sgrif