### PR TITLE
Rails 6: Fix fully qualified identifier tests

### DIFF
--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -42,14 +42,14 @@ class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
 
     it 'should not use fully qualified table name in order clause' do
       table = Arel::Table.new(:table)
-      expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]  ORDER BY [table].[name]"
+      expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] ORDER BY [table].[name]"
       assert_equal expected_sql, table.project(Arel.star).order(table[:name]).to_sql
     end
 
     it 'should use fully qualified table name in insert statement' do
       manager = Arel::InsertManager.new
       manager.into Arel::Table.new(:table)
-      manager.values = manager.create_values [Arel.sql('*')], %w{ a }
+      manager.values = manager.create_values [Arel.sql('*')]
       expected_sql = "INSERT INTO [my.server].[db].[schema].[table] VALUES (*)"
       quietly { assert_equal expected_sql, manager.to_sql }
     end


### PR DESCRIPTION
This PR fixes the following tests:
- FullyQualifiedIdentifierTestSQLServer::remote server#test_0004_should not use fully qualified table name in order clause 
- FullyQualifiedIdentifierTestSQLServer::remote server#test_0005_should use fully qualified table name in insert statement

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/674956935
```
6728 runs, 18681 assertions, 39 failures, 12 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675213049
```
6728 runs, 18695 assertions, 38 failures, 10 errors, 25 skips
```