### PR TITLE
Rails 6: Workaround for randomly failing schema test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1470,3 +1470,15 @@ class LogSubscriberTest < ActiveRecord::TestCase
     original_test_vebose_query_logs
   end
 end
+
+
+
+
+class ActiveRecordSchemaTest < ActiveRecord::TestCase
+  # Workaround for randomly failing test.
+  coerce_tests! :test_has_primary_key
+  def test_has_primary_key_coerced
+    @schema_migration.reset_column_information
+    original_test_has_primary_key
+  end
+end


### PR DESCRIPTION
The test `ActiveRecordSchemaTest#test_has_primary_key` is randomly failing (see https://travis-ci.org/github/rails-sqlserver/activerecord-sqlserver-adapter/jobs/683462468). To recreate the issue checkout commit 66db048 and run test with command `SEED=7965 bundle exec rake test`.

The column information for the table must be already set from previous test sometimes.