### PR TITLE
Rails 6: Allow primary key query in query cache test

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -153,7 +153,6 @@ module Arel
       def visit_Orders_And_Let_Fetch_Happen o, collector
         make_Fetch_Possible_And_Deterministic o
         unless o.orders.empty?
-          collector << " "
           collector << " ORDER BY "
           len = o.orders.length - 1
           o.orders.each_with_index { |x, i|


### PR DESCRIPTION
The MSSQL adapter is different from other adapters in that it adds an ORDER BY clause even to simple `find` queries to make them deterministic. 

SQL generated by `Task.find(1)`:
```
SELECT [tasks].* FROM [tasks] WHERE [tasks].[id] = @0  ORDER BY [tasks].[id] ASC OFFSET 0 ROWS FETCH NEXT @1 ROWS ONLY
```

The ordering requirement causes the Rails `QueryCacheTest#test_query_cached_even_when_types_are_reset` to fail. The test resets the column information (which includes the table's primary key) and then tests that no queries were performed to confirm that the result came from the query cache rather than the database. However, for the MSSQL adapter to generate the SQL that is used as the query cache key it needs to query the database to find the primary key to use in the ORDER BY clause.

This PR coerces the original `QueryCacheTest#test_query_cached_even_when_types_are_reset` test and now performs similar test that asserts only 1 query was performed and checks that that query was to retrieve the table's primary key.