### PR TITLE
Rails 6: Store table names on columns to generate identities

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -66,14 +66,13 @@ module ActiveRecord
         def columns(table_name)
           return [] if table_name.blank?
           column_definitions(table_name).map do |ci|
-            sqlserver_options = ci.slice :ordinal_position, :is_primary, :is_identity
+            sqlserver_options = ci.slice :ordinal_position, :is_primary, :is_identity, :table_name
             sql_type_metadata = fetch_type_metadata ci[:type], sqlserver_options
             new_column(
               ci[:name],
               ci[:default_value],
               sql_type_metadata,
               ci[:null],
-              ci[:table_name],
               ci[:default_function],
               ci[:collation],
               nil,
@@ -82,16 +81,16 @@ module ActiveRecord
           end
         end
 
-        def new_column(name, default, sql_type_metadata, null, table_name, default_function = nil, collation = nil, comment = nil, sqlserver_options = {})
+        def new_column(name, default, sql_type_metadata, null, default_function = nil, collation = nil, comment = nil, sqlserver_options = {})
           SQLServerColumn.new(
             name,
             default,
             sql_type_metadata,
-            null, table_name,
+            null,
             default_function,
-            collation,
-            comment,
-            sqlserver_options
+            collation: collation,
+            comment: comment,
+            **sqlserver_options
           )
         end
 

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -2,9 +2,9 @@ module ActiveRecord
   module ConnectionAdapters
     class SQLServerColumn < Column
 
-      def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, default_function = nil, collation = nil, comment = nil, sqlserver_options = {})
-        @sqlserver_options = sqlserver_options || {}
-        super(name, default, sql_type_metadata, null, default_function, collation: collation, comment: comment)
+      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, **sqlserver_options)
+        @sqlserver_options = sqlserver_options
+        super
       end
 
       def is_identity?
@@ -13,6 +13,10 @@ module ActiveRecord
 
       def is_primary?
         @sqlserver_options[:is_primary]
+      end
+
+      def table_name
+        @sqlserver_options[:table_name]
       end
 
       def is_utf8?


### PR DESCRIPTION
Rails no longer stores table names on columns since https://github.com/rails/rails/pull/35890 However, for the MSSQL adapter we need to continue to store the table name so that identity values can be calculated. See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8b48e5ff5bdb3e95d38437d0433735d0cf6f6b98/lib/active_record/connection_adapters/sqlserver/database_statements.rb#L115

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672064166
```
6728 runs, 18676 assertions, 53 failures, 16 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672458067
```
6728 runs, 18680 assertions, 53 failures, 13 errors, 25 skips
```