### PR TITLE
Configure tests to run inside a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ Gemfile.lock
 test/profile/output/*
 .rvmrc
 .rbenv-version
+.tool-versions
 .idea
 coverage/*
 .flooignore
 .floo
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 cache: bundler
 services:
   - docker
+env:
+  global:
+    - COMPOSE_FILE: docker-compose.ci.yml
 before_install:
   - sudo rm /usr/local/bin/docker-compose
   - sudo curl -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -9,7 +12,7 @@ before_install:
 install:
   - docker-compose build --build-arg TARGET_VERSION=$TARGET_VERSION
 script:
-  - docker-compose run tests
+  - docker-compose run ci
 matrix:
   include:
     - env: TARGET_VERSION=2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,17 @@ sudo: required
 cache: bundler
 services:
   - docker
-env:
-  global:
-    - TINYTDS_VERSION=2.1.0
-    - ACTIVERECORD_UNITTEST_HOST=localhost
-    - ACTIVERECORD_UNITTEST_DATASERVER=localhost
-rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
 before_install:
-  - export PATH=/opt/local/bin:$PATH
-  - docker info
-  - sudo ./test/bin/setup.sh
-  - sudo ./test/bin/install-openssl.sh
-  - openssl version
-  - sudo ./test/bin/install-freetds.sh
-  - tsql -C
+  - sudo rm /usr/local/bin/docker-compose
+  - sudo curl -L "https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  - sudo chmod +x /usr/local/bin/docker-compose
 install:
-  - export PATH=/opt/local/bin:$PATH
-  - gem install bundler
-  - bundle --version
-  - bundle install
+  - docker-compose build --build-arg TARGET_VERSION=$TARGET_VERSION
 script:
-  - bundle exec rake
+  - docker-compose run tests
+matrix:
+  include:
+    - env: TARGET_VERSION=2.3.8
+    - env: TARGET_VERSION=2.4.5
+    - env: TARGET_VERSION=2.5.3
+    - env: TARGET_VERSION=2.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG TARGET_VERSION=2.5.3
+
+FROM wpolicarpo/activerecord-sqlserver-adapter:${TARGET_VERSION}
+
+ENV WORKDIR /activerecord-sqlserver-adapter
+
+RUN mkdir -p $WORKDIR
+WORKDIR $WORKDIR
+
+COPY . $WORKDIR
+
+RUN bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
+
+CMD ["sh"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,7 +2,7 @@ version: "2.2"
 services:
   database:
     image: metaskills/mssql-server-linux-rails
-  tests:
+  ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=database
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "2.2"
+services:
+  database:
+    image: metaskills/mssql-server-linux-rails
+  tests:
+    environment:
+      - ACTIVERECORD_UNITTEST_HOST=database
+    build: .
+    command: wait-for database:1433 -- bundle exec rake test
+    depends_on:
+      - "database"


### PR DESCRIPTION
It's no uncommon to see tests failing because FreeTDS could not be installed due to ftp issues. In order to mitigate this issue, I created a Docker image with all dependencies installed so we can use to run tests.

Dockerfile can be found [here](https://github.com/wpolicarpo/activerecord-sqlserver-adapter-docker-image).

I'm happy to move Dockerfile source code to https://github.com/rails-sqlserver/docker-images if necessary.