### PR TITLE
Primary key should be lowercase if schema forced to lowercase

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -93,7 +93,7 @@ module ActiveRecord
           identifier = database_prefix_identifier(table_name)
           database = identifier.fully_qualified_database_quoted
           sql = %{
-            SELECT KCU.COLUMN_NAME AS [name]
+            SELECT #{lowercase_schema_reflection_sql('KCU.COLUMN_NAME')} AS [name]
             FROM #{database}.INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU
             LEFT OUTER JOIN #{database}.INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC
               ON KCU.CONSTRAINT_NAME = TC.CONSTRAINT_NAME


### PR DESCRIPTION
I faced with errors while "rake db:schema:dump" on existing database.
This caused code do not match column object by name. Then null caused silent exceptions.
And schema had no dump for tables where primary keys where mixed case.