### PR TITLE
Rails 6: Fix randomly failing test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -193,6 +193,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_no_match(/\[firm_with_primary_keys_companies\]\.\[id\]/, sql)
     assert_match(/\[firm_with_primary_keys_companies\]\.\[name\]/, sql)
   end
+
+  # Asserted SQL to get one row different from original test.
+  coerce_tests! :test_belongs_to
+  def test_belongs_to_coerced
+    client = Client.find(3)
+    first_firm = companies(:first_firm)
+    assert_sql(/FETCH NEXT @(\d) ROWS ONLY(.)*@\1 = 1/) do
+      assert_equal first_firm, client.firm
+      assert_equal first_firm.name, client.firm.name
+    end
+  end
 end
 
 
@@ -644,7 +655,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   def test_has_one_coerced
     firm = companies(:first_firm)
     first_account = Account.find(1)
-    assert_sql(/FETCH NEXT @1 ROWS ONLY(.)*@1 = 1/) do
+    assert_sql(/FETCH NEXT @(\d) ROWS ONLY(.)*@\1 = 1/) do
       assert_equal first_account, firm.account
       assert_equal first_account.credit_limit, firm.account.credit_limit
     end
@@ -659,27 +670,12 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   coerce_tests! :test_has_one_through_executes_limited_query
   def test_has_one_through_executes_limited_query_coerced
     boring_club = clubs(:boring_club)
-    assert_sql(/FETCH NEXT @3 ROWS ONLY(.)*@3 = 1/) do
+    assert_sql(/FETCH NEXT @(\d) ROWS ONLY(.)*@\1 = 1/) do
       assert_equal boring_club, @member.general_club
     end
   end
 end
 
-
-
-
-class BelongsToAssociationsTest < ActiveRecord::TestCase
-  # Asserted SQL to get one row different from original test.
-  coerce_tests! :test_belongs_to
-  def test_belongs_to_coerced
-    client = Client.find(3)
-    first_firm = companies(:first_firm)
-    assert_sql(/FETCH NEXT @3 ROWS ONLY(.)*@3 = 1/) do
-      assert_equal first_firm, client.firm
-      assert_equal first_firm.name, client.firm.name
-    end
-  end
-end
 
 
 


### PR DESCRIPTION
Fix the randomly failing `BelongsToAssociationsTest#test_belongs_to_coerced` test. Sometimes the position of the number of rows being requested in the argument list was changing.

See https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/681436516