### PR TITLE
Use https protocol for Github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 require 'openssl'
 source 'https://rubygems.org'
+
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 gemspec
 
 gem 'sqlite3'
@@ -33,7 +38,7 @@ else
       ver
     end
   end
-  gem 'rails', git: "git://github.com/rails/rails.git", tag: "v#{version}"
+  gem 'rails', github: "rails/rails", tag: "v#{version}"
 end
 
 if ENV['AREL']


### PR DESCRIPTION
Use the `https` protocol to connect to Github rather than `git`. This will remove the following warning message.

```
$  bundle install
The git source `git://github.com/rails/rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Fetching git://github.com/rails/rails.git
...
```

I copied the code from the Rails Gemfile https://github.com/rails/rails/blob/master/Gemfile