### PR TITLE
[Rails5] Support `unprepared_statement` blocks & ValueTooLong excp.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -329,15 +329,15 @@ module ActiveRecord
             INNER JOIN #{database}.sys.columns AS c
               ON o.object_id = c.object_id
               AND c.name = columns.COLUMN_NAME
-            WHERE columns.TABLE_NAME = @0
-              AND columns.TABLE_SCHEMA = #{identifier.schema.blank? ? 'schema_name()' : '@1'}
+            WHERE columns.TABLE_NAME = #{prepared_statements ? '@0' : quote(identifier.object)}
+              AND columns.TABLE_SCHEMA = #{identifier.schema.blank? ? 'schema_name()' : (prepared_statements ? '@1' : quote(identifier.schema))}
             ORDER BY columns.ordinal_position
           }.gsub(/[ \t\r\n]+/, ' ').strip
           binds = []
           nv128 = SQLServer::Type::UnicodeVarchar.new limit: 128
           binds << Relation::QueryAttribute.new('TABLE_NAME', identifier.object, nv128)
           binds << Relation::QueryAttribute.new('TABLE_SCHEMA', identifier.schema, nv128) unless identifier.schema.blank?
-          results = sp_executesql(sql, 'SCHEMA', binds, prepare: true)
+          results = sp_executesql(sql, 'SCHEMA', binds)
           results.map do |ci|
             ci = ci.symbolize_keys
             ci[:_type] = ci[:type]

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -316,6 +316,8 @@ module ActiveRecord
           DeadlockVictim.new(message)
         when /database .* does not exist/i
           NoDatabaseError.new(message)
+        when /data would be truncated/
+          ValueTooLong.new(message)
         else
           super
         end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2,10 +2,22 @@ require 'cases/helper_sqlserver'
 
 
 
+require 'models/event'
 module ActiveRecord
   class AdapterTest < ActiveRecord::TestCase
     # As far as I can tell, SQL Server does not support null bytes in strings.
     coerce_tests! :test_update_prepared_statement
+
+    # So sp_executesql swallows this exception. Run without prpared to see it.
+    coerce_tests! :test_value_limit_violations_are_translated_to_specific_exception
+    def test_value_limit_violations_are_translated_to_specific_exception_coerced
+      connection.unprepared_statement do
+        error = assert_raises(ActiveRecord::ValueTooLong) do
+          Event.create(title: 'abcdefgh')
+        end
+        assert_not_nil error.cause
+      end
+    end
   end
 end
 


### PR DESCRIPTION
cc @sgrif