### PR TITLE
Rails5 supports datetime with precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 #### Added
 
-* ...
+* Support for `supports_datetime_with_precision`.
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -188,6 +188,16 @@ module ActiveRecord
             when 5..8       then  'bigint'
             else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
             end
+          when 'datetime2'
+            column_type_sql = super
+            if precision
+              if (0..7) === precision
+                column_type_sql << "(#{precision})"
+              else
+                raise(ActiveRecordError, "The dattime2 type has precision of #{precision}. The allowed range of precision is from 0 to 7")
+              end
+            end
+            column_type_sql
           else
             super
           end
@@ -200,6 +210,10 @@ module ActiveRecord
                .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, '')
             }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
           [super, *order_columns].join(', ')
+        end
+
+        def update_table_definition(table_name, base)
+          SQLServer::Table.new(table_name, base)
         end
 
         def change_column_null(table_name, column_name, allow_null, default = nil)

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -1,7 +1,8 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+
+      module ColumnMethods
 
         def primary_key(name, type = :primary_key, **options)
           return super unless type == :uuid
@@ -10,66 +11,89 @@ module ActiveRecord
           column name, type, options
         end
 
-        def real(name, options = {})
-          column(name, :real, options)
+        def real(*args, **options)
+          args.each { |name| column(name, :real, options) }
         end
 
-        def money(name, options = {})
-          column(name, :money, options)
+        def money(*args, **options)
+          args.each { |name| column(name, :money, options) }
         end
 
-        def datetime2(name, options = {})
-          column(name, :datetime2, options)
+        def datetime(*args, **options)
+          args.each do |name|
+            if options[:precision]
+              datetime2(name, options)
+            else
+              column(name, :datetime, options)
+            end
+          end
         end
 
-        def datetimeoffset(name, options = {})
-          column(name, :datetimeoffset, options)
+        def datetime2(*args, **options)
+          args.each { |name| column(name, :datetime2, options) }
         end
 
-        def smallmoney(name, options = {})
-          column(name, :smallmoney, options)
+        def datetimeoffset(*args, **options)
+          args.each { |name| column(name, :datetimeoffset, options) }
         end
 
-        def char(name, options = {})
-          column(name, :char, options)
+        def smallmoney(*args, **options)
+          args.each { |name| column(name, :smallmoney, options) }
         end
 
-        def varchar(name, options = {})
-          column(name, :varchar, options)
+        def char(*args, **options)
+          args.each { |name| column(name, :char, options) }
         end
 
-        def varchar_max(name, options = {})
-          column(name, :varchar_max, options)
+        def varchar(*args, **options)
+          args.each { |name| column(name, :varchar, options) }
         end
 
-        def text_basic(name, options = {})
-          column(name, :text_basic, options)
+        def varchar_max(*args, **options)
+          args.each { |name| column(name, :varchar_max, options) }
         end
 
-        def nchar(name, options = {})
-          column(name, :nchar, options)
+        def text_basic(*args, **options)
+          args.each { |name| column(name, :text_basic, options) }
         end
 
-        def ntext(name, options = {})
-          column(name, :ntext, options)
+        def nchar(*args, **options)
+          args.each { |name| column(name, :nchar, options) }
         end
 
-        def binary_basic(name, options = {})
-          column(name, :binary_basic, options)
+        def ntext(*args, **options)
+          args.each { |name| column(name, :ntext, options) }
         end
 
-        def varbinary(name, options = {})
-          column(name, :varbinary, options)
+        def binary_basic(*args, **options)
+          args.each { |name| column(name, :binary_basic, options) }
         end
 
-        def uuid(name, options = {})
-          column(name, :uniqueidentifier, options)
+        def varbinary(*args, **options)
+          args.each { |name| column(name, :varbinary, options) }
         end
 
-        def ss_timestamp(name, options = {})
-          column(name, :ss_timestamp, options)
+        def uuid(*args, **options)
+          args.each { |name| column(name, :uniqueidentifier, options) }
         end
 
+        def ss_timestamp(*args, **options)
+          args.each { |name| column(name, :ss_timestamp, options) }
+        end
+
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+
+        def new_column_definition(name, type, options)
+          type = :datetime2 if type == :datetime && options[:precision]
+          super name, type, options
+        end
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -6,11 +6,6 @@ module ActiveRecord
 
           include TimeValueFractional
 
-          def initialize(*args)
-            super
-            @precision = nil if self.class == DateTime
-          end
-
           def sqlserver_type
             'datetime'.freeze
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -6,6 +6,11 @@ module ActiveRecord
 
           include TimeValueFractional
 
+          def initialize(*args)
+            super
+            @precision = nil if self.class == DateTime
+          end
+
           def sqlserver_type
             'datetime'.freeze
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/money.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/money.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class Money < Decimal
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @precision = 19
             @scale = 4

--- a/lib/active_record/connection_adapters/sqlserver/type/small_money.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/small_money.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class SmallMoney < Money
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @precision = 10
             @scale = 4

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class UnicodeVarchar < UnicodeChar
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 4000 if @limit.to_i == 0
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar_max.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class UnicodeVarcharMax < UnicodeVarchar
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 2_147_483_647
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/varbinary.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varbinary.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class Varbinary < Binary
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 8000 if @limit.to_i == 0
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/varbinary_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varbinary_max.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class VarbinaryMax < Varbinary
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 2_147_483_647
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/varchar.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varchar.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class Varchar < Char
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 8000 if @limit.to_i == 0
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/varchar_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varchar_max.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       module Type
         class VarcharMax < Varchar
 
-          def initialize(options = {})
+          def initialize(*args)
             super
             @limit = 2_147_483_647
           end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -128,7 +128,7 @@ module ActiveRecord
       end
 
       def supports_datetime_with_precision?
-        false
+        true
       end
 
       def supports_json?
@@ -268,10 +268,13 @@ module ActiveRecord
         m.register_type              'real',              SQLServer::Type::Real.new
         # Date and Time
         m.register_type              'date',              SQLServer::Type::Date.new
-        m.register_type              'datetime',          SQLServer::Type::DateTime.new
-        m.register_type              %r{\Adatetime2}i do |sql_type|
+        m.register_type              %r{\Adatetime} do |sql_type|
           precision = extract_precision(sql_type)
-          SQLServer::Type::DateTime2.new precision: precision
+          if precision
+            SQLServer::Type::DateTime2.new precision: precision
+          else
+            SQLServer::Type::DateTime.new
+          end
         end
         m.register_type              %r{\Adatetimeoffset}i do |sql_type|
           precision = extract_precision(sql_type)

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -612,3 +612,29 @@ class YamlSerializationTest < ActiveRecord::TestCase
     assert_equal 5, dumped.posts_count
   end
 end
+
+
+
+
+class DateTimePrecisionTest < ActiveRecord::TestCase
+  # Original test had `7` which we support vs `8` which we use.
+  coerce_tests! :test_invalid_datetime_precision_raises_error
+  def test_invalid_datetime_precision_raises_error_coerced
+    assert_raises ActiveRecord::ActiveRecordError do
+      @connection.create_table(:foos, force: true) do |t|
+        t.timestamps precision: 8
+      end
+    end
+  end
+
+  # Original test uses `datetime` vs `datetime2` type which we dynamically use.
+  coerce_tests! :test_schema_dump_includes_datetime_precision
+  def test_schema_dump_includes_datetime_precision_coerced
+    @connection.create_table(:foos, force: true) do |t|
+      t.timestamps precision: 6
+    end
+    output = dump_table_schema("foos")
+    assert_match %r{t\.datetime2\s+"created_at",\s+precision: 6,\s+null: false$}, output
+    assert_match %r{t\.datetime2\s+"updated_at",\s+precision: 6,\s+null: false$}, output
+  end
+end


### PR DESCRIPTION
* Automatically use datetime2 when precision is used.
* Integration of datetime2 with `type_to_sql` so schema types are right.
* New subclasses for Table and TableDefinition with overhauled column methods.
* Fix our time fractional helpers to make datetime/datetime2 under full tests pass.
* New coerced tests.