### PR TITLE
Use default precision for 'time' column type

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -4,6 +4,9 @@ module ActiveRecord
       module Type
         class Time < ActiveRecord::Type::Time
 
+          # Default fractional scale for 'time' (See https://docs.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql)
+          DEFAULT_FRACTIONAL_SCALE = 7
+
           include TimeValueFractional2
 
           def serialize(value)
@@ -42,7 +45,7 @@ module ActiveRecord
           end
 
           def fractional_scale
-            precision
+            precision || DEFAULT_FRACTIONAL_SCALE
           end
 
         end

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -349,7 +349,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it 'datetime2' do
-      skip 'datetime2 not supported in this protocal version' unless connection_dblib_73?
+      skip 'datetime2 not supported in this protocol version' unless connection_dblib_73?
       col = column('datetime2_7')
       _(col.sql_type).must_equal           'datetime2(7)'
       _(col.type).must_equal               :datetime
@@ -414,7 +414,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it 'datetimeoffset' do
-      skip 'datetimeoffset not supported in this protocal version' unless connection_dblib_73?
+      skip 'datetimeoffset not supported in this protocol version' unless connection_dblib_73?
       col = column('datetimeoffset_7')
       _(col.sql_type).must_equal           'datetimeoffset(7)'
       _(col.type).must_equal               :datetimeoffset
@@ -480,7 +480,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it 'time(7)' do
-      skip 'time() not supported in this protocal version' unless connection_dblib_73?
+      skip 'time() not supported in this protocol version' unless connection_dblib_73?
       col = column('time_7')
       _(col.sql_type).must_equal           'time(7)'
       _(col.type).must_equal               :time
@@ -512,7 +512,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it 'time(2)' do
-      skip 'time() not supported in this protocal version' unless connection_dblib_73?
+      skip 'time() not supported in this protocol version' unless connection_dblib_73?
       col = column('time_2')
       _(col.sql_type).must_equal           'time(2)'
       _(col.type).must_equal               :time
@@ -539,6 +539,38 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
       obj.save! ; obj.reload
       _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
+    end
+
+    it 'time using default precision' do
+      skip 'time() not supported in this protocol version' unless connection_dblib_73?
+      col = column('time_default')
+      _(col.sql_type).must_equal           'time(7)'
+      _(col.type).must_equal               :time
+      _(col.null).must_equal               true
+      _(col.default).must_equal            Time.utc(1900, 01, 01, 15, 03, 42, Rational(62197800, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <62197800>"
+      _(col.default_function).must_be_nil
+      type = connection.lookup_cast_type_from_column(col)
+      _(type).must_be_instance_of          Type::Time
+      _(type.limit).must_be_nil
+      _(type.precision).must_equal         7
+      _(type.scale).must_be_nil
+      # Time's #usec precision (low micro)
+      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 300)
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
+      obj.save! ; obj.reload
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
+      # Time's #usec precision (high micro)
+      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 234567)
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      obj.save! ; obj.reload
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      # Time's #usec precision (high nano rounded)
+      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321545, 1000))
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
+      obj.save! ; obj.reload
+      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
     end
 
     # Character Strings

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -34,6 +34,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     if connection_dblib_73?
     assert_line :time_7,            type: 'time',         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
     assert_line :time_2,            type: 'time',         limit: nil,           precision: 2,     scale: nil,  default: nil
+    assert_line :time_default,      type: 'time',         limit: nil,           precision: 7,     scale: nil,  default: "15:03:42.0621978"
     end
     # Character Strings
     assert_line :char_10,           type: 'char',         limit: 10,            precision: nil,   scale: nil,  default: "1234567890",           collation: nil

--- a/test/schema/datatypes/2012.sql
+++ b/test/schema/datatypes/2012.sql
@@ -35,6 +35,7 @@ CREATE TABLE [sst_datatypes] (
   [smalldatetime] [smalldatetime] NULL DEFAULT '1901-01-01T15:45:00.000Z',
   [time_7] [time](7) NULL DEFAULT '04:20:00.2883215',
   [time_2] [time](2) NULL,
+  [time_default] [time] NULL DEFAULT '15:03:42.0621978',
   -- Character Strings
   [char_10] [char](10) NULL DEFAULT '1234567890',
   [varchar_50] [varchar](50) NULL DEFAULT 'test varchar_50',


### PR DESCRIPTION
Fixes the failing ActiveRecord "SchemaDumperDefaultsTest#test_schema_dump_with_float_column_infinity_default" test, which was throwing an error during the setup stage.

See failing test at https://travis-ci.org/rails-sqlserver/activerecord-sqlserver-adapter/jobs/655397653?utm_medium=notification&utm_source=github_status

The test was failing because the precision was being extracted from the column type. The precision for `time(2)` is correctly returned as 2. The precision for `time` was incorrectly being returned as `nil`. The actual default precision for `time` in MSSQL is 7 (https://docs.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql?view=sql-server-ver15). So updated the adapter to return default precision if column type is `time`.

The "SchemaDumperDefaultsTest#test_schema_dump_with_float_column_infinity_default" test is actually skipped for non-PostgreSQL databases (https://github.com/rails/rails/blob/v5.2.4.1/activerecord/test/cases/schema_dumper_test.rb#L518).