### PR TITLE
Rails 6: Cache database version in schema cache

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -256,6 +256,9 @@ module ActiveRecord
         result
       end
 
+      def get_database_version # :nodoc:
+        version_year
+      end
 
       protected
 


### PR DESCRIPTION
Added method `ActiveRecord::ConnectionAdapters::SQLServerAdapter#get_database_version` to support https://github.com/rails/rails/pull/35795

This fixes the `ActiveRecord::ConnectionAdapters::SchemaCacheTest` failing tests.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/669298290?utm_medium=notification&utm_source=github_status
```
6728 runs, 18648 assertions, 53 failures, 38 errors, 25 skips
```

**After**
```
6728 runs, 18636 assertions, 53 failures, 36 errors, 25 skips
```