### PR TITLE
rails 6.0 dependency

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.add_dependency 'activerecord', '~> 6.0.0.beta3'
+  spec.add_dependency 'activerecord', '~> 6.0.0'
   spec.add_dependency 'tiny_tds'
 end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -223,7 +223,7 @@ module ActiveRecord
 
         protected
 
-        def sql_for_insert(sql, pk, sequence_name, binds)
+        def sql_for_insert(sql, pk, binds)
           if pk.nil?
             table_name = query_requires_identity_insert?(sql)
             pk = primary_key(table_name)

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -2,9 +2,15 @@ module ActiveRecord
   module ConnectionAdapters
     class SQLServerColumn < Column
 
-      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, sqlserver_options = {})
-        @sqlserver_options = sqlserver_options || {}
-        super(name, default, sql_type_metadata, null, table_name, default_function, collation, comment: comment)
+      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, **)
+        @sqlserver_options = {}
+        @name = name.freeze
+        @sql_type_metadata = sql_type_metadata
+        @null = null
+        @default = default
+        @default_function = default_function
+        @collation = collation
+        @comment = comment
       end
 
       def is_identity?


### PR DESCRIPTION
Included #710 changes from @serkaniyigun 
Since rails 6.0 has been released, I changed the gem depency from rails ~>6.0 beta3 to ~> 6.0

Tests are failing: 
`TinyTds::Error: Cannot insert explicit value for identity column in table [tasks] when IDENTITY_INSERT is set to OFF`

This could be as simple as setting IDENTITY_INSERT to ON/OFF. Doesn't help with activerecord tests that fail. 
`before do`
`    connection.execute("SET IDENTITY_INSERT on [table] ON;")`
`   ...`
`after do `
`  connection.execute("SET IDENTITY_INSERT [table] OFF;") `
`  .... `