### PR TITLE
Rails 6: Cleanup code using .host_windows? helper method

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -629,7 +629,7 @@ module ActiveRecord
 
   class DatabaseTasksDumpSchemaCacheTest < ActiveRecord::TestCase
     # Skip this test with /tmp/my_schema_cache.yml path on Windows.
-    coerce_tests! :test_dump_schema_cache if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+    coerce_tests! :test_dump_schema_cache if host_windows?
   end
 
   class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
@@ -1625,7 +1625,7 @@ end
 
 class FixturesTest < ActiveRecord::TestCase
   # Skip test on Windows. Skip can be removed when Rails PR https://github.com/rails/rails/pull/39234 has been merged.
-  coerce_tests! :test_binary_in_fixtures if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+  coerce_tests! :test_binary_in_fixtures if host_windows?
 end
 
 
@@ -1634,5 +1634,5 @@ end
 class ReloadModelsTest < ActiveRecord::TestCase
   # Skip test on Windows. The number of arguements passed to `IO.popen` in
   # `activesupport/lib/active_support/testing/isolation.rb` exceeds what Windows can handle.
-  coerce_tests! :test_has_one_with_reload if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+  coerce_tests! :test_has_one_with_reload if host_windows?
 end


### PR DESCRIPTION
Cleanup code using `.host_windows?` helper method.