### PR TITLE
Rails 6: Updated unsafe raw sql tests to match tests in Rails 6

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -68,6 +68,42 @@ module ActiveRecord
           end
         end
 
+        def column_name_matcher
+          COLUMN_NAME
+        end
+
+        def column_name_with_order_matcher
+          COLUMN_NAME_WITH_ORDER
+        end
+
+        COLUMN_NAME = /
+          \A
+          (
+            (?:
+              # [table_name].[column_name] | function(one or no argument)
+              ((?:\w+\.|\[\w+\]\.)?(?:\w+|\[\w+\])) | \w+\((?:|\g<2>)\)
+            )
+            (?:\s+AS\s+(?:\w+|\[\w+\]))?
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        COLUMN_NAME_WITH_ORDER = /
+          \A
+          (
+            (?:
+              # [table_name].[column_name] | function(one or no argument)
+              ((?:\w+\.|\[\w+\]\.)?(?:\w+|\[\w+\])) | \w+\((?:|\g<2>)\)
+            )
+            (?:\s+ASC|\s+DESC)?
+            (?:\s+NULLS\s+(?:FIRST|LAST))?
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
 
         private
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1100,7 +1100,9 @@ module ActiveRecord
 end
 
 class UnsafeRawSqlTest < ActiveRecord::TestCase
-  coerce_tests! %r{always allows Arel}
+  # Coerce the originals as they use 'LENGTH' instead of SQL Servers 'LEN' function.
+
+  coerce_tests! %r{order: always allows Arel}
   test 'order: always allows Arel' do
     ids_depr     = with_unsafe_raw_sql_deprecated { Post.order(Arel.sql("len(title)")).pluck(:title) }
     ids_disabled = with_unsafe_raw_sql_disabled   { Post.order(Arel.sql("len(title)")).pluck(:title) }
@@ -1108,6 +1110,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal ids_depr, ids_disabled
   end
 
+  coerce_tests! %r{pluck: always allows Arel}
   test "pluck: always allows Arel" do
     values_depr     = with_unsafe_raw_sql_deprecated { Post.includes(:comments).pluck(:title, Arel.sql("len(title)")) }
     values_disabled = with_unsafe_raw_sql_disabled   { Post.includes(:comments).pluck(:title, Arel.sql("len(title)")) }
@@ -1115,71 +1118,17 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal values_depr, values_disabled
   end
 
-
-  coerce_tests! %r{order: disallows invalid Array arguments}
-  test "order: disallows invalid Array arguments" do
-    with_unsafe_raw_sql_disabled do
-      assert_raises(ActiveRecord::UnknownAttributeReference) do
-        Post.order(["author_id", "len(title)"]).pluck(:id)
-      end
-    end
-  end
-
   coerce_tests! %r{order: allows valid Array arguments}
   test "order: allows valid Array arguments" do
     ids_expected = Post.order(Arel.sql("author_id, len(title)")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order(["author_id", Arel.sql("len(title)")]).pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order(["author_id", Arel.sql("len(title)")]).pluck(:id) }
+    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order(["author_id", "len(title)"]).pluck(:id) }
+    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order(["author_id", "len(title)"]).pluck(:id) }
 
     assert_equal ids_expected, ids_depr
     assert_equal ids_expected, ids_disabled
   end
 
-  coerce_tests! %r{order: logs deprecation warning for unrecognized column}
-  test "order: logs deprecation warning for unrecognized column" do
-    with_unsafe_raw_sql_deprecated do
-      assert_deprecated(/Dangerous query method/) do
-        Post.order("len(title)")
-      end
-    end
-  end
-
-  coerce_tests! %r{pluck: disallows invalid column name}
-  test "pluck: disallows invalid column name" do
-     with_unsafe_raw_sql_disabled do
-       assert_raises(ActiveRecord::UnknownAttributeReference) do
-         Post.pluck("len(title)")
-       end
-     end
-   end
-
-   coerce_tests! %r{pluck: disallows invalid column name amongst valid names}
-   test "pluck: disallows invalid column name amongst valid names" do
-     with_unsafe_raw_sql_disabled do
-       assert_raises(ActiveRecord::UnknownAttributeReference) do
-         Post.pluck(:title, "len(title)")
-       end
-     end
-   end
-
-   coerce_tests! %r{pluck: disallows invalid column names with includes}
-   test "pluck: disallows invalid column names with includes" do
-     with_unsafe_raw_sql_disabled do
-       assert_raises(ActiveRecord::UnknownAttributeReference) do
-         Post.includes(:comments).pluck(:title, "len(title)")
-       end
-     end
-   end
-
-   coerce_tests! %r{pluck: logs deprecation warning}
-   test "pluck: logs deprecation warning" do
-     with_unsafe_raw_sql_deprecated do
-       assert_deprecated(/Dangerous query method/) do
-         Post.includes(:comments).pluck(:title, "len(title)")
-       end
-     end
-   end
 end
 
 


### PR DESCRIPTION
Updated the `UnsafeRawSqlTest` tests to match the tests in Rails 6. Tests were coerced as the originals were using `LENGTH` to get string length. MSSQL does not support `LENGTH` and you need to use `LEN` instead. Some of the original tests were changed to no longer use `LENGTH` and so they no longer have to be coerced. Many of the Rails tests were changed in https://github.com/rails/rails/pull/36448

Added MSSQL specific sanitization matchers to handle square brackets in table names (eg: [posts].[title]). This follows the same method that the other database adapters use (https://github.com/rails/rails/blob/8544c9c23687964ab754c06a7745215a5369a4e0/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb#L43).

These changes fix all of the failing `UnsafeRawSqlTest` tests.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672900188
```
6728 runs, 18675 assertions, 52 failures, 17 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/672915638
```
6728 runs, 18692 assertions, 46 failures, 11 errors, 25 skips
```