### PR TITLE
Fix concatenate syntax

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -22,6 +22,12 @@ module Arel
         collector << " #{ActiveRecord::ConnectionAdapters::SQLServerAdapter.cs_equality_operator} "
       end
 
+      def visit_Arel_Nodes_Concat(o, collector)
+        visit o.left, collector
+        collector << " + "
+        visit o.right, collector
+      end
+
       def visit_Arel_Nodes_UpdateStatement(o, a)
         if o.orders.any? && o.limit.nil?
           o.limit = Nodes::Limit.new(9_223_372_036_854_775_807)


### PR DESCRIPTION
This fixes concat to generate `a + b`, previously it generated the standard SQL `a || b` which SQL Server does not support.