### PR TITLE
Rails 6: Coerce test "an empty transaction does not raise if preventing writes"

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -177,6 +177,18 @@ class BasicsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  # SQL Server does not have query for release_savepoint
+  coerce_tests! %r{an empty transaction does not raise if preventing writes}
+  test "an empty transaction does not raise if preventing writes coerced" do
+    ActiveRecord::Base.connection_handler.while_preventing_writes do
+      assert_queries(1, ignore_none: true) do
+        Bird.transaction do
+          ActiveRecord::Base.connection.materialize_transactions
+        end
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
Because tests automatically wrapped in transaction the transaction in the test become SavepointTransaction and SQL Server does not have `release_savepoint` query so the assert should be corrected to 1.