### PR TITLE
Rails 6: fix deprecated update_attributes method usage

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -155,7 +155,7 @@ class BasicsTest < ActiveRecord::TestCase
     Time.use_zone("Eastern Time (US & Canada)") do
       topic = Topic.find(1)
       time = Time.zone.parse("2017-07-17 10:56")
-      topic.update_attributes!(written_on: time)
+      topic.update!(written_on: time)
       assert_equal(time, topic.written_on)
     end
   end
@@ -166,7 +166,7 @@ class BasicsTest < ActiveRecord::TestCase
         Time.use_zone("Eastern Time (US & Canada)") do
           topic = Topic.find(1)
           time = Time.zone.parse("2017-07-17 10:56")
-          topic.update_attributes!(written_on: time)
+          topic.update!(written_on: time)
           assert_equal(time, topic.written_on)
         end
       end


### PR DESCRIPTION
Rails 6 deprecated update_attributes/! aliases for update/!  https://github.com/rails/rails/pull/31998.
 
Remove `coerced_tests.rb` update_attributes usage.