### PR TITLE
Fix Time value precision calculation

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
@@ -10,12 +10,16 @@ module ActiveRecord
           def apply_seconds_precision(value)
             return value if !value.respond_to?(fractional_property) || value.send(fractional_property).zero?
             value.change fractional_property => seconds_precision(value)
+
+            millis = seconds_precision(value).to_i
+            value = value.change fractional_property => millis % fractional_operator
+            value + millis / fractional_operator
           end
 
           def seconds_precision(value)
             return 0 if fractional_scale == 0
             seconds = value.send(fractional_property).to_d / fractional_operator.to_d
-            seconds = ((seconds * (1 / fractional_precision)).round / (1 / fractional_precision)).truncate(fractional_scale)
+            seconds = ((seconds / fractional_precision).round * fractional_precision).round(fractional_scale)
             (seconds * fractional_operator).round(0).to_i
           end
 
@@ -39,7 +43,7 @@ module ActiveRecord
           end
 
           def fractional_precision
-            BigDecimal('0.00333')
+            BigDecimal('0.003333')
           end
 
           def fractional_scale

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -223,14 +223,14 @@ module ActiveRecord
       coerce_tests! :test_quote_ar_object
       def test_quote_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "'02-14-2017 12:34:56.789'",  @connection.quote(value)
+        assert_equal "'02-14-2017 12:34:56.79'",  @connection.quote(value)
       end
 
       # Use our date format.
       coerce_tests! :test_type_cast_ar_object
       def test_type_cast_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "02-14-2017 12:34:56.789",  @connection.type_cast(value)
+        assert_equal "02-14-2017 12:34:56.79",  @connection.type_cast(value)
       end
 
     end


### PR DESCRIPTION
From [MS SQL docs](https://docs.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql?view=sql-server-2017), the datetime type has a millisecond precision of 1/300th of a second, or more specifically:

> Rounded to increments of .000, .003, or .007 seconds

The current implementation tries to round values passed as `datetime` to this standard, however the implementation is giving wrong values that do not end in either 0, 3 or 7. For example, if we pass a date ending in, say, `.8666667` seconds, it will incorrectly round to `.865` instead of `.867`, which would be the correct rounding for SQL Server, and also the correct rounding anywhere.

What I did was to eliminate a couple of inversions that were being done without any good reason (in fact they only made the result stray further from the right value), and increase the precision of the divider being applied (to make the overall precision 1/300th of a second).

Now milliseconds ending in `9` are being rounded to `10`, or more precisely, to `0`. This means that a date of `2017-11-25 10:05:38.999499` should be rounded to `2017-11-25 10:05:39.000`, but was instead being rounded to `2017-11-25 10:05:38.000`. There's actually an [open issue](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/631) about this. The second part of this PR addresses this. We now detect if there's a "carry second", and add it to the final date, after manually changing the microseconds to the rounded value.

Overall, because of the removed inversion logic, this conversion does not add any extra execution time, and this can demonstrated with a benchmark (which I will soon add here).