### PR TITLE
Rails 6: Coerce ReloadModelsTest test on Windows

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1627,3 +1627,12 @@ class FixturesTest < ActiveRecord::TestCase
   # Skip test on Windows. Skip can be removed when Rails PR https://github.com/rails/rails/pull/39234 has been merged.
   coerce_tests! :test_binary_in_fixtures if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
 end
+
+
+
+
+class ReloadModelsTest < ActiveRecord::TestCase
+  # Skip test on Windows. The number of arguements passed to `IO.popen` in
+  # `activesupport/lib/active_support/testing/isolation.rb` exceeds what Windows can handle.
+  coerce_tests! :test_has_one_with_reload if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+end


### PR DESCRIPTION
The `ReloadModelsTest#test_has_one_with_reload` test fails on Windows because too many arguments are being passed to create the new subprocess (https://github.com/rails/rails/blob/v6.0.3/activesupport/lib/active_support/testing/isolation.rb#L93).

On the AppVeyor CI, when all tests are being run the test is calling `IO.popen` with 442 arguments (see https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/32821521/job/e47ljgrcbpmmiuyf). Because of the number of arguments or the total length of the arguments a `Arg list too long - C:/Ruby25-x64/bin/ruby.exe (Errno::E2BIG)` exception is being thrown.

| Variable  | Number of arguments|
| ------------- | ------------- |
| load_path_args | 166  |
| $0 | 1  |
| ORIG_ARGV | 274 |
| test_opts | 1  |

If just the `ReloadModelsTest#test_has_one_with_reload` is run then the number of arguments in `ORIG_ARGV` is reduced to 2 and the test passes. See https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/32821146/job/nr3abuyi476eu0s7

Coercing the `ReloadModelsTest#test_has_one_with_reload` test if being run on a Windows environment.