### PR TITLE
use schema_cache

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -513,7 +513,7 @@ module ActiveRecord
         end
 
         def identity_columns(table_name)
-          columns(table_name).select(&:is_identity?)
+          schema_cache.columns(table_name).select(&:is_identity?)
         end
 
 


### PR DESCRIPTION
We had slow performance on inserts in rails 5 because ```column_definitions``` is called for each insert.

The call to ```column_definitions``` comes from ```query_requires_identity_insert?``` which calls ```identity_columns```

Not sure what other consequences this patch has, please review. Also I'm unsure how to test.