### PR TITLE
Fix `EagerLoadingTooManyIdsTest#test_preloading_too_many_ids`

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
@@ -1,0 +1,34 @@
+require "active_record/associations/preloader"
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module CoreExt
+        module Preloader
+          private
+
+          def records_for(ids)
+            ids.each_slice(in_clause_length).flat_map do |slice|
+              scope.where(association_key_name => slice).load do |record|
+                # Processing only the first owner
+                # because the record is modified but not an owner
+                owner = owners_by_key[convert_key(record[association_key_name])].first
+                association = owner.association(reflection.name)
+                association.set_inverse_instance(record)
+              end.records
+            end
+          end
+
+          def in_clause_length
+            10_000
+          end
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  mod = ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Preloader
+  ActiveRecord::Associations::Preloader::Association.prepend(mod)
+end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -9,6 +9,7 @@ require 'active_record/connection_adapters/sqlserver/core_ext/explain_subscriber
 require 'active_record/connection_adapters/sqlserver/core_ext/attribute_methods'
 require 'active_record/connection_adapters/sqlserver/core_ext/finder_methods'
 require 'active_record/connection_adapters/sqlserver/core_ext/query_methods'
+require 'active_record/connection_adapters/sqlserver/core_ext/preloader'
 require 'active_record/connection_adapters/sqlserver/version'
 require 'active_record/connection_adapters/sqlserver/type'
 require 'active_record/connection_adapters/sqlserver/database_limits'


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/36074, `in_clause_length` will
no longer help the adapter to avoid complex query limitation, and will
be removed from Rails code base (https://github.com/rails/rails/pull/39057).