### PR TITLE
Adapter does not use prepared statement cache

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -145,8 +145,27 @@ end
 
 module ActiveRecord
   class BindParameterTest < ActiveRecord::TestCase
-    # Never finds `sql` since we use `EXEC sp_executesql` wrappers.
+    # Same as original coerced test except log is found using `EXEC sp_executesql` wrapper.
     coerce_tests! :test_binds_are_logged
+    def test_binds_are_logged_coerced
+      sub   = Arel::Nodes::BindParam.new(1)
+      binds = [Relation::QueryAttribute.new("id", 1, Type::Value.new)]
+      sql   = "select * from topics where id = #{sub.to_sql}"
+
+      @connection.exec_query(sql, "SQL", binds)
+
+      logged_sql = "EXEC sp_executesql N'#{sql}', N'#{sub.to_sql} int', #{sub.to_sql} = 1"
+      message = @subscriber.calls.find { |args| args[4][:sql] == logged_sql }
+
+      assert_equal binds, message[4][:binds]
+    end
+
+    # SQL Server adapter does not use a statement cache as query plans are already reused using `EXEC sp_executesql`.
+    coerce_tests! :test_statement_cache
+    coerce_tests! :test_statement_cache_with_query_cache
+    coerce_tests! :test_statement_cache_with_find_by
+    coerce_tests! :test_statement_cache_with_in_clause
+    coerce_tests! :test_statement_cache_with_sql_string_literal
   end
 end
 


### PR DESCRIPTION
On PostgreSQL/MySQL/SQLite to reuse a query plan you need to first prepare the query as a prepared statement, cache the prepared statement in a statement pool and then call that prepared statement with your bindings. If same query is called again on that connection then the prepared statement can be retrieved from the statement pool and reused.

SQL Server using `EXEC sp_executesq` works differently. Query plans are reused based on the SQL that is passed. So there is no need to prepare the query into a prepared statement first. This removes the need for the statement cache in the SQL Server adapter. So the binding tests that assume a statement pool can be coerced.

The PR also includes a substitute test for a previously coerced test.