### PR TITLE
SET SINGLE_USER before dropping the database

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
@@ -12,6 +12,7 @@ module ActiveRecord
 
         def drop_database(database)
           name = SQLServer::Utils.extract_identifiers(database)
+          do_execute "ALTER DATABASE #{name} SET SINGLE_USER WITH ROLLBACK IMMEDIATE"
           do_execute "DROP DATABASE #{name}"
         end
 


### PR DESCRIPTION
SQLServer sometimes (actually very often in my experience) fails to drop database with
`Cannot drop database [DATABASE_NAME] because it is currently in use.` error in some environments.

https://stackoverflow.com/questions/12702524/unable-to-drop-and-create-database-in-sql-server/12702579#12702579
https://dba.stackexchange.com/questions/2387/sql-server-cannot-drop-database-dbname-because-it-is-currently-in-use-but-n/2391#2391
https://www.mytechmantra.com/LearnSQLServer/Drop-Database-in-SQL-Server-by-Killing-Existing-Connections.html
https://serverfault.com/questions/440034/how-to-force-a-drop-of-mssql-server-database

This patch addresses this FAQ pitfall by changing the target DB to be SINGLE_USER mode before dropping, to make sure no other connections are alive.