### PR TITLE
Missing parentheses around native_text_database_type

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -231,7 +231,7 @@ module ActiveRecord
       end
 
       def native_text_database_type
-        @@native_text_database_type || enable_default_unicode_types ? 'nvarchar(max)' : 'varchar(max)'
+        @@native_text_database_type || (enable_default_unicode_types ? 'nvarchar(max)' : 'varchar(max)')
       end
 
       def native_time_database_type

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -214,6 +214,42 @@ class AdapterTestSqlserver < ActiveRecord::TestCase
 
     end
 
+    context 'testing #native_string_database_type configuration' do
+
+      should 'use non-unicode types when set to false' do
+        with_native_string_database_type('varchar') do
+          assert_equal 'varchar', @connection.native_string_database_type
+          assert_equal 'nvarchar(max)', @connection.native_text_database_type
+        end
+      end
+
+      should 'use unicode types when set to true' do
+        with_native_string_database_type('nvarchar') do
+          assert_equal 'nvarchar', @connection.native_string_database_type
+          assert_equal 'nvarchar(max)', @connection.native_text_database_type
+        end
+      end
+
+    end
+
+    context 'testing #native_string_database_type configuration' do
+
+      should 'use unicode types when set to true' do
+        with_native_text_database_type('varchar(max)') do
+          assert_equal 'nvarchar', @connection.native_string_database_type
+          assert_equal 'varchar(max)', @connection.native_text_database_type
+        end
+      end
+
+      should 'use unicode types when set to true' do
+        with_native_text_database_type('nvarchar(max)') do
+          assert_equal 'nvarchar', @connection.native_string_database_type
+          assert_equal 'nvarchar(max)', @connection.native_text_database_type
+        end
+      end
+
+    end
+
     context 'testing #lowercase_schema_reflection' do
 
       setup do

--- a/test/cases/sqlserver_helper.rb
+++ b/test/cases/sqlserver_helper.rb
@@ -103,6 +103,22 @@ module ActiveRecord
       ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_string_database_type = old_string
     end
 
+    def with_native_string_database_type(type)
+      old_string = ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_string_database_type
+      ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_string_database_type = type
+      yield
+    ensure
+      ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_string_database_type = old_string
+    end
+
+    def with_native_text_database_type(type)
+      old_text = ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_text_database_type
+      ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_text_database_type = type
+      yield
+    ensure
+      ActiveRecord::ConnectionAdapters::SQLServerAdapter.native_text_database_type = old_text
+    end
+
     def with_auto_connect(boolean)
       existing = ActiveRecord::ConnectionAdapters::SQLServerAdapter.auto_connect
       ActiveRecord::ConnectionAdapters::SQLServerAdapter.auto_connect = boolean


### PR DESCRIPTION
These missing parentheses were causing the string setting and text
setting to behave differently. I think that we really want the setting
to update the text data type when it is set.

Here is a simplified example of what was happening:
```
2.1.3 :006 > boolean = false
 => false
2.1.3 :007 > "good" || (boolean ? 'bad' : 'should never happen')
 => "good"
2.1.3 :008 > "good" || boolean ? 'bad' : 'should never happen'
 => "bad"
```

Test screenshots:
Red
![screen shot 2017-02-07 at 4 21 43 pm](https://cloud.githubusercontent.com/assets/1371190/22712369/92e46032-ed52-11e6-950d-a758431c2438.png)

Green
![screen shot 2017-02-07 at 4 22 42 pm](https://cloud.githubusercontent.com/assets/1371190/22712372/949d2a58-ed52-11e6-972f-dd69250d661f.png)
