### PR TITLE
Make String equality check work for Type::Data values

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/string.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/string.rb
@@ -4,6 +4,13 @@ module ActiveRecord
       module Type
         class String < ActiveRecord::Type::String
 
+          def changed_in_place?(raw_old_value, new_value)
+            if raw_old_value.is_a?(Data)
+              raw_old_value.value != new_value
+            else
+              super
+            end
+          end
 
         end
       end

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -798,6 +798,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       obj.save!
     end
 
+    it 'does not mark object as changed after save' do
+      obj.save!
+      obj.attributes
+      obj.changed?.must_equal false
+    end
+
   end
 
 end


### PR DESCRIPTION
This is to fix #645.

String values in the `@value_before_type_cast` variables of the `attributes` set might be of type `ActiveRecord::ConnectionAdapters::SQLServer::Type::Data` after `serialize` has been called on them (e.g. on `save`) instead of being plain strings (which is the case for freshly created objects).

These values would get compared to the current values of attributes (these would be plain Ruby strings) when Rails figures out which fields to update.

However, this check would fail currently, marking the object as `changed` and so it would result in an extra unnecessary update query the next time it's saved.

This PR is intended to resolve this by enabling comparisons between `Type::Data` and plain string objects for `Type::String` attributes.