### PR TITLE
Rails 6: Adapter does not use prepared statement cache

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -222,6 +222,7 @@ module ActiveRecord
     # SQL Server adapter does not use a statement cache as query plans are already reused using `EXEC sp_executesql`.
     coerce_tests! :test_statement_cache
     coerce_tests! :test_statement_cache_with_query_cache
+    coerce_tests! :test_statement_cache_with_find
     coerce_tests! :test_statement_cache_with_find_by
     coerce_tests! :test_statement_cache_with_in_clause
     coerce_tests! :test_statement_cache_with_sql_string_literal


### PR DESCRIPTION
SQL Server adapter does not use a statement cache. This PR coerces the `ActiveRecord::BindParameterTest#test_statement_cache_with_find` test added in Rails 6.

References:
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/744 