### PR TITLE
Use the query lock hint when joining tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## v5.1.5
+## v5.1.6
 
 #### Added
 
 * Use lock hint when joining table in query.
+
+
+## v5.1.5
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v5.1.5
 
+#### Added
+
+* Use lock hint when joining table in query.
+
 #### Fixed
 
 * Memoize `@@version` queries. Fixes #632

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -95,17 +95,29 @@ module Arel
           collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector
         end
         if o.right.any?
-          collector << " " if o.left
+          collector << SPACE if o.left
           collector = inject_join o.right, collector, ' '
         end
         collector
+      end
+
+      def visit_Arel_Nodes_InnerJoin o, collector
+        collector << "INNER JOIN "
+        collector = visit o.left, collector
+        collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector, space: true
+        if o.right
+          collector << SPACE
+          visit(o.right, collector)
+        else
+          collector
+        end
       end
 
       def visit_Arel_Nodes_OuterJoin o, collector
         collector << "LEFT OUTER JOIN "
         collector = visit o.left, collector
         collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector, space: true
-        collector << " "
+        collector << SPACE
         visit o.right, collector
       end
 

--- a/test/cases/pessimistic_locking_test_sqlserver.rb
+++ b/test/cases/pessimistic_locking_test_sqlserver.rb
@@ -52,6 +52,34 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
       end
     end
 
+    describe 'joining tables' do
+
+      it 'joined tables use updlock by default' do
+        assert_sql %r|SELECT \[people\]\.\* FROM \[people\] WITH\(UPDLOCK\) INNER JOIN \[readers\] WITH\(UPDLOCK\)\s+ON \[readers\]\.\[person_id\] = \[people\]\.\[id\]| do
+          Person.lock(true).joins(:readers).load
+        end
+      end
+
+      it 'joined tables can use custom lock directive' do
+        assert_sql %r|SELECT \[people\]\.\* FROM \[people\] WITH\(NOLOCK\) INNER JOIN \[readers\] WITH\(NOLOCK\)\s+ON \[readers\]\.\[person_id\] = \[people\]\.\[id\]| do
+          Person.lock('WITH(NOLOCK)').joins(:readers).load
+        end
+      end
+
+      it 'left joined tables use updlock by default' do
+        assert_sql %r|SELECT \[people\]\.\* FROM \[people\] WITH\(UPDLOCK\) LEFT OUTER JOIN \[readers\] WITH\(UPDLOCK\)\s+ON \[readers\]\.\[person_id\] = \[people\]\.\[id\]| do
+          Person.lock(true).left_joins(:readers).load
+        end
+      end
+
+      it 'left joined tables can use custom lock directive' do
+        assert_sql %r|SELECT \[people\]\.\* FROM \[people\] WITH\(NOLOCK\) LEFT OUTER JOIN \[readers\] WITH\(NOLOCK\)\s+ON \[readers\]\.\[person_id\] = \[people\]\.\[id\]| do
+          Person.lock('WITH(NOLOCK)').left_joins(:readers).load
+        end
+      end
+
+    end
+
   end
 
   describe 'For paginated finds' do


### PR DESCRIPTION
When you perform a query using locking and a left-join, the lock is used in both the FROM and LEFT OUTER JOIN portions of the query:

**ActiveRecord:** `Person.lock(true).left_joins(:readers).load`
**SQL:** `SELECT [people].* FROM [people] WITH(UPDLOCK) LEFT OUTER JOIN [readers] WITH(UPDLOCK) ON [readers].[person_id] = [people].[id]`

However, when you use the same query with a inner-join, the lock is not used in the INNER JOIN portion of the query:

**ActiveRecord:** `Person.lock(true).joins(:readers).load`
**SQL:** `SELECT [people].* FROM [people] WITH(UPDLOCK) INNER JOIN [readers] ON [readers].[person_id] = [people].[id]`

This change will apply the lock hint to the inner-joins. 

I came across this issue as we are trying to use NOLOCK hints on queries containing joins. 

**ActiveRecord:** `Person.lock('WITH(NOLOCK)').joins(:readers).load`  
**Before change SQL:** `SELECT [people].* FROM [people] WITH(NOLOCK) INNER JOIN [readers] ON [readers].[person_id] = [people].[id]`
**After change SQL:** `SELECT [people].* FROM [people] WITH(NOLOCK) INNER JOIN [readers] WITH(NOLOCK) ON [readers].[person_id] = [people].[id]`