### PR TITLE
Rails 6: Coerce reaper test using fork

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1483,3 +1483,15 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     original_test_has_primary_key
   end
 end
+
+
+
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ReaperTest < ActiveRecord::TestCase
+      # Coerce can be removed if Rails version > 6.0.3
+      coerce_tests! :test_connection_pool_starts_reaper_in_fork
+    end
+  end
+end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1491,7 +1491,7 @@ module ActiveRecord
   module ConnectionAdapters
     class ReaperTest < ActiveRecord::TestCase
       # Coerce can be removed if Rails version > 6.0.3
-      coerce_tests! :test_connection_pool_starts_reaper_in_fork
+      coerce_tests! :test_connection_pool_starts_reaper_in_fork unless Process.respond_to?(:fork)
     end
   end
 end


### PR DESCRIPTION
After Rails 6.0.3 the `ActiveRecord::ConnectionAdapters::ReaperTest#test_connection_pool_starts_reaper_in_fork` test is wrapped in `if Process.respond_to?(:fork)` so no need to coerce the test after that.

https://github.com/rails/rails/pull/37789