### PR TITLE
Rails 6: Log subscriber workaround

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1468,6 +1468,7 @@ end
 
 
 class LogSubscriberTest < ActiveRecord::TestCase
+  # Call original test from coerced test. Fixes issue on CI with Rails installed as a gem.
   coerce_tests! :test_vebose_query_logs
   def test_vebose_query_logs_coerced
     original_test_vebose_query_logs

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1463,3 +1463,13 @@ class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
     end
   end
 end
+
+
+
+
+class LogSubscriberTest < ActiveRecord::TestCase
+  coerce_tests! :test_vebose_query_logs
+  def test_vebose_query_logs_coerced
+    original_test_vebose_query_logs
+  end
+end


### PR DESCRIPTION
Workaround to fix the failing `LogSubscriberTest#test_vebose_query_logs` test on the CI by calling the original test from the coerced test.

The issue seems to be caused by the adapter installing Rails as a gem and the `ActiveSupport::BacktraceCleaner`, which cleans up backtraces and is used by `ActiveRecord::LogSubscriber`. It seems to be silencing calls from installed gems. 

References:
https://github.com/rails/rails/pull/33455