### PR TITLE
Rails 6: Sanitize forbidden attributes for exists relation

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
@@ -11,13 +11,13 @@ module ActiveRecord
 
           # Same as original except we order by values in distinct select if present.
           def construct_relation_for_exists(conditions)
-            if distinct_value && offset_value
-              relation = limit!(1)
+            conditions = sanitize_forbidden_attributes(conditions)
 
+            if distinct_value && offset_value
               if select_values.present?
-                relation = relation.order(*select_values)
+                relation = order(*select_values).limit!(1)
               else
-                relation = relation.except(:order)
+                relation = except(:order).limit!(1)
               end
             else
               relation = except(:select, :distinct, :order)._select!(::ActiveRecord::FinderMethods::ONE_AS_ONE).limit!(1)


### PR DESCRIPTION
Updated our monkey-patched `construct_relation_for_exists` method with change to sanitize forbidden attributes. Original Rails change in https://github.com/rails/rails/pull/35193

This fixes ActiveRecord test `FinderTest#test_exists_with_strong_parameters`.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/669152512?utm_medium=notification&utm_source=github_status
```
6728 runs, 18645 assertions, 53 failures, 39 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/669281834?utm_medium=notification&utm_source=github_status
```
6728 runs, 18646 assertions, 53 failures, 38 errors, 25 skips
```
