### PR TITLE
[Rails 5] Fix some times coming back nil after save.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -14,7 +14,7 @@ module ActiveRecord
             return super unless value.acts_like?(:time)
             datetime = super.to_s(:_sqlserver_datetime).tap do |v|
               fraction = quote_fractional(value)
-              v << ".#{fraction}" unless fraction.to_i.zero?
+              v << ".#{fraction}"
             end
             Data.new datetime, self
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -10,7 +10,7 @@ module ActiveRecord
             return super unless value.acts_like?(:time)
             time = value.to_s(:_sqlserver_time).tap do |v|
               fraction = quote_fractional(value)
-              v << ".#{fraction}" unless fraction.to_i.zero?
+              v << ".#{fraction}"
             end
             Data.new time, self
           end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -30,7 +30,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :datetime2_3,       type: 'datetime2',    limit: nil,           precision: 3,     scale: nil,  default: nil
     assert_line :datetime2_1,       type: 'datetime2',    limit: nil,           precision: 1,     scale: nil,  default: nil
     end
-    assert_line :smalldatetime,     type: 'smalldatetime',limit: nil,           precision: nil,   scale: nil,  default: "01-01-1901 15:45:00"
+    assert_line :smalldatetime,     type: 'smalldatetime',limit: nil,           precision: nil,   scale: nil,  default: "01-01-1901 15:45:00.0"
     if connection_dblib_73?
     assert_line :time_7,            type: 'time',         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
     assert_line :time_2,            type: 'time',         limit: nil,           precision: 2,     scale: nil,  default: nil


### PR DESCRIPTION
As part of #528, a few errors were introduced. Since we have a `fast_string_to_time` implementation that uses a custom format which includes %N, parsing the time for DB from DB could fail. So we ensure we always have a nanosecond on the SQL even if it is 0. No need not to.