### PR TITLE
Fix prepared statement caching for MSSQL

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -264,7 +264,6 @@ module ActiveRecord
           options[:ar_result] = true if options[:fetch] != :rows
 
           unless without_prepared_statement?(binds)
-            types, params = sp_executesql_types_and_parameters(binds)
             unless options[:prepare]
               types, params = sp_executesql_types_and_parameters(binds)
             else
@@ -290,8 +289,8 @@ module ActiveRecord
           binds.each_with_index do |attr, index|
             attr = attr.value if attr.is_a?(Arel::Nodes::BindParam)
 
-            types << "@#{index} #{sp_executesql_sql_type(attr)}"
-            params << sp_executesql_sql_param(attr) unless skip_types
+            types << "@#{index} #{sp_executesql_sql_type(attr)}" unless skip_types
+            params << sp_executesql_sql_param(attr)
           end
           [types, params]
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'active_record'
 require 'arel_sqlserver'
 require 'active_record/connection_adapters/abstract_adapter'
+require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/sqlserver/core_ext/active_record'
 require 'active_record/connection_adapters/sqlserver/core_ext/calculations'
 require 'active_record/connection_adapters/sqlserver/core_ext/explain'
@@ -52,10 +53,19 @@ module ActiveRecord
       self.use_output_inserted = true
       self.exclude_output_inserted_table_names = Concurrent::Map.new { false }
 
+      class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
+        private
+
+        def dealloc(stmt)
+          # noop
+        end
+      end
+
       def initialize(connection, logger = nil, config = {})
         super(connection, logger, config)
         # Our Responsibility
         @connection_options = config
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         connect
         initialize_dateformatter
         use_database
@@ -180,6 +190,7 @@ module ActiveRecord
 
       def clear_cache!
         @view_information = nil
+        @statements.clear
         super
       end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -147,6 +147,20 @@ module ActiveRecord
   class BindParameterTest < ActiveRecord::TestCase
     # Never finds `sql` since we use `EXEC sp_executesql` wrappers.
     coerce_tests! :test_binds_are_logged
+
+    # Same as original coerced test except log is found using `EXEC sp_executesql` wrapper.
+    def test_binds_are_logged_coerced
+      sub   = Arel::Nodes::BindParam.new(1)
+      binds = [Relation::QueryAttribute.new("id", 1, Type::Value.new)]
+      sql   = "select * from topics where id = #{sub.to_sql}"
+
+      @connection.exec_query(sql, "SQL", binds)
+
+      logged_sql = "EXEC sp_executesql N'#{sql}', N'#{sub.to_sql} int', #{sub.to_sql} = 1"
+      message = @subscriber.calls.find { |args| args[4][:sql] == logged_sql }
+
+      assert_equal binds, message[4][:binds]
+    end
   end
 end
 


### PR DESCRIPTION
Fix the failing tests that were introduced by https://github.com/rails/rails/pull/35399

### Binding Parameter Tests

`bundle exec rake test TEST_FILES_AR="test/cases/bind_parameter_test.rb"`

### Before

The failing tests had error:
```
NoMethodError: undefined method `cache' for nil:NilClass
```

```
Finished in 3.639557s, 3.5719 runs/s, 4.6709 assertions/s.
13 runs, 17 assertions, 0 failures, 5 errors, 0 skips
```
### After

```
Finished in 3.277385s, 3.9666 runs/s, 8.8485 assertions/s.
13 runs, 29 assertions, 0 failures, 0 errors, 0 skips
``` 