### PR TITLE
Rails 6: Install PostgreSQL gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem 'sqlite3'
+gem 'pg'
 gem 'bcrypt'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -18,7 +19,7 @@ end
 if ENV['RAILS_SOURCE']
   gemspec path: ENV['RAILS_SOURCE']
 else
-  # Need to get rails source beacause the gem doesn't include tests
+  # Need to get rails source because the gem doesn't include tests
   version = ENV['RAILS_VERSION'] || begin
     require 'net/http'
     require 'yaml'


### PR DESCRIPTION

https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675297322
```
ActiveRecord::ConnectionAdapters::ConnectionHandlersMultiDbTest#test_switching_connections_with_database_url:

LoadError: Error loading the 'postgresql' Active Record adapter. Missing a gem it depends on? pg is not part of the bundle. Add it to your Gemfile.
```