### PR TITLE
Rails 6: Subqueries cannot include ordering unless TOP/LIMIT also specified

### DIFF
--- a/test/cases/in_clause_test_sqlserver.rb
+++ b/test/cases/in_clause_test_sqlserver.rb
@@ -1,0 +1,34 @@
+require 'cases/helper_sqlserver'
+require 'models/post'
+require 'models/author'
+
+class InClauseTestSQLServer < ActiveRecord::TestCase
+  fixtures :posts, :authors
+
+  it 'removes ordering from subqueries' do
+    authors_subquery = Author.where(name: ['David', 'Mary', 'Bob']).order(:name)
+    posts = Post.where(author: authors_subquery)
+
+    assert_includes authors_subquery.to_sql, "ORDER BY [authors].[name]"
+    assert_not_includes posts.to_sql, "ORDER BY [authors].[name]"
+    assert_equal 10, posts.length
+  end
+
+  it 'does not remove ordering from subquery that includes a limit' do
+    authors_subquery = Author.where(name: ['David', 'Mary', 'Bob']).order(:name).limit(2)
+    posts = Post.where(author: authors_subquery)
+
+    assert_includes authors_subquery.to_sql, "ORDER BY [authors].[name]"
+    assert_includes posts.to_sql, "ORDER BY [authors].[name]"
+    assert_equal 7, posts.length
+  end
+
+  it 'does not remove ordering from subquery that includes an offset' do
+    authors_subquery = Author.where(name: ['David', 'Mary', 'Bob']).order(:name).offset(1)
+    posts = Post.where(author: authors_subquery)
+
+    assert_includes authors_subquery.to_sql, "ORDER BY [authors].[name]"
+    assert_includes posts.to_sql, "ORDER BY [authors].[name]"
+    assert_equal 8, posts.length
+  end
+end


### PR DESCRIPTION
In MSSQL subqueries cannot have ordering unless they include `TOP` or `OFFSET`, otherwise a `The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.` error is returned.

_Note that ordering in subqueries is valid if it includes `FOR XML` but this use-case is not supported in the adapter._

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/670183329?utm_medium=notification&utm_source=github_status
```
6728 runs, 18634 assertions, 53 failures, 34 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/671990453?utm_medium=notification&utm_source=github_status
```
6731 runs, 18699 assertions, 53 failures, 20 errors, 25 skips
```