### PR TITLE
change_column_null should not clear other column attributes

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -258,7 +258,7 @@ module ActiveRecord
         def change_column_null(table_name, column_name, allow_null, default = nil)
           table_id = SQLServer::Utils.extract_identifiers(table_name)
           column_id = SQLServer::Utils.extract_identifiers(column_name)
-          column = detect_column_for! table_name, column_name
+          column = column_for(table_name, column_name)
           if !allow_null.nil? && allow_null == false && !default.nil?
             do_execute("UPDATE #{table_id} SET #{column_id}=#{quote(default)} WHERE #{column_id} IS NULL")
           end
@@ -490,13 +490,6 @@ module ActiveRecord
 
         def default_constraint_name(table_name, column_name)
           "DF_#{table_name}_#{column_name}"
-        end
-
-        def detect_column_for!(table_name, column_name)
-          unless column = schema_cache.columns(table_name).find { |c| c.name == column_name.to_s }
-            raise ActiveRecordError, "No such column: #{table_name}.#{column_name}"
-          end
-          column
         end
 
         def lowercase_schema_reflection_sql(node)

--- a/test/cases/change_column_null_test_sqlserver.rb
+++ b/test/cases/change_column_null_test_sqlserver.rb
@@ -1,0 +1,42 @@
+require 'cases/helper_sqlserver'
+require 'migrations/create_clients_and_change_column_null'
+
+class ChangeColumnNullTestSqlServer < ActiveRecord::TestCase
+  before do
+    @old_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    CreateClientsAndChangeColumnNull.new.up
+  end
+
+  after do
+    CreateClientsAndChangeColumnNull.new.down
+    ActiveRecord::Migration.verbose = @old_verbose
+  end
+
+  def find_column(table, name)
+    table.find { |column| column.name == name }
+  end
+
+  let(:clients_table) { connection.columns('clients') }
+  let(:name_column) { find_column(clients_table, 'name') }
+  let(:code_column) { find_column(clients_table, 'code') }
+  let(:value_column) { find_column(clients_table, 'value') }
+
+  describe '#change_column_null' do
+    it 'does not change the column limit' do
+      name_column.limit.must_equal 15
+    end
+
+    it 'does not change the column default' do
+      code_column.default.must_equal 'n/a'
+    end
+
+    it 'does not change the column precision' do
+      value_column.precision.must_equal 32
+    end
+
+    it 'does not change the column scale' do
+      value_column.scale.must_equal 8
+    end
+  end
+end

--- a/test/migrations/create_clients_and_change_column_null.rb
+++ b/test/migrations/create_clients_and_change_column_null.rb
@@ -1,0 +1,23 @@
+class CreateClientsAndChangeColumnNull < ActiveRecord::Migration[5.2]
+  def up
+    create_table :clients do |t|
+      t.string :name
+      t.string :code
+      t.decimal :value
+
+      t.timestamps
+    end
+
+    change_column :clients, :name, :string, limit: 15
+    change_column :clients, :code, :string, default: 'n/a'
+    change_column :clients, :value, :decimal, precision: 32, scale: 8
+
+    change_column_null :clients, :name, false
+    change_column_null :clients, :code, false
+    change_column_null :clients, :value, false
+  end
+
+  def down
+    drop_table :clients
+  end
+end


### PR DESCRIPTION
When using `change_column_null` in the following migration, the column's limit, precision and scale were being cleared.

https://github.com/lairtonlelis/sqlserver_adapter_issue/blob/master/db/migrate/20190222183019_create_clients.rb

Seems to be the same issue as #582.