### PR TITLE
Added prepared statement caching

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -262,19 +262,34 @@ module ActiveRecord
 
         def sp_executesql(sql, name, binds, options = {})
           options[:ar_result] = true if options[:fetch] != :rows
+
           unless without_prepared_statement?(binds)
-            types, params = sp_executesql_types_and_parameters(binds)
+            unless options[:prepare]
+              types, params = sp_executesql_types_and_parameters(binds)
+            else
+              cache = @statements[sql]
+
+              if cache
+                types  = cache[:types]
+                _, params = sp_executesql_types_and_parameters(binds, true)
+              else
+                types, params = sp_executesql_types_and_parameters(binds)
+                @statements[sql] = { types: types }
+              end
+            end
+
             sql = sp_executesql_sql(sql, types, params, name)
           end
+
           raw_select sql, name, binds, options
         end
 
-        def sp_executesql_types_and_parameters(binds)
+        def sp_executesql_types_and_parameters(binds, skip_types = false)
           types, params = [], []
           binds.each_with_index do |attr, index|
             attr = attr.value if attr.is_a?(Arel::Nodes::BindParam)
 
-            types << "@#{index} #{sp_executesql_sql_type(attr)}"
+            types << "@#{index} #{sp_executesql_sql_type(attr)}" unless skip_types
             params << sp_executesql_sql_param(attr)
           end
           [types, params]

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'active_record'
 require 'arel_sqlserver'
 require 'active_record/connection_adapters/abstract_adapter'
+require 'active_record/connection_adapters/statement_pool'
 require 'active_record/connection_adapters/sqlserver/core_ext/active_record'
 require 'active_record/connection_adapters/sqlserver/core_ext/calculations'
 require 'active_record/connection_adapters/sqlserver/core_ext/explain'
@@ -52,10 +53,19 @@ module ActiveRecord
       self.use_output_inserted = true
       self.exclude_output_inserted_table_names = Concurrent::Map.new { false }
 
+      class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
+        private
+
+        def dealloc(stmt)
+          # noop
+        end
+      end
+
       def initialize(connection, logger = nil, config = {})
         super(connection, logger, config)
         # Our Responsibility
         @connection_options = config
+        @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
         connect
         initialize_dateformatter
         use_database
@@ -180,6 +190,7 @@ module ActiveRecord
 
       def clear_cache!
         @view_information = nil
+        @statements.clear
         super
       end
 


### PR DESCRIPTION
Fix the failing tests that were introduced by https://github.com/rails/rails/pull/35399

### Binding Parameter Tests

`bundle exec rake test TEST_FILES_AR="test/cases/bind_parameter_test.rb"`

### Before

The failing tests had error:
```
NoMethodError: undefined method `cache' for nil:NilClass
```

```
Finished in 3.639557s, 3.5719 runs/s, 4.6709 assertions/s.
13 runs, 17 assertions, 0 failures, 5 errors, 0 skips
```
### After

```
Finished in 3.277385s, 3.9666 runs/s, 8.8485 assertions/s.
13 runs, 29 assertions, 0 failures, 0 errors, 0 skips
``` 