### PR TITLE
Add case insensitive comparison for better performance with CI collations

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -84,7 +84,7 @@ module ActiveRecord
         end
 
         def can_perform_case_insensitive_comparison_for?(column)
-          column.type == :string
+          column.type == :string && (!column.collation || column.case_sensitive?)
         end
         private :can_perform_case_insensitive_comparison_for?
 


### PR DESCRIPTION
Right now, the adapter will use the default `case_insensitive_comparison` from ActiveRecord which performs a conversion to lower case no matter what ([see here](https://github.com/rails/rails/blob/f10a6467c5252afa73cbdecb7400667fdda27ada/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L428)). This gets called e.g. using the uniqueness validator with `case_sensitive: false`.

This conversion is unneeded and can be a performance issue if the collation in use is case insensitive anyway.

This PR is intended to avoid this when possible.