### PR TITLE
Rails 6: Coerce time no precision test

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -236,7 +236,7 @@ module ActiveRecord
               if (0..7) === precision
                 column_type_sql << "(#{precision})"
               else
-                raise(ActiveRecordError, "The dattime2 type has precision of #{precision}. The allowed range of precision is from 0 to 7")
+                raise(ActiveRecordError, "The datetime2 type has precision of #{precision}. The allowed range of precision is from 0 to 7")
               end
             end
             column_type_sql

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1120,6 +1120,9 @@ class TimePrecisionTest < ActiveRecord::TestCase
     assert_equal 0, foo.start.nsec
     assert_equal 123457000, foo.finish.nsec
   end
+
+  # SQL Server uses default precision for time.
+  coerce_tests! :test_no_time_precision_isnt_truncated_on_assignment
 end
 
 


### PR DESCRIPTION
Coerce the `TimePrecisionTest#test_no_time_precision_isnt_truncated_on_assignment` test as its not applicable for SQL Server. 

Test checks that time value isn't truncated if the time column has no precision. However, SQL Server uses default time precision of 7, so value is truncated. The `test_time_precision_is_truncated_on_assignment_coerced` already tests that the values in columns with precision are truncated correctly.