### PR TITLE
Don't disable referential integrity for the same table twice

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -189,7 +189,7 @@ module ActiveRecord
 
       def tables_with_referential_integrity
         schemas_and_tables = select_rows <<-SQL.strip_heredoc
-          SELECT s.name, o.name
+          SELECT DISTINCT s.name, o.name
           FROM sys.foreign_keys i
           INNER JOIN sys.objects o ON i.parent_object_id = o.OBJECT_ID
           INNER JOIN sys.schemas s ON o.schema_id = s.schema_id

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -231,6 +231,11 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       end
     end
 
+    it 'not disable referential integrity for the same table twice' do
+      tables = SSTestHasPk.connection.tables_with_referential_integrity
+      assert_equal tables.size, tables.uniq.size
+    end
+
   end
 
   describe 'database statements' do

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -144,12 +144,20 @@ ActiveRecord::Schema.define do
 
   # Constraints
 
-  create_table(:sst_has_fks, force: true) { |t| t.column(:fk_id, :bigint, null: false) }
+  create_table(:sst_has_fks, force: true) do |t|
+    t.column(:fk_id, :bigint, null: false)
+    t.column(:fk_id2, :bigint)
+  end
+
   create_table(:sst_has_pks, force: true) { }
   execute <<-ADDFKSQL
     ALTER TABLE sst_has_fks
     ADD CONSTRAINT FK__sst_has_fks_id
     FOREIGN KEY ([fk_id])
+    REFERENCES [sst_has_pks] ([id]),
+
+    CONSTRAINT FK__sst_has_fks_id2
+    FOREIGN KEY ([fk_id2])
     REFERENCES [sst_has_pks] ([id])
   ADDFKSQL
 


### PR DESCRIPTION
The following caught my eye when running `connection.disable_referential_integrity { ... }` in a Rails console (using v4.2.18 of the adapter):
```
...
  SQL (99.4ms)  ALTER TABLE [dbo].[accounts] CHECK CONSTRAINT ALL
  SQL (80.5ms)  ALTER TABLE [dbo].[accounts] CHECK CONSTRAINT ALL
  SQL (85.7ms)  ALTER TABLE [dbo].[accounts] CHECK CONSTRAINT ALL
  SQL (107.9ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (83.6ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (86.2ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (87.2ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (88.5ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (82.9ms)  ALTER TABLE [dbo].[debt_claim_postings] CHECK CONSTRAINT ALL
  SQL (84.8ms)  ALTER TABLE [dbo].[tx_pins] CHECK CONSTRAINT ALL
...
```
Apparently duplicates are not eliminated when determining the set of tables with foreign key constraints.

In our case the adapter emitted 2 * 256 `ALTER TABLE ... (NO)CHECK CONSTRAINT ALL` statements instead of the sufficient 2 * 167.

It would be lovely to see this fix in the 4.2 line as well.