### PR TITLE
Adjust error message when connection is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#812](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/812) Rails 6: Coerce ReloadModelsTest test on Windows
 - [#818](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/818) Handle false return by TinyTDS if connection fails and fixed CI
 - [#819](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/819) Fix Ruby 2.7 kwargs warnings
+- [#825](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/825) Adjust error message when connection is dead
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -353,10 +353,12 @@ module ActiveRecord
           case @connection_options[:mode]
           when :dblib
             result = @connection.execute(sql)
-            # If connection fails then TinyTDS returns false instead of an exception (see https://github.com/rails-sqlserver/tiny_tds/issues/464)
-            if result == false
-              raise TinyTds::Error, 'TinyTDS execute returned false instead of results'
-            end
+
+            # TinyTDS returns false instead of raising an exception if connection fails.
+            # Getting around this by raising an exception ourselves while this PR
+            # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
+            raise TinyTds::Error, 'failed to execute statement' if result.is_a?(FalseClass)
+
             result.do
           end
         ensure


### PR DESCRIPTION
TinyTDS returns false instead of raising an exception if connection fails while
executing a query.

Getting around this by raising an exception ourselves while this PR
https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.

The solution came from #717 and #818, I am just adjusting the error
message to make it the same as that TinyTDS PR.