### PR TITLE
dateformat to ISO 8601

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -143,14 +143,6 @@ module ActiveRecord
           end
         end
 
-        def user_options_dateformat
-          if sqlserver_azure?
-            select_value 'SELECT [dateformat] FROM [sys].[syslanguages] WHERE [langid] = @@LANGID', 'SCHEMA'
-          else
-            user_options['dateformat']
-          end
-        end
-
         def user_options_isolation_level
           if sqlserver_azure?
             sql = %(SELECT CASE [transaction_isolation_level]

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -418,14 +418,12 @@ module ActiveRecord
       def configure_application_name ; end
 
       def initialize_dateformatter
-        @database_dateformat = user_options_dateformat
-        a, b, c = @database_dateformat.each_char.to_a
-        [a, b, c].each { |f| f.upcase! if f == 'y' }
-        dateformat = "%#{a}-%#{b}-%#{c}"
+        # ISO 8601 format
+        dateformat = "%Y-%m-%d"
         ::Date::DATE_FORMATS[:_sqlserver_dateformat]     = dateformat
         ::Time::DATE_FORMATS[:_sqlserver_dateformat]     = dateformat
         ::Time::DATE_FORMATS[:_sqlserver_time]           = '%H:%M:%S'
-        ::Time::DATE_FORMATS[:_sqlserver_datetime]       = "#{dateformat} %H:%M:%S"
+        ::Time::DATE_FORMATS[:_sqlserver_datetime]       = "#{dateformat}T%H:%M:%S"
         ::Time::DATE_FORMATS[:_sqlserver_datetimeoffset] = lambda { |time|
           time.strftime "#{dateformat} %H:%M:%S.%9N #{time.formatted_offset}"
         }


### PR DESCRIPTION
Change date format for SQL server and Azure that date format will
always be ISO 8601 format.