### PR TITLE
Rails 6: Fixed migration test

### DIFF
--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -20,7 +20,7 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
     it 'not create a tables if error in migrations' do
       begin
         migrations_dir = File.join ARTest::SQLServer.migrations_root, 'transaction_table'
-        quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+        quietly { ActiveRecord::MigrationContext.new(migrations_dir, ActiveRecord::SchemaMigration).up }
       rescue Exception => e
         assert_match %r|this and all later migrations canceled|, e.message
       end


### PR DESCRIPTION
Fixes the failing test `FullyQualifiedIdentifierTestSQLServer::remote server#test_0005_should use fully qualified table name in insert statement`.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672479581
```
6728 runs, 18679 assertions, 53 failures, 14 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672538462
```
6728 runs, 18688 assertions, 52 failures, 13 errors, 25 skips
```