### PR TITLE
Translate the connection timed out error

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -154,7 +154,7 @@ module ActiveRecord
       def supports_lazy_transactions?
         true
       end
-      
+
       def supports_in_memory_oltp?
         @version_year >= 2014
       end
@@ -367,6 +367,8 @@ module ActiveRecord
           NoDatabaseError.new(message, sql: sql, binds: binds)
         when /data would be truncated/
           ValueTooLong.new(message, sql: sql, binds: binds)
+        when /connection timed out/
+          StatementTimeout.new(message, sql: sql, binds: binds)
         when /Column '(.*)' is not the same data type as referencing column '(.*)' in foreign key/
           pk_id, fk_id = SQLServer::Utils.extract_identifiers($1), SQLServer::Utils.extract_identifiers($2)
           MismatchedForeignKey.new(


### PR DESCRIPTION
Hi there,  
We have connection issues in our production environment.  
It is supposed to be an easy fix but we cannot safely rescue the exception because it is billed as an `ActiveRecord::StatementInvalid` exception.

I add my exception translation where it is supposed to be. It is not feasible to emulate the same issue in tests so I simply don't add any test.

Hopes you guys could release a quick fix version soon.