### PR TITLE
 Fix constants missing in 6.0.0.rc1 

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -31,7 +31,7 @@ module Arel
 
       def visit_Arel_Nodes_Lock o, collector
         o.expr = Arel.sql('WITH(UPDLOCK)') if o.expr.to_s =~ /FOR UPDATE/
-        collector << SPACE
+        collector << " "
         visit o.expr, collector
       end
 
@@ -57,7 +57,7 @@ module Arel
         distinct_One_As_One_Is_So_Not_Fetch o
         if o.with
           collector = visit o.with, collector
-          collector << SPACE
+          collector << " "
         end
         collector = o.cores.inject(collector) { |c,x|
           visit_Arel_Nodes_SelectCore(x, c)
@@ -95,7 +95,7 @@ module Arel
           collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector
         end
         if o.right.any?
-          collector << SPACE if o.left
+          collector << " " if o.left
           collector = inject_join o.right, collector, ' '
         end
         collector
@@ -106,7 +106,7 @@ module Arel
         collector = visit o.left, collector
         collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector, space: true
         if o.right
-          collector << SPACE
+          collector << " "
           visit(o.right, collector)
         else
           collector
@@ -117,7 +117,7 @@ module Arel
         collector << "LEFT OUTER JOIN "
         collector = visit o.left, collector
         collector = visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector, space: true
-        collector << SPACE
+        collector << " "
         visit o.right, collector
       end
 
@@ -126,7 +126,7 @@ module Arel
       def visit_Arel_Nodes_SelectStatement_SQLServer_Lock collector, options = {}
         if select_statement_lock?
           collector = visit @select_statement.lock, collector
-          collector << SPACE if options[:space]
+          collector << " " if options[:space]
         end
         collector
       end
@@ -134,12 +134,12 @@ module Arel
       def visit_Orders_And_Let_Fetch_Happen o, collector
         make_Fetch_Possible_And_Deterministic o
         unless o.orders.empty?
-          collector << SPACE
-          collector << ORDER_BY
+          collector << " "
+          collector << " ORDER BY "
           len = o.orders.length - 1
           o.orders.each_with_index { |x, i|
             collector = visit(x, collector)
-            collector << COMMA unless len == i
+            collector << ", " unless len == i
           }
         end
         collector


### PR DESCRIPTION
These constants have been removed in 6.0.0.rc1 since it's a micro-optimisation that Ruby no longer needs. I have replaced them with string literals.