### PR TITLE
[Rails5] Performance optimizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Removed
 
 * ODBC connection mode. Not been maintained since Rails 4.0.
+* View table name detection in `with_identity_insert_enabled` method for fixtures. Perf hit.
 
 #### Fixed
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -396,15 +396,6 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert SSTestStringDefaultsView.connection.data_source_exists?(SSTestStringDefaultsView.table_name)
     end
 
-    # Doing identity inserts
-
-    it 'be able to do an identity insert' do
-      customer = SSTestCustomersView.new
-      customer.id = 420
-      customer.save!
-      assert SSTestCustomersView.find(420)
-    end
-
     # That have more than 4000 chars for their defintion
 
     it 'cope with null returned for the defintion' do


### PR DESCRIPTION
These changes make the full ActiveRecord test suite run about 100s faster from ~580s to ~480s.

* Use the `schema_cache.columns` for the `#primary_keys` method.
* Ensure that `exec_query` uses the proper arity/arg names. Namely `:prepare` opt.
* Ensure all view checks/methods used in `#columns` only.
* Removed view table name detection in `with_identity_insert_enabled` method for fixtures.
* Removed `#select` abstract adapter override since it was the same.

cc @sgrif