### PR TITLE
Refactor `_type_cast` & `_quote`.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -86,17 +86,10 @@ module ActiveRecord
 
         def _type_cast(value)
           case value
-          when nil
-            "NULL"
-          when Symbol
-            _quote(value.to_s)
-          when String, ActiveSupport::Multibyte::Chars
-            _quote(value)
-          when Type::Binary::Data
-            _quote(value)
           when ActiveRecord::Type::SQLServer::Data
-            _quote(value)
-          else super
+            value.to_s
+          else
+            super
           end
         end
 

--- a/lib/active_record/connection_adapters/sqlserver/type/data.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/data.rb
@@ -19,6 +19,10 @@ module ActiveRecord
           end
           alias_method :to_str, :to_s
 
+          def inspect
+            @value.inspect
+          end
+
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/date.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/date.rb
@@ -10,13 +10,12 @@ module ActiveRecord
 
           def serialize(value)
             return unless value.present?
-            return value if value.is_a?(Data)
-            Data.new super, self
+            date = value.to_s(:_sqlserver_dateformat)
+            Data.new date, self
           end
 
           def deserialize(value)
-            return value.value if value.is_a?(Data)
-            super
+            value.is_a?(Data) ? super(value.value) : super
           end
 
           def type_cast_for_schema(value)
@@ -24,8 +23,19 @@ module ActiveRecord
           end
 
           def quoted(value)
-            date = value.to_s(:_sqlserver_dateformat)
-            Utils.quote_string_single(date)
+            Utils.quote_string_single(value)
+          end
+
+          private
+
+          def fast_string_to_date(string)
+            ::Date.strptime(string, fast_string_to_date_format)
+          rescue ArgumentError
+            super
+          end
+
+          def fast_string_to_date_format
+            ::Date::DATE_FORMATS[:_sqlserver_dateformat]
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
@@ -8,28 +8,12 @@ module ActiveRecord
             :datetimeoffset
           end
 
-          def type_cast_for_schema(value)
-            serialize(value).inspect
-          end
-
           def sqlserver_type
             "datetimeoffset(#{precision.to_i})"
           end
 
           def quoted(value)
-            datetime = value.to_s(:_sqlserver_datetimeoffset)
-            Utils.quote_string_single(datetime)
-          end
-
-          private
-
-          def fast_string_to_time(string)
-            dateformat = ::Time::DATE_FORMATS[:_sqlserver_dateformat]
-            ::Time.strptime string, "#{dateformat} %H:%M:%S.%N %:z"
-          end
-
-          def zone_conversion(value)
-            value
+            Utils.quote_string_single(value)
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
@@ -14,6 +14,10 @@ module ActiveRecord
 
           private
 
+          def fast_string_to_time_format
+            ::Time::DATE_FORMATS[:_sqlserver_datetime]
+          end
+
           def apply_seconds_precision(value)
             value.change usec: 0
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -8,7 +8,15 @@ module ActiveRecord
 
           def serialize(value)
             return super unless value.acts_like?(:time)
-            Data.new super, self
+            time = value.to_s(:_sqlserver_time).tap do |v|
+              fraction = quote_fractional(value)
+              v << ".#{fraction}" unless fraction.to_i.zero?
+            end
+            Data.new time, self
+          end
+
+          def deserialize(value)
+            value.is_a?(Data) ? super(value.value) : super
           end
 
           def type_cast_for_schema(value)
@@ -20,11 +28,7 @@ module ActiveRecord
           end
 
           def quoted(value)
-            time = value.to_s(:_sqlserver_time).tap do |v|
-              fraction = quote_fractional(value)
-              v << ".#{fraction}" unless fraction.to_i.zero?
-            end
-            Utils.quote_string_single(time)
+            Utils.quote_string_single(value)
           end
 
           private

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -281,7 +281,14 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       type.limit.must_be_nil
       type.precision.must_be_nil
       type.scale.must_be_nil
-      # Can cast strings.
+      # Can cast strings. SQL Server format.
+      obj.date = '04-01-0001'
+      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.save!
+      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.reload
+      obj.date.must_equal               Date.civil(0001, 4, 1)
+      # Can cast strings. ISO format.
       obj.date = '0001-04-01'
       obj.date.must_equal               Date.civil(0001, 4, 1)
       obj.save!


### PR DESCRIPTION
I made a mistake and made `_type_cast` do quoting too. This is now fixed and we have greatly simplified it along with `_quote` and we now use these two to cast and quote as needed in our sp_executesql helpers.

Changed `sp_executesql_sql_type` to have a default `String` case to `nvarchar(max)` not ideal and there are places where we prefer the bind contain the proper SQLServer type. For example, uniquness validations yielding a `ActiveRecord::Relation::QueryAttribute` with a [basic cast type](https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/validations/uniqueness.rb#L80) vs the in scope `cast_type` further up.

Added `sp_executesql_sql_param` which looks out for all `SQLServer::Data` and quotes it accordingly. For example, date & time objects need single quote '' vs. national N'' quoting.

* New base `SQLServer::Data` shared for all types. Delegates quoting decisoin back to type.
* Time types use variouse flavors of (Date|Time)#strptime in concert with SQL Server date/time formats in fast string processing.

cc @sgrif