### PR TITLE
Calculate should not remove ordering for MSSQL

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -6,6 +6,25 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module Calculations
+
+          # Same as original except we don't perform PostgreSQL hack that removes ordering.
+          def calculate(operation, column_name)
+            if has_include?(column_name)
+              relation = apply_join_dependency
+
+              if operation.to_s.downcase == "count"
+                unless distinct_value || distinct_select?(column_name || select_for_count)
+                  relation.distinct!
+                  relation.select_values = [ klass.primary_key || table[Arel.star] ]
+                end
+              end
+
+              relation.calculate(operation, column_name)
+            else
+              perform_calculation(operation, column_name)
+            end
+          end
+
           private
 
           def build_count_subquery(relation, column_name, distinct)


### PR DESCRIPTION
Fixes the following failing calculation tests:
- CalculationsTest#test_group_by_with_offset
- CalculationsTest#test_group_by_with_limit_and_offset
- CalculationsTest#test_group_by_with_limit

The tests were failing because of a change made in Rails 5.2.3 (https://github.com/rails/rails/pull/35850/files#diff-e0e70620d0897d6819a6bcc2b5ee7a73R137) that removed ordering in calculations. The change works for PostgreSQL/SQLite/MySQL but causes invalid SQL to be generated for MSSQL.

### Example: CalculationsTest#test_group_by_with_offset

**Rails** 5.2.3

SQL generated for this test was:

```
EXEC sp_executesql N'SELECT COUNT(DISTINCT comments.id) AS count_comments_id, [posts].[type] AS posts_type FROM [posts] LEFT OUTER JOIN [comments] ON [comments].[post_id] = [posts].[id] GROUP BY [posts].[type]  ORDER BY [posts].[type] ASC OFFSET @0 ROWS', N'@0 int', @0 = 1
```

**Rails** 5.2.4 & 5.2.4.1

Invalid SQL generated was:

```
EXEC sp_executesql N'SELECT COUNT(DISTINCT comments.id) AS count_comments_id, [posts].[type] AS posts_type FROM [posts] LEFT OUTER JOIN [comments] ON [comments].[post_id] = [posts].[id] GROUP BY [posts].[type]  ORDER BY [posts].[id] ASC OFFSET @0 ROWS', N'@0 int', @0 = 1
```

This results in error:
```ActiveRecord::StatementInvalid: TinyTds::Error: Column "posts.id" is invalid in the ORDER BY clause because it is not contained in either an aggregate function or the GROUP BY clause."```