### PR TITLE
Rails 6: Raise exception for foreign key constraint violation

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -332,15 +332,15 @@ module ActiveRecord
       def translate_exception(e, message:, sql:, binds:)
         case message
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
-          RecordNotUnique.new(message)
-        when /conflicted with the foreign key constraint/i
-          InvalidForeignKey.new(message)
+          RecordNotUnique.new(message, sql: sql, binds: binds)
+        when /(conflicted with the foreign key constraint) | (The DELETE statement conflicted with the REFERENCE constraint)/i
+          InvalidForeignKey.new(message, sql: sql, binds: binds)
         when /has been chosen as the deadlock victim/i
-          DeadlockVictim.new(message)
+          DeadlockVictim.new(message, sql: sql, binds: binds)
         when /database .* does not exist/i
-          NoDatabaseError.new(message)
+          NoDatabaseError.new(message, sql: sql, binds: binds)
         when /data would be truncated/
-          ValueTooLong.new(message)
+          ValueTooLong.new(message, sql: sql, binds: binds)
         when /Column '(.*)' is not the same data type as referencing column '(.*)' in foreign key/
           pk_id, fk_id = SQLServer::Utils.extract_identifiers($1), SQLServer::Utils.extract_identifiers($2)
           MismatchedForeignKey.new(
@@ -352,9 +352,9 @@ module ActiveRecord
             primary_key: pk_id.object
           )
         when /Cannot insert the value NULL into column.*does not allow nulls/
-          NotNullViolation.new(message)
+          NotNullViolation.new(message, sql: sql, binds: binds)
         when /Arithmetic overflow error/
-          RangeError.new(message)
+          RangeError.new(message, sql: sql, binds: binds)
         else
           super
         end


### PR DESCRIPTION
This PR fixes the `ActiveRecord::AdapterForeignKeyTest#test_foreign_key_violations_on_delete_are_translated_to_specific_exception` test. Needed to convert SQL Server error message into `ActiveRecord::InvalidForeignKey` exception.

Also, updated the SQL Server exceptions to pass SQL and binds when created. This follows how the rest of the adapters work.

**Before**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/680001607
```
6730 runs, 18712 assertions, 25 failures, 1 errors, 26 skips
```

**After**
https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/680112852
```
6730 runs, 18717 assertions, 24 failures, 1 errors, 26 skips
```