### PR TITLE
Rails 6: Fix showplan test

### DIFF
--- a/test/cases/showplan_test_sqlserver.rb
+++ b/test/cases/showplan_test_sqlserver.rb
@@ -21,14 +21,14 @@ class ShowplanTestSQLServer < ActiveRecord::TestCase
 
     it 'from prepared statement' do
       plan = Car.where(name: ',').limit(1).explain
-      _(plan).must_include " SELECT  [cars].* FROM [cars] WHERE [cars].[name]"
+      _(plan).must_include "SELECT [cars].* FROM [cars] WHERE [cars].[name]"
       _(plan).must_include "TOP EXPRESSION", 'make sure we do not showplan the sp_executesql'
       _(plan).must_include "Clustered Index Scan", 'make sure we do not showplan the sp_executesql'
     end
 
     it 'from array condition using index' do
       plan = Car.where(id: [1, 2]).explain
-      _(plan).must_include " SELECT [cars].* FROM [cars] WHERE [cars].[id] IN (1, 2)"
+      _(plan).must_include "SELECT [cars].* FROM [cars] WHERE [cars].[id] IN (1, 2)"
       _(plan).must_include "Clustered Index Seek", 'make sure we do not showplan the sp_executesql'
     end
 


### PR DESCRIPTION
Fixes the `activerecord-sqlserver-adapter/test/cases/showplan_test_sqlserver.rb:22` test. 

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675244061
```
6732 runs, 18719 assertions, 33 failures, 10 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675306721
```
6732 runs, 18717 assertions, 32 failures, 10 errors, 25 skips
```