### PR TITLE
[Rails5] Pass more attribute tests for date/time/zones.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -11,8 +11,9 @@ module ActiveRecord
           end
 
           def serialize(value)
-            return super unless value.acts_like?(:time)
-            datetime = super.to_s(:_sqlserver_datetime).tap do |v|
+            value = super
+            return value unless value.acts_like?(:time)
+            datetime = value.to_s(:_sqlserver_datetime).tap do |v|
               fraction = quote_fractional(value)
               v << ".#{fraction}"
             end
@@ -34,9 +35,7 @@ module ActiveRecord
           private
 
           def cast_value(value)
-            value = value.acts_like?(:time) ? value : super
-            return unless value
-            apply_seconds_precision(value)
+            super.try(:in_time_zone)
           end
 
           def fast_string_to_time(string)
@@ -51,6 +50,20 @@ module ActiveRecord
 
           def fast_string_to_time_zone
             ::Time.zone || ActiveSupport::TimeZone.new('UTC')
+          end
+
+          # Copy of module ActiveModel::Type::Helpers::TimeValue with
+          # else condition using a zone for local parsing.
+          def new_time(year, mon, mday, hour, min, sec, microsec, offset = nil)
+            return if year.nil? || (year == 0 && mon == 0 && mday == 0)
+            if offset
+              time = ::Time.utc(year, mon, mday, hour, min, sec, microsec) rescue nil
+              return unless time
+              time -= offset
+              is_utc? ? time : time.getlocal
+            else
+              fast_string_to_time_zone.local(year, mon, mday, hour, min, sec, microsec) rescue nil
+            end
           end
 
         end


### PR DESCRIPTION
Another chapter in an epic series of getting our custom date time types passing all tests. I feel like we are in a constant battle that has gone downhill since we have to have specific quoting for each datetime type/precision that typically follows `%m-%d-%Y` format. This has been complicated by the fact that as part of forgetting assignment we could not rely on ActiveModel/Record to pare these strings for us which does not support a) our formats and b) time zones. I am willing to admit that all this work could somehow be easier but I can not see it. Other PRs include:

* https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/528
* https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/534
* https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/537
* https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/539

Now that we only have a few dozen tests failing. I might try this freedom patch again to see if things really break dirty support and/or helps reduce the complexity.

* https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/504

cc @sgrif