### PR TITLE
Refactor columns introspection query to make it faster

### DIFF
--- a/test/support/core_ext/query_cache.rb
+++ b/test/support/core_ext/query_cache.rb
@@ -5,6 +5,7 @@ module SqlIgnoredCache
 
   IGNORED_SQL = [
     /INFORMATION_SCHEMA\.(TABLES|VIEWS|COLUMNS|KEY_COLUMN_USAGE)/im,
+    /sys.columns/i,
     /SELECT @@version/,
     /SELECT @@TRANCOUNT/,
     /(BEGIN|COMMIT|ROLLBACK|SAVE) TRANSACTION/,

--- a/test/support/sql_counter_sqlserver.rb
+++ b/test/support/sql_counter_sqlserver.rb
@@ -14,6 +14,7 @@ module ARTest
 
     ignored_sql = [
       /INFORMATION_SCHEMA\.(TABLES|VIEWS|COLUMNS|KEY_COLUMN_USAGE)/im,
+      /sys.columns/i,
       /SELECT @@version/,
       /SELECT @@TRANCOUNT/,
       /(BEGIN|COMMIT|ROLLBACK|SAVE) TRANSACTION/,


### PR DESCRIPTION
# Problem

I work on a large Rails application with multiple databases and several tables each. We identified that one particular type of query was taking too much CPU and time to compile and sometimes it was giving us bad query plans. The query in question is the one the adapter uses to read table information to pass onto `ActiveRecord` underlying `Column` object.

After some refactoring we came up with a better query that reduced CPU by 75% and compilation time by 50% on average.

We used 2 main statistics to analyse the performance (apart from our monitoring tools, which give us a better overview that I can't share publicly, unfortunately). We've been running a monkey patched version of the adapter with this query with no problems and I thought it would be good to send it upstream.

# Results

Running the old query and the new one with both `time` and `io` statistics `on`, here are the results we got for one popular table with 158 columns we have:

```sql
SET STATISTICS time ON
SET STATISTICS io ON
```

**Before** 

```
SQL Server parse and compile time: 
   CPU time = 0 ms, elapsed time = 0 ms.
SQL Server parse and compile time: 
   CPU time = 0 ms, elapsed time = 0 ms.
(158 rows affected)
Table 'Worktable'. Scan count 0, logical reads 0, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysschobjs'. Scan count 475, logical reads 29452, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'syssingleobjrefs'. Scan count 185, logical reads 1002, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysiscols'. Scan count 158, logical reads 316, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'Worktable'. Scan count 0, logical reads 0, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysscalartypes'. Scan count 0, logical reads 316, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'syscolpars'. Scan count 159, logical reads 443, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysclsobjs'. Scan count 0, logical reads 2, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.

 SQL Server Execution Times:
   CPU time = 187 ms,  elapsed time = 182 ms.

 SQL Server Execution Times:
   CPU time = 187 ms,  elapsed time = 182 ms.
Total execution time: 00:00:00.378
```

**After**

```
SQL Server parse and compile time: 
   CPU time = 0 ms, elapsed time = 0 ms.
SQL Server parse and compile time: 
   CPU time = 0 ms, elapsed time = 0 ms.
(158 rows affected)
Table 'sysiscols'. Scan count 158, logical reads 316, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysschobjs'. Scan count 158, logical reads 27812, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'syssingleobjrefs'. Scan count 158, logical reads 316, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysobjvalues'. Scan count 158, logical reads 474, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysscalartypes'. Scan count 0, logical reads 316, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'syscolpars'. Scan count 1, logical reads 5, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.
Table 'sysclsobjs'. Scan count 0, logical reads 2, physical reads 0, read-ahead reads 0, lob logical reads 0, lob physical reads 0, lob read-ahead reads 0.

 SQL Server Execution Times:
   CPU time = 62 ms,  elapsed time = 61 ms.

 SQL Server Execution Times:
   CPU time = 62 ms,  elapsed time = 61 ms.
Total execution time: 00:00:00.098
```
