### PR TITLE
WIP: Rails 6: Handle false return by TinyTDS if connection fails and fixed CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,11 @@ clone_depth: 5
 build: off
 matrix:
   fast_finish: true
-
+  allow_failures:
+    - ruby_version: "25"
+    - ruby_version: "26"
+    - ruby_version: "27"
+    - ruby_version: "27-x64"
 services:
   - mssql2014
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -350,7 +350,12 @@ module ActiveRecord
         def raw_connection_do(sql)
           case @connection_options[:mode]
           when :dblib
-            @connection.execute(sql).do
+            result = @connection.execute(sql)
+            # If connection fails then TinyTDS returns false instead of an exception (see https://github.com/rails-sqlserver/tiny_tds/issues/464)
+            if result == false
+              raise TinyTds::Error, 'TinyTDS execute returned false instead of results'
+            end
+            result.do
           end
         ensure
           @update_sql = false


### PR DESCRIPTION
Ruby 25 (https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/32855936/job/6lxy5y73pv8d4h6y) and 26 (https://ci.appveyor.com/project/rails-sqlserver/activerecord-sqlserver-adapter/builds/32856253/job/aymtvlvjfb3c9qon) both fail with `File does not exist: tiny_tds/tiny_tds` error. Allow these CIs to fail. They can be added as issues to be fixed later.

Allowing Ruby 27 and 27-x64 to fail as they are not installed on the AppVeyor Windows instance. See https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/32868782/job/vx7gopv5benhf8in

TinyTDS returns `false` instead of results if the database fails. Updated adapter to throw a `TinyTds::Error` if `false` returned by TinyTDS. This has resolved the `NoMethodError: undefined method do for false:FalseClass` CI errors on Windows (example of this error https://ci.appveyor.com/project/rails-sqlserver/activerecord-sqlserver-adapter/builds/32850932/job/gop6taxai5sblxgd). This issue is open in the TinyTDS project as https://github.com/rails-sqlserver/tiny_tds/issues/464

https://github.com/rails-sqlserver/tiny_tds/blob/7fb858045e8c918b81f8001dc46e3aafe7cbb2c3/ext/tiny_tds/client.c#L256