### PR TITLE
Rails 6: Fix tests that fail because of unique NULL indexes

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -879,7 +879,7 @@ class RelationTest < ActiveRecord::TestCase
   # so we are skipping all together.
   coerce_tests! :test_empty_complex_chained_relations
 
-  # Can't apply offset withour ORDER
+  # Can't apply offset without ORDER
   coerce_tests! %r{using a custom table affects the wheres}
   test 'using a custom table affects the wheres coerced' do
     post = posts(:welcome)
@@ -887,7 +887,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal post, custom_post_relation.where!(title: post.title).order(:id).take
   end
 
-  # Can't apply offset withour ORDER
+  # Can't apply offset without ORDER
   coerce_tests! %r{using a custom table with joins affects the joins}
   test 'using a custom table with joins affects the joins coerced' do
     post = posts(:welcome)
@@ -1151,10 +1151,21 @@ end
 
 
 
+require "models/book"
 module ActiveRecord
   class StatementCacheTest < ActiveRecord::TestCase
     # Getting random failures.
     coerce_tests! :test_find_does_not_use_statement_cache_if_table_name_is_changed
+
+    # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+    coerce_tests! :test_statement_cache_values_differ
+    def test_statement_cache_values_differ_coerced
+      Book.connection.remove_index(:books, column: [:author_id, :name])
+
+      original_test_statement_cache_values_differ
+    ensure
+      Book.connection.add_index(:books, [:author_id, :name], unique: true)
+    end
   end
 end
 
@@ -1262,5 +1273,49 @@ module ActiveRecord
     # constraints. As this test truncates all tables we would need to remove all foreign
     # key constraints and then restore them afterwards to get this test to pass.
     coerce_tests! :test_truncate_tables
+  end
+end
+
+
+require "models/book"
+class EnumTest < ActiveRecord::TestCase
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! %r{enums are distinct per class}
+  test "enums are distinct per class coerced" do
+    Book.connection.remove_index(:books, column: [:author_id, :name])
+
+    send(:'original_enums are distinct per class')
+  ensure
+    Book.connection.add_index(:books, [:author_id, :name], unique: true)
+  end
+
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! %r{creating new objects with enum scopes}
+  test "creating new objects with enum scopes coerced" do
+    Book.connection.remove_index(:books, column: [:author_id, :name])
+
+    send(:'original_creating new objects with enum scopes')
+  ensure
+    Book.connection.add_index(:books, [:author_id, :name], unique: true)
+  end
+
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! %r{enums are inheritable}
+  test "enums are inheritable coerced" do
+    Book.connection.remove_index(:books, column: [:author_id, :name])
+
+    send(:'original_enums are inheritable')
+  ensure
+    Book.connection.add_index(:books, [:author_id, :name], unique: true)
+  end
+
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! %r{declare multiple enums at a time}
+  test "declare multiple enums at a time coerced" do
+    Book.connection.remove_index(:books, column: [:author_id, :name])
+
+    send(:'original_declare multiple enums at a time')
+  ensure
+    Book.connection.add_index(:books, [:author_id, :name], unique: true)
   end
 end

--- a/test/support/coerceable_test_sqlserver.rb
+++ b/test/support/coerceable_test_sqlserver.rb
@@ -19,21 +19,28 @@ module ARTest
         end
 
         def coerce_all_tests!
-          once = false
           instance_methods(false).each do |method|
             next unless method.to_s =~ /\Atest/
             undef_method(method)
-            once = true
           end
           STDOUT.puts "🙉 🙈 🙊  Undefined all tests: #{self.name}"
         end
 
         private
 
-        def coerced_test_warning(method)
-          method = instance_methods(false).select { |m| m =~ method } if method.is_a?(Regexp)
+        def coerced_test_warning(test_to_coerce)
+          if test_to_coerce.is_a?(Regexp)
+            method = instance_methods(false).select { |m| m =~ test_to_coerce }
+          else
+            method = test_to_coerce
+          end
+
           Array(method).each do |m|
-            result = undef_method(m) if m && method_defined?(m)
+            result = if m && method_defined?(m)
+                       alias_method("original_#{test_to_coerce.inspect.tr('/\:"', '')}", m)
+                       undef_method(m)
+                     end
+
             if result.blank?
               STDOUT.puts "🐳  Unfound coerced test: #{self.name}##{m}"
             else


### PR DESCRIPTION
SQL Server differs from PostgreSQL/MySQL/SQLite in how it handles `NULL` values in unique indexes. 

For example, if you had a table with first and last names and created a unique index on both columns then the following 2 records would violate the unique index on SQL Server. 
 
| First Name  | Last Name |
| ------------- | ------------- |
| Bob  | NULL  |
| Bob  | NULL  |

However, in PostgreSQL/MySQL/SQLite unique indexes do not consider the NULL values equal and so the 2 records can be inserted successfully. 

This meant that some Rails tests were failing because the records required for the tests could not be inserted using SQL Server. The tests themselves were not testing unique indexes and assumed the records could be inserted.

In this PR the unique indexes are removed before the Rails tests are then called. The unique indexes are then restored afterwards. 

The code to coerce tests has been updated so that the coerced Rails tests can be called by prepending `original_` to their method name. This will help prevent duplicating the Rails test code in our test cases.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/675315237
```
6731 runs, 18715 assertions, 30 failures, 10 errors, 25 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/677268504
```
6731 runs, 18712 assertions, 30 failures, 5 errors, 25 skips
```

References:
- https://www.postgresql.org/docs/current/indexes-unique.html
- https://www.sqlitetutorial.net/sqlite-unique-constraint/
- https://dev.mysql.com/doc/refman/5.7/en/create-index.html#create-index-unique