### PR TITLE
 Added 2017 to supported list for Rails 4.0

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       VERSION                     = File.read(File.expand_path('../../../../VERSION', __FILE__)).strip
       ADAPTER_NAME                = 'SQLServer'.freeze
       DATABASE_VERSION_REGEXP     = /Microsoft SQL Server\s+"?(\d{4}|\w+)"?/
-      SUPPORTED_VERSIONS          = [2005, 2008, 2010, 2011, 2012, 2014, 2016]
+      SUPPORTED_VERSIONS          = [2005, 2008, 2010, 2011, 2012, 2014, 2016, 2017]
 
       attr_reader :database_version, :database_year, :spid, :product_level, :product_version, :edition
 


### PR DESCRIPTION
Similar to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/601

Adding in SQL Server 2017 support for the Rails 4.0 branch