### PR TITLE
Rails 6: Skip binary fixtures test on Windows

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1619,3 +1619,11 @@ module ActiveRecord
     end
   end
 end
+
+
+
+
+class FixturesTest < ActiveRecord::TestCase
+  # Skip test on Windows. Skip can be removed when Rails PR https://github.com/rails/rails/pull/39234 has been merged.
+  coerce_tests! :test_binary_in_fixtures if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+end


### PR DESCRIPTION
The `FixturesTest#test_binary_in_fixtures` test fails on Windows because the binary file is not being read in binary format.

Opened Rails PR https://github.com/rails/rails/pull/39234 to fix the issue on Rails. Coercing the test on Windows until the issue is fixed.