### PR TITLE
Rails 6: SQL Server does not support 'CREATE TABLE IF NOT EXISTS [table_name]'.

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -10,8 +10,10 @@ module ActiveRecord
             table_name = quote_table_name(o.temporary ? "##{o.name}" : o.name)
             query = o.as.respond_to?(:to_sql) ? o.as.to_sql : o.as
             projections, source = query.match(%r{SELECT\s+(.*)?\s+FROM\s+(.*)?}).captures
-            select_into = "SELECT #{projections} INTO #{table_name} FROM #{source}"
+            "SELECT #{projections} INTO #{table_name} FROM #{source}"
           else
+            raise NotImplementedError.new("SQL Server does not support 'CREATE TABLE IF NOT EXISTS [table_name]'") if o.if_not_exists
+
             o.instance_variable_set :@as, nil
             super
           end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -425,6 +425,17 @@ class MigrationTest < ActiveRecord::TestCase
 
   # SQL Server does not support 'CREATE TABLE IF NOT EXISTS [table_name]'.
   coerce_tests! :test_create_table_with_if_not_exists_true
+  def test_create_table_with_if_not_exists_true_coerced
+    connection = Person.connection
+
+    assert_raise(NotImplementedError, "SQL Server does not support 'CREATE TABLE IF NOT EXISTS [table_name]'") do
+      connection.create_table :testings, if_not_exists: true do |t|
+        t.string :foo
+      end
+    end
+  ensure
+    connection.drop_table :testings, if_exists: true
+  end
 end
 
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -422,6 +422,9 @@ class MigrationTest < ActiveRecord::TestCase
   # For some reason our tests set Rails.@_env which breaks test env switching.
   coerce_tests! :test_internal_metadata_stores_environment_when_other_data_exists
   coerce_tests! :test_internal_metadata_stores_environment
+
+  # SQL Server does not support 'CREATE TABLE IF NOT EXISTS [table_name]'.
+  coerce_tests! :test_create_table_with_if_not_exists_true
 end
 
 


### PR DESCRIPTION
The `MigrationTest#test_create_table_with_if_not_exists_true` test is failing because SQL Server does not support `CREATE TABLE IF NOT EXISTS [tablename]`. 

SQL generated:
```sql
CREATE TABLE IF NOT EXISTS [testings] ([id] bigint NOT NULL IDENTITY(1,1) PRIMARY KEY, [foo] nvarchar(4000))
```

Which causes the error:
```
ActiveRecord::StatementInvalid: TinyTds::Error: Incorrect syntax near the keyword 'IF'.
```

The main database adapters (Postgresql, MySQL and SQLite) all support the `CREATE TABLE IF NOT EXISTS` syntax.

There are workarounds to get the same functionality in SQL Server but the SQL is a lot different than what ActiveRecord generates. So in this PR we generate a `NotImplementedError` if you try to generate a `CREATE TABLE IF NOT EXISTS [tablename]` query.

References:
- https://lonewolfonline.net/sql-server-create-table-if-not-exists/