### PR TITLE
Avoid exception when db-connection is lost

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -281,7 +281,8 @@ module ActiveRecord
         def raw_connection_do(sql)
           case @connection_options[:mode]
           when :dblib
-            @connection.execute(sql).do
+            result = @connection.execute(sql)
+            result == false ? false : result.do
           end
         ensure
           @update_sql = false

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -152,8 +152,7 @@ module ActiveRecord
 
       def active?
         return false unless @connection
-        raw_connection_do 'SELECT 1'
-        true
+        raw_connection_do('SELECT 1') == 1
       rescue *connection_errors
         false
       end


### PR DESCRIPTION
The tiny_tds lib might return false on execute when the call fails.
This caused exceptions when active? is called after the connection
was lost.

fixes #707