### PR TITLE
Multi-column primary keys in deterministic queries

### DIFF
--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -167,4 +167,10 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
     assert_equal 'field_2', connection.columns('test2.sst_schema_test_mulitple_schema').detect(&:is_primary?).name
   end
 
+  it 'returns ordered by both primary keys when no order is given' do
+    2.times { |i| SSTestDoublePk.create!(pk_1: 0, pk_2: i) }
+
+    assert_equal 0, SSTestDoublePk.find_by(pk_1: 0).pk_2
+  end
+
 end

--- a/test/models/sqlserver/double_pk.rb
+++ b/test/models/sqlserver/double_pk.rb
@@ -1,0 +1,5 @@
+class SSTestDoublePk < ActiveRecord::Base
+
+  self.table_name = 'sst_double_pk'
+
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -277,4 +277,12 @@ ActiveRecord::Schema.define do
     )
   SCHEMATESTMULTIPLESCHEMA
 
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_double_pk' and TABLE_SCHEMA = 'test') DROP TABLE test.sst_double_pk"
+  execute <<-SCHEMADOUBLEPRIMARYKEY
+    CREATE TABLE test.sst_double_pk(
+      pk_1 int NOT NULL,
+      pk_2 int NOT NULL,
+      PRIMARY KEY (pk_1, pk_2)
+    )
+  SCHEMADOUBLEPRIMARYKEY
 end


### PR DESCRIPTION
The older version of the adapter supported (accidentally or by design) multi-column primary keys in queries that expected deterministic order - those using `limit` / `offset` syntax. This PR brings back the support, so `Model.find`, `Model.find_by` queries work again.