### PR TITLE
Set default time precision when registering time type

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -4,9 +4,6 @@ module ActiveRecord
       module Type
         class Time < ActiveRecord::Type::Time
 
-          # Default fractional scale for 'time' (See https://docs.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql)
-          DEFAULT_FRACTIONAL_SCALE = 7
-
           include TimeValueFractional2
 
           def serialize(value)
@@ -45,7 +42,7 @@ module ActiveRecord
           end
 
           def fractional_scale
-            precision || DEFAULT_FRACTIONAL_SCALE
+            precision
           end
 
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -41,6 +41,9 @@ module ActiveRecord
 
       ADAPTER_NAME = 'SQLServer'.freeze
 
+      # Default precision for 'time' (See https://docs.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql)
+      DEFAULT_TIME_PRECISION = 7
+
       attr_reader :spid
 
       cattr_accessor :cs_equality_operator, instance_accessor: false
@@ -297,8 +300,7 @@ module ActiveRecord
         end
         m.register_type              'smalldatetime',     SQLServer::Type::SmallDateTime.new
         m.register_type              %r{\Atime}i do |sql_type|
-          scale = extract_scale(sql_type)
-          precision = extract_precision(sql_type)
+          precision = extract_precision(sql_type) || DEFAULT_TIME_PRECISION
           SQLServer::Type::Time.new precision: precision
         end
         # Character Strings


### PR DESCRIPTION
Should set the default precision of the time type when registering it rather than defaulting it within the `ActiveRecord::ConnectionAdapters::SQLServer::Type::Time` class.

This is a refactoring of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/737