### PR TITLE
Enable supports_json? for 2016 and up with a little bit of sugar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ create_table :in_memory_table, id: false,
 end
 ```
 
+* Enable supports_json? Fixes #577.
+
+```ruby
+create_table :users do |t|
+  t.string :name, :email
+  t.json :data # Creates a nvarchar(max) column.
+ end
+
+class Users < ActiveRecord::Base
+  attribute :data, ActiveRecord::Type::SQLServer::Json.new
+end
+
+User.create! name: 'Ken Collins', data: { 'admin' => true, 'foo' => 'bar' }
+
+admin = User.where("JSON_VALUE(data, '$.admin') = CAST(1 AS BIT)").first
+admin.data['foo'] # => "bar"
+```
+
 
 ## v5.0.5
 

--- a/RAILS5-TODO.md
+++ b/RAILS5-TODO.md
@@ -1,12 +1,6 @@
 
 ## Rails v5.0
 
-* Docs on Docker Usage & Testing - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/547
-* Supports Comments - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/486
-* Supports Indexed in Create - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/483
-  https://blog.dbi-services.com/sql-server-2014-tips-create-indexes-directly-via-create-table/
-  Column Store https://msdn.microsoft.com/en-us/library/gg492153.aspx
-  https://www.microsoft.com/en-us/sql-server/developer-get-started/node-mac
 * Does the schema cache serialize properly since we conform to that now?
 * Can we use `OPTIMIZE FOR UNKNOWN`
   - http://sqlblog.com/blogs/aaron_bertrand/archive/2011/09/17/bad-habits-to-kick-using-exec-instead-of-sp-executesql.aspx

--- a/RAILS5-TODO.md
+++ b/RAILS5-TODO.md
@@ -2,7 +2,6 @@
 ## Rails v5.0
 
 * Docs on Docker Usage & Testing - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/547
-* Supports JSON - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/485
 * Supports Comments - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/486
 * Supports Indexed in Create - https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/483
   https://blog.dbi-services.com/sql-server-2014-tips-create-indexes-directly-via-create-table/

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -281,7 +281,8 @@ module ActiveRecord
             varbinary: { name: 'varbinary', limit: 8000 },
             binary: { name: 'varbinary(max)' },
             uuid: { name: 'uniqueidentifier' },
-            ss_timestamp: { name: 'timestamp' }
+            ss_timestamp: { name: 'timestamp' },
+            json: { name: 'nvarchar(max)' }
           }
         end
 

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -85,6 +85,10 @@ module ActiveRecord
           args.each { |name| column(name, :ss_timestamp, options) }
         end
 
+        def json(*args, **options)
+          args.each { |name| column(name, :text, options) }
+        end
+
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition

--- a/lib/active_record/connection_adapters/sqlserver/type.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type.rb
@@ -40,6 +40,7 @@ require 'active_record/connection_adapters/sqlserver/type/varbinary_max'
 # Other Data Types
 require 'active_record/connection_adapters/sqlserver/type/uuid'
 require 'active_record/connection_adapters/sqlserver/type/timestamp'
+require 'active_record/connection_adapters/sqlserver/type/json'
 
 module ActiveRecord
   module Type

--- a/lib/active_record/connection_adapters/sqlserver/type/json.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/json.rb
@@ -1,0 +1,11 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module Type
+        class Json < ActiveRecord::Type::Internal::AbstractJson
+
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -130,7 +130,7 @@ module ActiveRecord
       end
 
       def supports_json?
-        true
+        @version_year >= 2016
       end
 
       def supports_comments?
@@ -304,6 +304,8 @@ module ActiveRecord
         register_class_with_limit m, %r{\Anvarchar}i,     SQLServer::Type::UnicodeVarchar
         m.alias_type                 'string',            'nvarchar(4000)'
         m.register_type              'nvarchar(max)',     SQLServer::Type::UnicodeVarcharMax.new
+        m.register_type              'nvarchar(max)',     SQLServer::Type::UnicodeVarcharMax.new
+        m.alias_type                 'json',              'nvarchar(max)'
         m.register_type              'ntext',             SQLServer::Type::UnicodeText.new
         # Binary Strings
         register_class_with_limit m, %r{\Abinary}i,       SQLServer::Type::Binary

--- a/test/cases/json_test_sqlserver.rb
+++ b/test/cases/json_test_sqlserver.rb
@@ -1,0 +1,32 @@
+require 'cases/helper_sqlserver'
+
+if ActiveRecord::Base.connection.supports_json?
+class JsonTestSQLServer < ActiveRecord::TestCase
+
+  before do
+    @o1 = SSTestDatatypeMigrationJson.create! json_col: { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
+    @o2 = SSTestDatatypeMigrationJson.create! json_col: { 'a' => nil, 'b' => 'b', 'c' => 'c' }
+    @o3 = SSTestDatatypeMigrationJson.create! json_col: { 'x' => 1, 'y' => 2, 'z' => 3 }
+    @o4 = SSTestDatatypeMigrationJson.create! json_col: { 'array' => [1, 2, 3] }
+    @o5 = SSTestDatatypeMigrationJson.create! json_col: nil
+  end
+
+  it 'can return and save JSON data' do
+    SSTestDatatypeMigrationJson.find(@o1.id).json_col.must_equal({ 'a' => 'a', 'b' => 'b', 'c' => 'c' })
+    @o1.json_col = { 'a' => 'a' }
+    @o1.json_col.must_equal({ 'a' => 'a' })
+    @o1.save!
+    @o1.reload.json_col.must_equal({ 'a' => 'a' })
+  end
+
+  it 'can use ISJSON function' do
+    SSTestDatatypeMigrationJson.where('ISJSON(json_col) > 0').count.must_equal 4
+    SSTestDatatypeMigrationJson.where('ISJSON(json_col) IS NULL').count.must_equal 1
+  end
+
+  it 'can use JSON_VALUE function' do
+    SSTestDatatypeMigrationJson.where("JSON_VALUE(json_col, '$.b') = 'b'").count.must_equal 2
+  end
+
+end
+end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -97,6 +97,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     columns['varbinary_col'].sql_type.must_equal    'varbinary(8000)'
     columns['uuid_col'].sql_type.must_equal         'uniqueidentifier'
     columns['sstimestamp_col'].sql_type.must_equal  'timestamp'
+    columns['json_col'].sql_type.must_equal         'nvarchar(max)'
     assert_line :real_col,          type: 'real',           limit: nil,           precision: nil,   scale: nil,  default: nil
     assert_line :money_col,         type: 'money',          limit: nil,           precision: 19,    scale: 4,    default: nil
     assert_line :datetime2_col,     type: 'datetime',       limit: nil,           precision: 7,     scale: nil,  default: nil
@@ -111,6 +112,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :varbinary_col,     type: 'varbinary',      limit: nil,           precision: nil,   scale: nil,  default: nil
     assert_line :uuid_col,          type: 'uuid',           limit: nil,           precision: nil,   scale: nil,  default: nil
     assert_line :sstimestamp_col,   type: 'ss_timestamp',   limit: nil,           precision: nil,   scale: nil,  default: nil
+    assert_line :json_col,          type: 'text',           limit: 2147483647,    precision: nil,   scale: nil,  default: nil
   end
 
   # Special Cases

--- a/test/models/sqlserver/datatype_migration.rb
+++ b/test/models/sqlserver/datatype_migration.rb
@@ -1,3 +1,8 @@
 class SSTestDatatypeMigration < ActiveRecord::Base
   self.table_name = :sst_datatypes_migration
 end
+
+class SSTestDatatypeMigrationJson < ActiveRecord::Base
+  self.table_name = :sst_datatypes_migration
+  attribute :json_col, ActiveRecord::Type::SQLServer::Json.new
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -33,7 +33,11 @@ ActiveRecord::Schema.define do
     t.varbinary      :varbinary_col
     t.uuid           :uuid_col
     t.ss_timestamp   :sstimestamp_col
-    t.json           :json_col if supports_json?
+    if supports_json?
+      t.json :json_col
+    else
+      t.text :json_col
+    end
   end
 
   # Edge Cases

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define do
     t.varbinary      :varbinary_col
     t.uuid           :uuid_col
     t.ss_timestamp   :sstimestamp_col
+    t.json           :json_col if supports_json?
   end
 
   # Edge Cases


### PR DESCRIPTION
Adds a simple JSON type for creating an underlying `nvarchar(max)` column to add JSON too. Since SQL Server does not have a true JSON type. This means supporting JSON from a Rails perspective is a simple as adding the proper SQL Server type to your model's column which has some form of underlying string type.

```ruby
create_table :users do |t|
  t.string :name, :email
  t.json :data # Creates a nvarchar(max) column.
 end

class Users < ActiveRecord::Base
  attribute :data, ActiveRecord::Type::SQLServer::Json.new
end
```

This allows you to save and return JSON data and query it as needed.

```ruby
User.create! name: 'DJ Ruby Rhod', data: nil
User.create! name: 'Ken Collins', data: { 'admin' => true, 'foo' => 'bar' }

admin = User.where("JSON_VALUE(data, '$.admin') = CAST(1 AS BIT)").first
admin.data['foo'] # => "bar"
```


Fixes #485.