### PR TITLE
Bugfix: Use `ActiveSupport.on_load` to hook into ActiveRecord

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/active_record.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/active_record.rb
@@ -24,4 +24,6 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::Base.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::ActiveRecord
+ActiveSupport.on_load(:active_record) do
+  include ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::ActiveRecord
+end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
@@ -22,4 +22,6 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::Base.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::AttributeMethods
+ActiveSupport.on_load(:active_record) do
+  include ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::AttributeMethods
+end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -43,5 +43,7 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::Base.extend ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Explain
-ActiveRecord::Relation.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Explain
+ActiveSupport.on_load(:active_record) do
+  extend ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Explain
+  ActiveRecord::Relation.include(ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Explain)
+end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain_subscriber.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain_subscriber.rb
@@ -1,4 +1,6 @@
-silence_warnings do
-  # Already defined in Rails
-  ActiveRecord::ExplainSubscriber::EXPLAINED_SQLS = /(select|update|delete|insert)\b/i
+ActiveSupport.on_load(:active_record) do
+  silence_warnings do
+    # Already defined in Rails
+    ActiveRecord::ExplainSubscriber::EXPLAINED_SQLS = /(select|update|delete|insert)\b/i
+  end
 end


### PR DESCRIPTION
See #588 
Use `ActiveSupport.on_load` to hook into ActiveRecord to respect the loading order. Otherwise configuration parameters might not be picked up in time.