### PR TITLE
Rails 6: Fix for translate_exception method signature

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/query_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/query_methods.rb
@@ -9,7 +9,8 @@ module ActiveRecord
 
           private
 
-          # Copy of original from Rails master. This patch can be removed when adapter supports Rails 6.
+          # Copy of original from Rails master.
+          # This patch can be removed when adapter supports Rails version greater than 6.0.2.2
           def table_name_matches?(from)
             table_name = Regexp.escape(table.name)
             quoted_table_name = Regexp.escape(connection.quote_table_name(table.name))

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -325,7 +325,7 @@ module ActiveRecord
         m.register_type              'timestamp',         SQLServer::Type::Timestamp.new
       end
 
-      def translate_exception(e, message)
+      def translate_exception(e, message:, sql:, binds:)
         case message
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message)


### PR DESCRIPTION
Fixes the `translate_exception` method signature to match https://github.com/rails/rails/pull/34468

Solution taken from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/731/commits/8d2b737d36c34435fdf5b47c5cf8a33b8f83c1cd#diff-04856c2487c5333749a6ebcd6637213cR324

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/667214433?utm_medium=notification&utm_source=github_status
```
6728 runs, 18598 assertions, 72 failures, 48 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/667328226?utm_medium=notification&utm_source=github_status
```
6728 runs, 18643 assertions, 53 failures, 44 errors, 25 skips
```