### PR TITLE
Fix mangled times after save when default_timezone is set to local

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -37,7 +37,7 @@ module ActiveRecord
           def fast_string_to_time(string)
             time = ActiveSupport::TimeZone['UTC'].strptime(string, fast_string_to_time_format)
             new_time(time.year, time.month, time.day, time.hour,
-                     time.min, time.sec, time.nsec / 1_000.0)
+                     time.min, time.sec, Rational(time.nsec, 1_000))
           rescue ArgumentError
             super
           end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -35,7 +35,9 @@ module ActiveRecord
           private
 
           def fast_string_to_time(string)
-            fast_string_to_time_zone.strptime(string, fast_string_to_time_format).time
+            time = ActiveSupport::TimeZone['UTC'].strptime(string, fast_string_to_time_format)
+            new_time(time.year, time.month, time.day, time.hour,
+                     time.min, time.sec, time.nsec / 1_000)
           rescue ArgumentError
             super
           end
@@ -43,11 +45,6 @@ module ActiveRecord
           def fast_string_to_time_format
             "#{::Time::DATE_FORMATS[:_sqlserver_datetime]}.%N".freeze
           end
-
-          def fast_string_to_time_zone
-            ::Time.zone || ActiveSupport::TimeZone['UTC']
-          end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -37,7 +37,7 @@ module ActiveRecord
           def fast_string_to_time(string)
             time = ActiveSupport::TimeZone['UTC'].strptime(string, fast_string_to_time_format)
             new_time(time.year, time.month, time.day, time.hour,
-                     time.min, time.sec, time.nsec / 1_000)
+                     time.min, time.sec, time.nsec / 1_000.0)
           rescue ArgumentError
             super
           end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -586,6 +586,28 @@ class PersistenceTest < ActiveRecord::TestCase
     # assert_nothing_raised { topic.reload }
     # assert_equal topic.title, Topic.find(1234).title
   end
+
+  def test_update_date_time_attributes
+    Time.use_zone("Eastern Time (US & Canada)") do
+      topic = Topic.find(1)
+      time = Time.zone.parse("2017-07-17 10:56")
+      topic.update_attributes!(written_on: time)
+      assert_equal(time, topic.written_on)
+    end
+  end
+
+  def test_update_date_time_attributes_with_default_timezone_local
+    with_env_tz 'America/New_York' do
+      with_timezone_config default: :local do
+        Time.use_zone("Eastern Time (US & Canada)") do
+          topic = Topic.find(1)
+          time = Time.zone.parse("2017-07-17 10:56")
+          topic.update_attributes!(written_on: time)
+          assert_equal(time, topic.written_on)
+        end
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
Time attributes are being mangled in the Active Record after filter `changes_internally_applied` because the new attribute is being based of the serialized version of the time, which is a string. The new column value comes from parsing this string, but the old parsing method does not  account for the `default_timezone` setting causing the the time to be mis-interpreted.