### PR TITLE
Rails 6: Support lazy transactions

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -136,6 +136,8 @@ module ActiveRecord
         # === SQLServer Specific ======================================== #
 
         def execute_procedure(proc_name, *variables)
+          materialize_transactions
+
           vars = if variables.any? && variables.first.is_a?(Hash)
                    variables.first.map { |k, v| "@#{k} = #{quote(v)}" }
                  else
@@ -268,6 +270,8 @@ module ActiveRecord
         # === SQLServer Specific (Executing) ============================ #
 
         def do_execute(sql, name = 'SQL')
+          materialize_transactions
+
           log(sql, name) { raw_connection_do(sql) }
         end
 
@@ -378,6 +382,8 @@ module ActiveRecord
         # === SQLServer Specific (Selecting) ============================ #
 
         def raw_select(sql, name = 'SQL', binds = [], options = {})
+          materialize_transactions
+
           log(sql, name, binds) { _raw_select(sql, options) }
         end
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -14,6 +14,8 @@ module ActiveRecord
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
 
+          materialize_transactions
+
           if id_insert_table_name = query_requires_identity_insert?(sql)
             with_identity_insert_enabled(id_insert_table_name) { do_execute(sql, name) }
           else
@@ -25,6 +27,8 @@ module ActiveRecord
           if preventing_writes? && write_query?(sql)
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
+
+          materialize_transactions
 
           sp_executesql(sql, name, binds, prepare: prepare)
         end
@@ -270,8 +274,6 @@ module ActiveRecord
         # === SQLServer Specific (Executing) ============================ #
 
         def do_execute(sql, name = 'SQL')
-          materialize_transactions
-
           log(sql, name) { raw_connection_do(sql) }
         end
 
@@ -382,8 +384,6 @@ module ActiveRecord
         # === SQLServer Specific (Selecting) ============================ #
 
         def raw_select(sql, name = 'SQL', binds = [], options = {})
-          materialize_transactions
-
           log(sql, name, binds) { _raw_select(sql, options) }
         end
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -274,6 +274,8 @@ module ActiveRecord
         # === SQLServer Specific (Executing) ============================ #
 
         def do_execute(sql, name = 'SQL')
+          materialize_transactions
+
           log(sql, name) { raw_connection_do(sql) }
         end
 

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -145,6 +145,10 @@ module ActiveRecord
         true
       end
 
+      def supports_lazy_transactions?
+        true
+      end
+      
       def supports_in_memory_oltp?
         @version_year >= 2014
       end

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -45,7 +45,7 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
       Person.reset_column_information
     end
 
-    it 'not drop the default contraint if just renaming' do
+    it 'not drop the default constraint if just renaming' do
       find_default = lambda do
         connection.execute_procedure(:sp_helpconstraint, 'sst_string_defaults', 'nomsg').select do |row|
           row['constraint_type'] == "DEFAULT on column string_with_pretend_paren_three"


### PR DESCRIPTION
Lazy transactions changes required by https://github.com/rails/rails/pull/32647/

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/680126303
```
6730 runs, 18723 assertions, 24 failures, 1 errors, 26 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/680176451
```
6730 runs, 18725 assertions, 8 failures, 1 errors, 26 skips
```