### PR TITLE
Rails 6: Fix persistence and update all tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -672,17 +672,35 @@ end
 
 
 
-
+require 'models/topic'
 class PersistenceTest < ActiveRecord::TestCase
-  # We can not UPDATE identity columns.
+  # Rails test required updating a identity column.
   coerce_tests! :test_update_columns_changing_id
+
+  # Rails test required updating a identity column.
+  coerce_tests! :test_update
+  def test_update_coerced
+    topic = Topic.find(1)
+    assert_not_predicate topic, :approved?
+    assert_equal "The First Topic", topic.title
+
+    topic.update("approved" => true, "title" => "The First Topic Updated")
+    topic.reload
+    assert_predicate topic, :approved?
+    assert_equal "The First Topic Updated", topic.title
+
+    topic.update(approved: false, title: "The First Topic")
+    topic.reload
+    assert_not_predicate topic, :approved?
+    assert_equal "The First Topic", topic.title
+  end
 end
 
 
 
 require 'models/author'
 class UpdateAllTest < ActiveRecord::TestCase
-  # Previous test required updating a identity column.
+  # Rails test required updating a identity column.
   coerce_tests! :test_update_all_doesnt_ignore_order
   def test_update_all_doesnt_ignore_order_coerced
     david, mary = authors(:david), authors(:mary)

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -673,12 +673,15 @@ end
 
 
 
-require 'models/parrot'
-require 'models/topic'
 class PersistenceTest < ActiveRecord::TestCase
   # We can not UPDATE identity columns.
   coerce_tests! :test_update_columns_changing_id
+end
 
+
+
+require 'models/author'
+class UpdateAllTest < ActiveRecord::TestCase
   # Previous test required updating a identity column.
   coerce_tests! :test_update_all_doesnt_ignore_order
   def test_update_all_doesnt_ignore_order_coerced
@@ -691,30 +694,6 @@ class PersistenceTest < ActiveRecord::TestCase
     end
     _(david.reload.name).must_equal 'David'
     _(mary.reload.name).must_equal 'Test'
-  end
-
-  # We can not UPDATE identity columns.
-  coerce_tests! :test_update_attributes
-  def test_update_attributes_coerced
-    topic = Topic.find(1)
-    assert !topic.approved?
-    assert_equal "The First Topic", topic.title
-    topic.update_attributes("approved" => true, "title" => "The First Topic Updated")
-    topic.reload
-    assert topic.approved?
-    assert_equal "The First Topic Updated", topic.title
-    topic.update_attributes(approved: false, title: "The First Topic")
-    topic.reload
-    assert !topic.approved?
-    assert_equal "The First Topic", topic.title
-    # SQLServer: Here is where it breaks down. No exceptions.
-    # assert_raise(ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid) do
-    #   topic.update_attributes(id: 3, title: "Hm is it possible?")
-    # end
-    # assert_not_equal "Hm is it possible?", Topic.find(3).title
-    # topic.update_attributes(id: 1234)
-    # assert_nothing_raised { topic.reload }
-    # assert_equal topic.title, Topic.find(1234).title
   end
 end
 


### PR DESCRIPTION
Moved tests that were extracted from `persistence_test.rb` into `update_all_test.rb`. Coerced tests that involved updating identity column, which SQL Server cannot do.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675244061
```
6732 runs, 18719 assertions, 33 failures, 10 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675297322
```
6731 runs, 18705 assertions, 31 failures, 10 errors, 25 skips
```