### PR TITLE
Rails 6: Clean coerced tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -64,7 +64,7 @@ module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     # SQL Server does not allow truncation of tables that are referenced by foreign key
     # constraints. So manually remove/add foreign keys in test.
-    coerce_tests! :test_truncate_tables, :test_truncate_tables_with_query_cache
+    coerce_tests! :test_truncate_tables
     def test_truncate_tables_coerced
       # Remove foreign key constraint to allow truncation.
       @connection.remove_foreign_key :authors, :author_addresses
@@ -85,6 +85,9 @@ module ActiveRecord
       @connection.add_foreign_key :authors, :author_addresses
     end
 
+    # SQL Server does not allow truncation of tables that are referenced by foreign key
+    # constraints. So manually remove/add foreign keys in test.
+    coerce_tests! :test_truncate_tables_with_query_cache
     def test_truncate_tables_with_query_cache
       # Remove foreign key constraint to allow truncation.
       @connection.remove_foreign_key :authors, :author_addresses

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -272,18 +272,20 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal BigDecimal('3.0').to_s, BigDecimal(value).to_s
   end
 
+  # Match SQL Server limit implementation
   coerce_tests! :test_limit_is_kept
   def test_limit_is_kept_coerced
     queries = capture_sql_ss { Account.limit(1).count }
     assert_equal 1, queries.length
-    _(queries.first).must_match %r{ORDER BY \[accounts\]\.\[id\] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1}
+    assert_match(/ORDER BY \[accounts\]\.\[id\] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/, queries.first)
   end
 
+  # Match SQL Server limit implementation
   coerce_tests! :test_limit_with_offset_is_kept
   def test_limit_with_offset_is_kept_coerced
     queries = capture_sql_ss { Account.limit(1).offset(1).count }
     assert_equal 1, queries.length
-    _(queries.first).must_match %r{ORDER BY \[accounts\]\.\[id\] ASC OFFSET @0 ROWS FETCH NEXT @1 ROWS ONLY.*@0 = 1, @1 = 1}
+    assert_match(/ORDER BY \[accounts\]\.\[id\] ASC OFFSET @0 ROWS FETCH NEXT @1 ROWS ONLY.*@0 = 1, @1 = 1/, queries.first)
   end
 
   # SQL Server needs an alias for the calculated column

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1278,10 +1278,6 @@ class RelationMergingTest < ActiveRecord::TestCase
 end
 
 
-class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
-  # Temporarily coerce this test due to https://github.com/rails/rails/issues/34945
-  coerce_tests! :test_eager_loading_too_may_ids
-end
 
 
 module ActiveRecord

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -60,6 +60,9 @@ module ActiveRecord
   end
 end
 
+
+
+
 module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     # SQL Server does not allow truncation of tables that are referenced by foreign key
@@ -223,6 +226,8 @@ module ActiveRecord
 end
 
 
+
+
 module ActiveRecord
   class InstrumentationTest < ActiveRecord::TestCase
     # This fails randomly due to schema cache being lost?
@@ -242,6 +247,9 @@ module ActiveRecord
     end
   end
 end
+
+
+
 
 class CalculationsTest < ActiveRecord::TestCase
   # This fails randomly due to schema cache being lost?
@@ -290,6 +298,7 @@ end
 
 
 
+
 module ActiveRecord
   class Migration
     class ChangeSchemaTest < ActiveRecord::TestCase
@@ -323,10 +332,10 @@ end
 
 
 
+
 module ActiveRecord
   module ConnectionAdapters
     class QuoteARBaseTest < ActiveRecord::TestCase
-
       # Use our date format.
       coerce_tests! :test_quote_ar_object
       def test_quote_ar_object_coerced
@@ -340,10 +349,10 @@ module ActiveRecord
         value = DatetimePrimaryKey.new(id: @time)
         assert_equal "02-14-2017 12:34:56.79",  @connection.type_cast(value)
       end
-
     end
   end
 end
+
 
 
 
@@ -479,10 +488,12 @@ module ActiveRecord
     # Skip this test with /tmp/my_schema_cache.yml path on Windows.
     coerce_tests! :test_dump_schema_cache if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
   end
+
   class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
     # We extend `local_database?` so that common VM IPs can be used.
     coerce_tests! :test_ignores_remote_databases, :test_warning_for_remote_databases
   end
+
   class DatabaseTasksDropAllTest < ActiveRecord::TestCase
     # We extend `local_database?` so that common VM IPs can be used.
     coerce_tests! :test_ignores_remote_databases, :test_warning_for_remote_databases
@@ -599,8 +610,9 @@ class FinderTest < ActiveRecord::TestCase
       end
     end
   end
-
 end
+
+
 
 
 module ActiveRecord
@@ -723,6 +735,7 @@ end
 
 
 
+
 require 'models/topic'
 class PersistenceTest < ActiveRecord::TestCase
   # Rails test required updating a identity column.
@@ -746,6 +759,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topic.title
   end
 end
+
 
 
 
@@ -812,7 +826,6 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert_equal 2, Task.connection.select_value("SELECT count(*) AS count_all FROM tasks")
     end
   end
-
 
   # Same as original test except that we expect one query to be performed to retrieve the table's primary key.
   # When we generate the SQL for the `find` it includes ordering on the primary key. If we reset the column
@@ -910,7 +923,6 @@ class RelationTest < ActiveRecord::TestCase
     topics = Topic.order(Arel.sql("LEN(title)") => :asc).reverse_order
     assert_equal topics(:second).title, topics.first.title
   end
-
 end
 
 
@@ -969,6 +981,9 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: 2\.78}, output
   end
 end
+
+
+
 
 class SchemaDumperDefaultsTest < ActiveRecord::TestCase
   # These date formats do not match ours. We got these covered in our dumper tests.
@@ -1041,6 +1056,10 @@ class ViewWithPrimaryKeyTest < ActiveRecord::TestCase
     assert_equal 'id', model.primary_key
   end
 end
+
+
+
+
 class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
   # We have a few view tables. use includes vs equality.
   coerce_tests! :test_views
@@ -1100,6 +1119,7 @@ end
 
 
 
+
 class TimePrecisionTest < ActiveRecord::TestCase
   # datetime is rounded to increments of .000, .003, or .007 seconds
   coerce_tests! :test_time_precision_is_truncated_on_assignment
@@ -1121,6 +1141,7 @@ class TimePrecisionTest < ActiveRecord::TestCase
     assert_equal 123457000, foo.finish.nsec
   end
 end
+
 
 
 
@@ -1196,6 +1217,9 @@ module ActiveRecord
   end
 end
 
+
+
+
 class UnsafeRawSqlTest < ActiveRecord::TestCase
    # Use LEN() vs length() function.
   coerce_tests! %r{order: always allows Arel}
@@ -1226,8 +1250,9 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal ids_expected, ids_depr
     assert_equal ids_expected, ids_disabled
   end
-
 end
+
+
 
 
 class ReservedWordTest < ActiveRecord::TestCase
@@ -1239,6 +1264,7 @@ class ReservedWordTest < ActiveRecord::TestCase
     assert_nothing_raised { @connection.rename_column(:group, :order, :values) }
   end
 end
+
 
 
 
@@ -1265,6 +1291,7 @@ end
 
 
 
+
 class RelationMergingTest < ActiveRecord::TestCase
   # Use nvarchar string (N'') in assert
   coerce_tests! :test_merging_with_order_with_binds
@@ -1285,6 +1312,8 @@ module ActiveRecord
     coerce_tests! :test_truncate_tables
   end
 end
+
+
 
 
 require "models/book"

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -136,11 +136,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 end
 
 
-class NumericDataTest < ActiveRecord::TestCase
-  # We do not have do the DecimalWithoutScale type.
-  coerce_tests! :test_numeric_fields
-  coerce_tests! :test_numeric_fields_with_scale
-end
+
 
 class BasicsTest < ActiveRecord::TestCase
   coerce_tests! :test_column_names_are_escaped

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -115,18 +115,20 @@ end
 
 require 'models/topic'
 class AttributeMethodsTest < ActiveRecord::TestCase
+  # Use IFF for boolean statement in SELECT
   coerce_tests! %r{typecast attribute from select to false}
   def test_typecast_attribute_from_select_to_false_coerced
     Topic.create(:title => 'Budget')
     topic = Topic.all.merge!(:select => "topics.*, IIF (1 = 2, 1, 0) as is_test").first
-    assert !topic.is_test?
+    assert_not_predicate topic, :is_test?
   end
 
+  # Use IFF for boolean statement in SELECT
   coerce_tests! %r{typecast attribute from select to true}
   def test_typecast_attribute_from_select_to_true_coerced
     Topic.create(:title => 'Budget')
     topic = Topic.all.merge!(:select => "topics.*, IIF (1 = 1, 1, 0) as is_test").first
-    assert topic.is_test?
+    assert_not_predicate topic, :is_test?
   end
 end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -134,7 +134,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   def test_typecast_attribute_from_select_to_true_coerced
     Topic.create(:title => 'Budget')
     topic = Topic.all.merge!(:select => "topics.*, IIF (1 = 1, 1, 0) as is_test").first
-    assert_not_predicate topic, :is_test?
+    assert_predicate topic, :is_test?
   end
 end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -919,24 +919,6 @@ class RelationTest < ActiveRecord::TestCase
 
 end
 
-class ActiveRecord::RelationTest < ActiveRecord::TestCase
-  coerce_tests! :test_relation_merging_with_merged_symbol_joins_is_aliased
-  def test_relation_merging_with_merged_symbol_joins_is_aliased__coerced
-    categorizations_with_authors = Categorization.joins(:author)
-    queries = capture_sql { Post.joins(:author, :categorizations).merge(Author.select(:id)).merge(categorizations_with_authors).to_a }
-
-    nb_inner_join = queries.sum { |sql| sql.scan(/INNER\s+JOIN/i).size }
-    assert_equal 3, nb_inner_join, "Wrong amount of INNER JOIN in query"
-
-    # using `\W` as the column separator
-    query_matches = queries.any? do |sql|
-      %r[INNER\s+JOIN\s+#{Regexp.escape(Author.quoted_table_name)}\s+\Wauthors_categorizations\W]i.match?(sql)
-    end
-
-    assert query_matches, "Should be aliasing the child INNER JOINs in query"
-  end
-end
-
 
 
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -177,16 +177,6 @@ class BasicsTest < ActiveRecord::TestCase
       end
     end
   end
-
-  # Need to escape `quoted_id` once it contains brackets
-  coerce_tests! %r{column names are quoted when using #from clause and model has ignored columns}
-  test "column names are quoted when using #from clause and model has ignored columns coerced" do
-    refute_empty Developer.ignored_columns
-    query = Developer.from("developers").to_sql
-    quoted_id = "#{Developer.quoted_table_name}.#{Developer.quoted_primary_key}"
-
-    assert_match(/SELECT #{Regexp.escape(quoted_id)}.* FROM developers/, query)
-  end
 end
 
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -795,9 +795,15 @@ end
 
 
 class PrimaryKeysTest < ActiveRecord::TestCase
-  # Gonna trust Rails core for this. We end up with 2 querys vs 3 asserted
-  # but as far as I can tell, this is only one for us anyway.
+  # SQL Server does not have query for release_savepoint
   coerce_tests! :test_create_without_primary_key_no_extra_query
+  def test_create_without_primary_key_no_extra_query_coerced
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "dashboards"
+    end
+    klass.create! # warmup schema cache
+    assert_queries(2, ignore_none: true) { klass.create! }
+  end
 end
 
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -697,23 +697,6 @@ end
 
 
 
-class NamedScopingTest < ActiveRecord::TestCase
-  # This works now because we add an `order(:id)` sort to break the order tie for deterministic results.
-  coerce_tests! :test_scopes_honor_current_scopes_from_when_defined
-  def test_scopes_honor_current_scopes_from_when_defined_coerced
-    assert !Post.ranked_by_comments.order(:id).limit_by(5).empty?
-    assert !authors(:david).posts.ranked_by_comments.order(:id).limit_by(5).empty?
-    assert_not_equal Post.ranked_by_comments.order(:id).limit_by(5), authors(:david).posts.ranked_by_comments.order(:id).limit_by(5)
-    assert_not_equal Post.order(:id).top(5), authors(:david).posts.order(:id).top(5)
-    # Oracle sometimes sorts differently if WHERE condition is changed
-    assert_equal authors(:david).posts.ranked_by_comments.limit_by(5).to_a.sort_by(&:id), authors(:david).posts.top(5).to_a.sort_by(&:id)
-    assert_equal Post.ranked_by_comments.limit_by(5), Post.top(5)
-  end
-end
-
-
-
-
 require 'models/developer'
 require 'models/computer'
 class NestedRelationScopingTest < ActiveRecord::TestCase


### PR DESCRIPTION
I run the tests suite without the `coerced tests.rb` file and found old coerced tests that been fix in active record.

I removed old tests and tried to update tests to match the original tests.

I added comments to tests.