### PR TITLE
Rails 6: Database limit method deprecations

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_limits.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_limits.rb
@@ -9,10 +9,12 @@ module ActiveRecord
         def column_name_length
           128
         end
+        deprecate :column_name_length
 
         def table_name_length
           128
         end
+        deprecate :table_name_length
 
         def index_name_length
           128
@@ -21,14 +23,17 @@ module ActiveRecord
         def columns_per_table
           1024
         end
+        deprecate :columns_per_table
 
         def indexes_per_table
           999
         end
+        deprecate :indexes_per_table
 
         def columns_per_multicolumn_index
           16
         end
+        deprecate :columns_per_multicolumn_index
 
         def in_clause_length
           10_000
@@ -37,10 +42,12 @@ module ActiveRecord
         def sql_query_length
           65_536 * 4_096
         end
+        deprecate :sql_query_length
 
         def joins_per_query
           256
         end
+        deprecate :joins_per_query
 
         private
 


### PR DESCRIPTION
Depreciate the SQL Server adapter's database limit methods that were deprecated in 
https://github.com/rails/rails/blob/v6.0.0/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/674787276
```
6728 runs, 18686 assertions, 46 failures, 11 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/674844320
```
6728 runs, 18687 assertions, 39 failures, 12 errors, 25 skips
```