### PR TITLE
Rails 6: Correctly retrieve Arel::Table in join queries

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -202,7 +202,7 @@ module Arel
         elsif Arel::Nodes::SqlLiteral === core.from
           Arel::Table.new(core.from)
         elsif Arel::Nodes::JoinSource === core.source
-          Arel::Nodes::SqlLiteral === core.source.left ? Arel::Table.new(core.source.left, @engine) : core.source.left
+          Arel::Nodes::SqlLiteral === core.source.left ? Arel::Table.new(core.source.left, @engine) : core.source.left.left
         end
       end
 


### PR DESCRIPTION
Fix to correctly retrieve the Arel::Table when using a join query. 

Solution taken from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/704

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/668693683?utm_medium=notification&utm_source=github_status
```
6728 runs, 18637 assertions, 53 failures, 43 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/668832573?utm_medium=notification&utm_source=github_status
```
6728 runs, 18642 assertions, 53 failures, 39 errors, 25 skips
```