### PR TITLE
Fix tinyint columns schema migration

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -220,7 +220,8 @@ module ActiveRecord
           case type.to_s
           when 'integer'
             case limit
-            when 1..2       then  'smallint'
+            when 1          then  'tinyint'
+            when 2          then  'smallint'
             when 3..4, nil  then  'integer'
             when 5..8       then  'bigint'
             else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -273,9 +273,12 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal 'integer', connection.type_to_sql(:integer, limit: 3)
     end
 
-    it 'create smallints when limit is less than 3' do
+    it 'create smallints when limit is 2' do
       assert_equal 'smallint', connection.type_to_sql(:integer, limit: 2)
-      assert_equal 'smallint', connection.type_to_sql(:integer, limit: 1)
+    end
+
+    it 'create tinyints when limit is 1' do
+      assert_equal 'tinyint', connection.type_to_sql(:integer, limit: 1)
     end
 
     it 'create bigints when limit is greateer than 4' do


### PR DESCRIPTION
Dumped `tinyint` columns should be imported back as `tinyint`, not `smallint`.

Fix #670.