### PR TITLE
Change to name the columns when querying for table info

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -350,10 +350,14 @@ module ActiveRecord
               AND columns.TABLE_SCHEMA = #{identifier.schema.blank? ? 'schema_name()' : (prepared_statements ? '@1' : quote(identifier.schema))}
             ORDER BY columns.ordinal_position
           }.gsub(/[ \t\r\n]+/, ' ').strip
+
           binds = []
-          nv128 = SQLServer::Type::UnicodeVarchar.new limit: 128
-          binds << Relation::QueryAttribute.new('TABLE_NAME', identifier.object, nv128)
-          binds << Relation::QueryAttribute.new('TABLE_SCHEMA', identifier.schema, nv128) unless identifier.schema.blank?
+          if prepared_statements
+            nv128 = SQLServer::Type::UnicodeVarchar.new limit: 128
+            binds << Relation::QueryAttribute.new('TABLE_NAME', identifier.object, nv128)
+            binds << Relation::QueryAttribute.new('TABLE_SCHEMA', identifier.schema, nv128) unless identifier.schema.blank?
+          end
+
           results = sp_executesql(sql, 'SCHEMA', binds)
           results.map do |ci|
             ci = ci.symbolize_keys

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -194,7 +194,7 @@ module ActiveRecord
 
       def tables_with_referential_integrity
         schemas_and_tables = select_rows <<-SQL.strip_heredoc
-          SELECT s.name, o.name
+          SELECT s.name AS schema_name, o.name AS table_name
           FROM sys.foreign_keys i
           INNER JOIN sys.objects o ON i.parent_object_id = o.OBJECT_ID
           INNER JOIN sys.schemas s ON o.schema_id = s.schema_id


### PR DESCRIPTION
This is a change that is needed for the jdbc driver to work with this code so that the result has 2 columns in it. I have been working on the activerecord-jdbcmssql-adapter gem so that the jruby/jdbc specific differences can be maintained by that gem. I will cross link trackers as they are created. This will be needed in all the stable branches unless its already been fixed in future ones. I'm just starting with Rails 5.0 support so that's why I pointed the change at the 5-0-stable branch.