### PR TITLE
Added new option "use_output_inserted_into" that defaults to false.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -198,7 +198,7 @@ module ActiveRecord
           end
           sql = if pk && self.class.use_output_inserted && !database_prefix_remote_server?
                   quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
-                  "DECLARE @inserted_identity table (#{quoted_pk} bigint);" << (sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_identity;") << ";SELECT CAST(#{quoted_pk} AS bigint) FROM @inserted_identity;"
+                  "DECLARE @inserted_identity table (#{quoted_pk} bigint);" << (sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_identity") << ";SELECT CAST(#{quoted_pk} AS bigint) FROM @inserted_identity;"
                 else
                   "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
                 end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -198,12 +198,7 @@ module ActiveRecord
           end
           sql = if pk && self.class.use_output_inserted && !database_prefix_remote_server?
                   quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
-                  if !self.class.use_output_inserted_into
-                    sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"
-                  else
-                    tempsql = sql.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_id"
-                    "DECLARE @inserted_id table (id int);#{tempsql}; SELECT * FROM @inserted_id;"
-                  end
+                  "DECLARE @inserted_id table (#{quoted_pk} bigint);" + sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_id" + "; SELECT CAST(#{quoted_pk} AS bigint) FROM @inserted_id;"
                 else
                   "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
                 end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -198,7 +198,7 @@ module ActiveRecord
           end
           sql = if pk && self.class.use_output_inserted && !database_prefix_remote_server?
                   quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
-                  "DECLARE @inserted_id table (#{quoted_pk} bigint);" + sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_id" + "; SELECT CAST(#{quoted_pk} AS bigint) FROM @inserted_id;"
+                  "DECLARE @inserted_identity table (#{quoted_pk} bigint);" << (sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @inserted_identity;") << ";SELECT CAST(#{quoted_pk} AS bigint) FROM @inserted_identity;"
                 else
                   "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
                 end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -44,7 +44,6 @@ module ActiveRecord
 
       cattr_accessor :cs_equality_operator, instance_accessor: false
       cattr_accessor :use_output_inserted, instance_accessor: false
-      cattr_accessor :use_output_inserted_into, instance_accessor: false
       cattr_accessor :showplan_option, instance_accessor: false
       cattr_accessor :lowercase_schema_reflection
 

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -44,6 +44,7 @@ module ActiveRecord
 
       cattr_accessor :cs_equality_operator, instance_accessor: false
       cattr_accessor :use_output_inserted, instance_accessor: false
+      cattr_accessor :use_output_inserted_into, instance_accessor: false
       cattr_accessor :showplan_option, instance_accessor: false
       cattr_accessor :lowercase_schema_reflection
 


### PR DESCRIPTION
Added new insert condition to use the OUTPUT INSERTED INTO TSQL statement format when the use_output_inserted_into option is set to true.
If the option is false, it uses the existing TSQL statement

This is due to SQL Server requiring the OUTPUT INSERTED INTO when a DB Table has a trigger. In that case a simple OUTPUT INSERTED will not work and will throw an error.

> The target table 'T' of the DML statement cannot have any enabled triggers if the statement contains an OUTPUT clause without INTO clause.

#593 