### PR TITLE
Rails 6: Updates for bulk insert/upsert

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -159,6 +159,22 @@ module ActiveRecord
         @version_year >= 2014
       end
 
+      def supports_insert_returning?
+        true
+      end
+
+      def supports_insert_on_duplicate_skip?
+        false
+      end
+
+      def supports_insert_on_duplicate_update?
+        false
+      end
+
+      def supports_insert_conflict_target?
+        false
+      end
+
       def disable_referential_integrity
         tables = tables_with_referential_integrity
         tables.each { |t| do_execute "ALTER TABLE #{quote_table_name(t)} NOCHECK CONSTRAINT ALL" }


### PR DESCRIPTION
Bulk inserts akin to the bulk updates provided by `update_all` and bulk deletes by `delete_all` was added to Rails in https://github.com/rails/rails/pull/35077. 

Other adapters support skipping or upserting duplicates through the `ON CONFLICT` syntax for Postgres (9.5+) and Sqlite (3.24+) and `ON DUPLICATE KEY UPDATE` syntax for MySQL.

SQL Server, however, does not support skipping or upserting duplicates. There are some workarounds in https://michaeljswart.com/2017/07/sql-server-upsert-patterns-and-antipatterns/ but they will require more work to implement and test.

This PR implements the functionality to support insert returning. This will run the previous skipped tests such as https://github.com/rails/rails/blob/master/activerecord/test/cases/insert_all_test.rb#L75

I have coerced the `QueryCacheExpiryTest#test_insert_all` test as it should have been checking whether the adapter supported the `supports_insert_on_duplicate_skip?`/`supports_insert_on_duplicate_update?` functionality before calling `insert`/`upsert`. 

References:

- https://github.com/rails/rails/pull/35077
- https://michaeljswart.com/2017/07/sql-server-upsert-patterns-and-antipatterns/