### PR TITLE
Identity Inserts with Triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 * Patched `Relation#build_count_subquery`. Fixes #613.
+* Inserts to tables with triggers using default `OUTPUT INSERTED` style. Fixes #595.
 
 
 ## v5.1.2

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -45,11 +45,13 @@ module ActiveRecord
 
       cattr_accessor :cs_equality_operator, instance_accessor: false
       cattr_accessor :use_output_inserted, instance_accessor: false
+      cattr_accessor :exclude_output_inserted_table_names, instance_accessor: false
       cattr_accessor :showplan_option, instance_accessor: false
       cattr_accessor :lowercase_schema_reflection
 
       self.cs_equality_operator = 'COLLATE Latin1_General_CS_AS_WS'
       self.use_output_inserted = true
+      self.exclude_output_inserted_table_names = Concurrent::Map.new { false }
 
       def initialize(connection, logger = nil, config = {})
         super(connection, logger, config)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -140,12 +140,12 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
 
     it 'return quoted table_name to #query_requires_identity_insert? when INSERT sql contains id column' do
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql)
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted)
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered)
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql_sp)
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted_sp)
-      assert_equal '[funny_jokes]', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered_sp)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql_sp)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted_sp)
+      assert_equal 'funny_jokes', connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered_sp)
     end
 
     it 'return false to #query_requires_identity_insert? for normal SQL' do

--- a/test/cases/trigger_test_sqlserver.rb
+++ b/test/cases/trigger_test_sqlserver.rb
@@ -1,0 +1,30 @@
+# encoding: UTF-8
+require 'cases/helper_sqlserver'
+
+class SQLServerTriggerTest < ActiveRecord::TestCase
+  after  { exclude_output_inserted_table_names.clear }
+
+  let(:exclude_output_inserted_table_names) do
+    ActiveRecord::ConnectionAdapters::SQLServerAdapter.exclude_output_inserted_table_names
+  end
+
+  it 'can insert into a table with output inserted - with a true setting for table name' do
+    exclude_output_inserted_table_names['sst_table_with_trigger'] = true
+    assert SSTestTriggerHistory.all.empty?
+    obj = SSTestTrigger.create! event_name: 'test trigger'
+    ['Fixnum', 'Integer'].must_include obj.id.class.name
+    obj.event_name.must_equal 'test trigger'
+    obj.id.must_be :present?
+    obj.id.to_s.must_equal SSTestTriggerHistory.first.id_source
+  end
+
+  it 'can insert into a table with output inserted - with a uniqueidentifier value' do
+    exclude_output_inserted_table_names['sst_table_with_uuid_trigger'] = 'uniqueidentifier'
+    assert SSTestTriggerHistory.all.empty?
+    obj = SSTestTriggerUuid.create! event_name: 'test uuid trigger'
+    obj.id.class.name.must_equal 'String'
+    obj.event_name.must_equal 'test uuid trigger'
+    obj.id.must_be :present?
+    obj.id.to_s.must_equal SSTestTriggerHistory.first.id_source
+  end
+end

--- a/test/models/sqlserver/trigger.rb
+++ b/test/models/sqlserver/trigger.rb
@@ -1,0 +1,7 @@
+class SSTestTrigger < ActiveRecord::Base
+  self.table_name = 'sst_table_with_trigger'
+end
+
+class SSTestTriggerUuid < ActiveRecord::Base
+  self.table_name = 'sst_table_with_uuid_trigger'
+end

--- a/test/models/sqlserver/trigger_history.rb
+++ b/test/models/sqlserver/trigger_history.rb
@@ -1,0 +1,3 @@
+class SSTestTriggerHistory < ActiveRecord::Base
+  self.table_name = 'sst_table_with_trigger_history'
+end


### PR DESCRIPTION
The adapter uses `OUTPUT INSERTED` so that we can select any data type key, for example UUID tables. However, this poses a problem with tables that use triggers. The solution requires that we use a more complex insert statement which uses a temporary table to select the inserted identity. To use this format you must declare your table exempt from the simple output inserted style with the table name into a concurrent hash. Optionally, you can set the data type of the table's primary key to return.

```ruby
adapter = ActiveRecord::ConnectionAdapters::SQLServerAdapter

adapter.exclude_output_inserted_table_names['my_table_name'] = true

adapter.exclude_output_inserted_table_names['my_uuid_table_name'] = 'uniqueidentifier'
```

Fixes #595 #593