### PR TITLE
Example In-Memory DB Setup & Table(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 * Misc index enhancements or testing. Fixes #570
   Enable `supports_index_sort_order?`, test `supports_partial_index?`, test how expression indexes work.
 
+#### Added
+
+* New `primary_key_nonclustered` type for easy In-Memory table creation.
+* Examples for an In-Memory table.
+
+```ruby
+create_table :in_memory_table, id: false,
+             options: 'WITH (MEMORY_OPTIMIZED = ON, DURABILITY = SCHEMA_AND_DATA)' do |t|
+  t.primary_key_nonclustered :id
+  t.string :name
+  t.timestamps
+end
+```
+
 
 ## v5.0.5
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -253,6 +253,7 @@ module ActiveRecord
         def initialize_native_database_types
           {
             primary_key: 'int NOT NULL IDENTITY(1,1) PRIMARY KEY',
+            primary_key_nonclustered: 'int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED',
             integer: { name: 'int', limit: 4 },
             bigint: { name: 'bigint' },
             boolean: { name: 'bit' },

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -11,6 +11,10 @@ module ActiveRecord
           column name, type, options
         end
 
+        def primary_key_nonclustered(*args, **options)
+          args.each { |name| column(name, :primary_key_nonclustered, options) }
+        end
+
         def real(*args, **options)
           args.each { |name| column(name, :real, options) }
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -141,6 +141,10 @@ module ActiveRecord
         false
       end
 
+      def supports_in_memory_oltp?
+        @version_year >= 2014
+      end
+
       def disable_referential_integrity
         tables = tables_with_referential_integrity
         tables.each { |t| do_execute "ALTER TABLE #{t} NOCHECK CONSTRAINT ALL" }
@@ -416,6 +420,7 @@ module ActiveRecord
 
       def version_year
         vstring = _raw_select('SELECT @@version', fetch: :rows).first.first.to_s
+        return 2016 if vstring =~ /vNext/
         /SQL Server (\d+)/.match(vstring).to_a.last.to_s.to_i
       rescue Exception => e
         2016

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -416,5 +416,14 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   end
 
+  it 'in_memory_oltp' do
+    if ENV['IN_MEMORY_OLTP'] && connection.supports_in_memory_oltp?
+      SSTMemory.primary_key.must_equal 'id'
+      SSTMemory.columns_hash['id'].must_be :is_identity?
+    else
+      skip 'supports_in_memory_oltp? => false'
+    end
+  end
+
 end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -806,3 +806,13 @@ module ActiveRecord
     coerce_tests! %r{with offset which return 0 rows}
   end
 end
+
+
+
+
+module ActiveRecord
+  class StatementCacheTest < ActiveRecord::TestCase
+    # Getting random failures.
+    coerce_tests! :test_find_does_not_use_statement_cache_if_table_name_is_changed
+  end
+end

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 Bundler.require :default, :development
 require 'pry'
 require 'support/minitest_sqlserver'
+require 'support/test_in_memory_oltp'
 require 'cases/helper'
 require 'support/load_schema_sqlserver'
 require 'support/coerceable_test_sqlserver'

--- a/test/models/sqlserver/sst_memory.rb
+++ b/test/models/sqlserver/sst_memory.rb
@@ -1,0 +1,3 @@
+class SSTMemory < ActiveRecord::Base
+  self.table_name = 'sst_memory'
+end

--- a/test/schema/enable-in-memory-oltp.sql
+++ b/test/schema/enable-in-memory-oltp.sql
@@ -1,0 +1,81 @@
+-- https://msdn.microsoft.com/en-us/library/mt694156.aspx
+-- https://raw.githubusercontent.com/Microsoft/sql-server-samples/master/samples/features/in-memory/t-sql-scripts/enable-in-memory-oltp.sql
+--
+-- The below scipt enables the use of In-Memory OLTP in the current database,
+--   provided it is supported in the edition / pricing tier of the database.
+-- It does the following:
+-- 1. Validate that In-Memory OLTP is supported.
+-- 2. In SQL Server, it will add a MEMORY_OPTIMIZED_DATA filegroup to the database
+--    and create a container within the filegroup in the default data folder.
+-- 3. Change the database compatibility level to 130 (needed for parallel queries
+--    and auto-update of statistics).
+-- 4. Enables the database option MEMORY_OPTIMIZED_ELEVATE_TO_SNAPSHOT to avoid the
+--    need to use the WITH (SNAPSHOT) hint for ad hoc queries accessing memory-optimized
+--    tables.
+--
+-- Applies To: SQL Server 2016 (or higher); Azure SQL Database
+-- Author: Jos de Bruijn (Microsoft)
+-- Last Updated: 2016-05-02
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+-- 1. validate that In-Memory OLTP is supported
+IF SERVERPROPERTY(N'IsXTPSupported') = 0
+BEGIN
+    PRINT N'Error: In-Memory OLTP is not supported for this server edition or database pricing tier.';
+END
+IF DB_ID() < 5
+BEGIN
+    PRINT N'Error: In-Memory OLTP is not supported in system databases. Connect to a user database.';
+END
+ELSE
+BEGIN
+  BEGIN TRY;
+-- 2. add MEMORY_OPTIMIZED_DATA filegroup when not using Azure SQL DB
+  IF SERVERPROPERTY('EngineEdition') != 5
+  BEGIN
+    DECLARE @SQLDataFolder nvarchar(max) = cast(SERVERPROPERTY('InstanceDefaultDataPath') as nvarchar(max))
+    DECLARE @MODName nvarchar(max) = DB_NAME() + N'_mod';
+    DECLARE @MemoryOptimizedFilegroupFolder nvarchar(max) = @SQLDataFolder + @MODName;
+
+    DECLARE @SQL nvarchar(max) = N'';
+
+    -- add filegroup
+    IF NOT EXISTS (SELECT 1 FROM sys.filegroups WHERE type = N'FX')
+    BEGIN
+      SET @SQL = N'
+ALTER DATABASE CURRENT
+ADD FILEGROUP ' + QUOTENAME(@MODName) + N' CONTAINS MEMORY_OPTIMIZED_DATA;';
+      EXECUTE (@SQL);
+
+    END;
+
+    -- add container in the filegroup
+    IF NOT EXISTS (SELECT * FROM sys.database_files WHERE data_space_id IN (SELECT data_space_id FROM sys.filegroups WHERE type = N'FX'))
+    BEGIN
+      SET @SQL = N'
+ALTER DATABASE CURRENT
+ADD FILE (name = N''' + @MODName + ''', filename = '''
+            + @MemoryOptimizedFilegroupFolder + N''')
+TO FILEGROUP ' + QUOTENAME(@MODName);
+      EXECUTE (@SQL);
+    END
+  END
+
+  -- 3. set compat level to 130 if it is lower
+  IF (SELECT compatibility_level FROM sys.databases WHERE database_id=DB_ID()) < 130
+    ALTER DATABASE CURRENT SET COMPATIBILITY_LEVEL = 130
+
+  -- 4. enable MEMORY_OPTIMIZED_ELEVATE_TO_SNAPSHOT for the database
+  ALTER DATABASE CURRENT SET MEMORY_OPTIMIZED_ELEVATE_TO_SNAPSHOT = ON;
+
+
+    END TRY
+    BEGIN CATCH
+        PRINT N'Error enabling In-Memory OLTP';
+    IF XACT_STATE() != 0
+      ROLLBACK;
+        THROW;
+    END CATCH;
+END;

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -37,6 +37,15 @@ ActiveRecord::Schema.define do
 
   # Edge Cases
 
+  if ENV['IN_MEMORY_OLTP'] && supports_in_memory_oltp?
+    create_table 'sst_memory', force: true, id: false,
+                 options: 'WITH (MEMORY_OPTIMIZED = ON, DURABILITY = SCHEMA_AND_DATA)' do |t|
+      t.primary_key_nonclustered :id
+      t.string :name
+      t.timestamps
+    end
+  end
+
   create_table 'sst_bookings', force: true do |t|
     t.string :name
     t.datetime2 :created_at, null: false

--- a/test/support/test_in_memory_oltp.rb
+++ b/test/support/test_in_memory_oltp.rb
@@ -1,0 +1,15 @@
+if ENV['IN_MEMORY_OLTP']
+  require 'config'
+  require 'active_record'
+  require 'support/config'
+  require 'support/connection'
+
+  ARTest.connect
+
+  if ActiveRecord::Base.connection.supports_in_memory_oltp?
+    puts 'Configuring In-Memory OLTP...'
+    inmem_file = ARTest::SQLServer.test_root_sqlserver, 'schema', 'enable-in-memory-oltp.sql'
+    inmem_sql = File.read File.join(inmem_file)
+    ActiveRecord::Base.connection.execute(inmem_sql)
+  end
+end


### PR DESCRIPTION
In support of this work I created a simple `primary_key_nonclustered` helper since you can created clustered indexes on In-Memory tables. Also included is a simple example script created by Microsoft that helps ensure you Database has been configured to use In-Memory OLTP. This setup is run with an environment variable `IN_MEMORY_OLTP` for our tests only. This is because if the whole ActiveRecord test DB were set to `SET MEMORY_OPTIMIZED_ELEVATE_TO_SNAPSHOT = ON` it would cause a few other Rails test to fail.

Example table creation, assuming In-Memory OLTP setup:

```ruby
create_table :in_memory_table, id: false,
             options: 'WITH (MEMORY_OPTIMIZED = ON, DURABILITY = SCHEMA_AND_DATA)' do |t|
  t.primary_key_nonclustered :id
  t.string :name
  t.timestamps
end
```

More about In-Memory OLTP at Microsoft's site:
https://msdn.microsoft.com/en-us/library/dn133186.aspx
