### PR TITLE
Rails 6: coerce test_default_decimal_number to assert against number

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1131,11 +1131,21 @@ class DefaultNumbersTest < ActiveRecord::TestCase
     assert_equal 7, record.positive_integer
     assert_equal 7, record.positive_integer_before_type_cast
   end
+
+  # We do better with native types and do not return strings for everything.
   coerce_tests! :test_default_negative_integer
   def test_default_negative_integer_coerced
     record = DefaultNumber.new
     assert_equal -5, record.negative_integer
     assert_equal -5, record.negative_integer_before_type_cast
+  end
+
+  # We do better with native types and do not return strings for everything.
+  coerce_tests! :test_default_decimal_number
+  def test_default_decimal_number_coerced
+    record = DefaultNumber.new
+    assert_equal BigDecimal("2.78"), record.decimal_number
+    assert_equal 2.78, record.decimal_number_before_type_cast
   end
 end
 


### PR DESCRIPTION
Fixes test_default_decimal_number to assert `record.decimal_number_before_type_cast` against number from string.
Like `test_default_positive_integer_coerced` and `test_default_negative_integer`.