### PR TITLE
Support for multiple schema types when dumping schema; potential fix for #317

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
@@ -30,8 +30,21 @@ module ActiveRecord
         def default_primary_key?(column)
           super && column.is_primary? && column.is_identity?
         end
-
       end
+    end
+  end
+
+  class SchemaDumper
+    private
+
+    def remove_prefix_and_suffix(table)
+      table = remove_schema(table)
+      table.gsub(/^(#{@options[:table_name_prefix]})(.+)(#{@options[:table_name_suffix]})$/,  "\\2")
+    end
+
+    def remove_schema(table_with_schema)
+      identifier = ActiveRecord::ConnectionAdapters::SQLServer::Utils.extract_identifiers(table_with_schema)
+      identifier.object
     end
   end
 end

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -254,15 +254,20 @@ module ActiveRecord
           do_execute sql
         end
 
+        def server_schema
+          'dbo'
+        end
+
         private
 
         def data_source_sql(name = nil, type: nil)
           scope = quoted_scope name, type: type
           table_name = lowercase_schema_reflection_sql 'TABLE_NAME'
-          sql = "SELECT #{table_name}"
+          table_schema = lowercase_schema_reflection_sql 'TABLE_SCHEMA'
+          sql = "SELECT '[' + #{table_schema} + '].' + #{table_name} as #{table_name}"
           sql << ' FROM INFORMATION_SCHEMA.TABLES'
           sql << ' WHERE TABLE_CATALOG = DB_NAME()'
-          sql << " AND TABLE_SCHEMA = #{quote(scope[:schema])}"
+          sql << " AND TABLE_SCHEMA in (#{ prepare_schema(scope[:schema]) { |schema| quote(schema) }})"
           sql << " AND TABLE_NAME = #{quote(scope[:name])}" if scope[:name]
           sql << " AND TABLE_TYPE = #{quote(scope[:type])}" if scope[:type]
           sql << " ORDER BY #{table_name}"
@@ -272,10 +277,14 @@ module ActiveRecord
         def quoted_scope(name = nil, type: nil)
           identifier = SQLServer::Utils.extract_identifiers(name)
           {}.tap do |scope|
-            scope[:schema] = identifier.schema || 'dbo'
+            scope[:schema] = identifier.schema || server_schema
             scope[:name] = identifier.object if identifier.object
             scope[:type] = type if type
           end
+        end
+
+        def prepare_schema(schema, &block)
+          Array(schema).map(&block).join(', ')
         end
 
         # === SQLServer Specific ======================================== #


### PR DESCRIPTION
This is what I got. PR for specs and questions. 

This PR allows `rake db:schema:dump` to dump the database schema for all microsoft table schemas. 

It does this through exposing a method that can be monkey patched in an initializer:

```
module ActiveRecord
  module ConnectionAdapters
    class SQLServerAdapter < AbstractAdapter

      def configure_connection
        raw_connection_do "SET TEXTSIZE #{64.megabytes}"
      end

      def configure_application_name
        "myapp_#{$$}_#{Thread.current.object_id}".to(29)
      end

    end

    module SQLServer
      module SchemaStatements
        def server_schema
          ['dbo', 'schema2', 'schema3']
        end
      end
    end
  end

end
```

A couple of questions I have, because I don't know the internals of sql server super well. 

1. Should the `dbo` schema always be present in the `information_schema.tables` query? 
2. Is there a way to put the alternative schemas in the database.yml file that you know of?
3. When writing to the schema.rb should we include the `[schema_name].` in the `create_table` definition?
3b. How do we create the table in the same schema it was dumped in during `rake db:schema:load`?