### PR TITLE
fix constrains bug

### DIFF
--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -57,6 +57,14 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
       assert default_after
       assert_equal default_before['constraint_keys'], default_after['constraint_keys']
     end
+    
+    it 'change limit' do
+      assert_nothing_raised { connection.change_column :people, :lock_version, :integer, limit: 8 }
+    end
+    
+    it 'change null and default' do
+      assert_nothing_raised { connection.change_column :people, :first_name, :text, null: true, default: nil }
+    end
 
   end
 


### PR DESCRIPTION
```
activerecord-sqlserver-adapter (5.2.0)
tiny_tds (2.1.2-x64-mingw32)
rails (5.2.2)
```

rails migration
```
change_column :projects, :description, :text, :null => true, :default => nil
```
raises an error TinyTds::Error: The object 'DF_projects_description' is dependent on column 'description'.

there's a bug in activerecord-sqlserver-adapter that executes commands in wrong order

before
```
ALTER TABLE table REMOVE CONSTRAINT
ALTER TABLE table ADD CONSTRAINT
ALTER TABLE table ALTER COLUMN
```

after
```
ALTER TABLE table REMOVE CONSTRAINT
ALTER TABLE table ALTER COLUMN
ALTER TABLE table ADD CONSTRAINT
```