### PR TITLE
Rubocop: Enable Layout/EmptyLinesAroundClassBody cop

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       class SchemaCreation < AbstractAdapter::SchemaCreation
-
         private
 
         def visit_TableDefinition(o)
@@ -63,7 +62,6 @@ module ActiveRecord
         def options_primary_key_with_nil_default?(options)
           options[:primary_key] && options.include?(:default) && options[:default].nil?
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       class SchemaDumper < ConnectionAdapters::SchemaDumper
-
         SQLSEVER_NO_LIMIT_TYPES = [
           "text",
           "ntext",
@@ -32,7 +31,6 @@ module ActiveRecord
         def default_primary_key?(column)
           super && column.is_primary? && column.is_identity?
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/sql_type_metadata.rb
+++ b/lib/active_record/connection_adapters/sqlserver/sql_type_metadata.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       class SqlTypeMetadata < ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-
         def initialize(**kwargs)
           @sqlserver_options = kwargs.extract!(:sqlserver_options)
           super(**kwargs)
@@ -15,7 +14,6 @@ module ActiveRecord
         def attributes_for_hash
           super + [@sqlserver_options]
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/type/big_integer.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/big_integer.rb
@@ -5,11 +5,9 @@ module ActiveRecord
     module SQLServer
       module Type
         class BigInteger < Integer
-
           def sqlserver_type
             "bigint"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/binary.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/binary.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Binary < ActiveRecord::Type::Binary
-
           def type
             :binary_basic
           end
@@ -16,7 +15,6 @@ module ActiveRecord
               type
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/boolean.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/boolean.rb
@@ -5,11 +5,9 @@ module ActiveRecord
     module SQLServer
       module Type
         class Boolean < ActiveRecord::Type::Boolean
-
           def sqlserver_type
             "bit"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/char.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Char < String
-
           def type
             :char
           end
@@ -27,7 +26,6 @@ module ActiveRecord
             return value.quoted_id if value.respond_to?(:quoted_id)
             Utils.quote_string_single(value)
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/data.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/data.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Data
-
           attr_reader :value, :type
 
           def initialize(value, type)
@@ -29,7 +28,6 @@ module ActiveRecord
             self.class == other.class && self.value == other.value
           end
           alias :== :eql?
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/date.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/date.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Date < ActiveRecord::Type::Date
-
           def sqlserver_type
             "date"
           end
@@ -39,7 +38,6 @@ module ActiveRecord
           def fast_string_to_date_format
             ::Date::DATE_FORMATS[:_sqlserver_dateformat]
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class DateTime < ActiveRecord::Type::DateTime
-
           include TimeValueFractional
 
           def sqlserver_type

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime2.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime2.rb
@@ -5,13 +5,11 @@ module ActiveRecord
     module SQLServer
       module Type
         class DateTime2 < DateTime
-
           include TimeValueFractional2
 
           def sqlserver_type
             "datetime2(#{precision.to_i})"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetimeoffset.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class DateTimeOffset < DateTime2
-
           def type
             :datetimeoffset
           end
@@ -17,7 +16,6 @@ module ActiveRecord
           def quoted(value)
             Utils.quote_string_single(value)
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/decimal.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/decimal.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Decimal < ActiveRecord::Type::Decimal
-
           def sqlserver_type
             "decimal".yield_self do |type|
               type += "(#{precision.to_i},#{scale.to_i})" if precision || scale
@@ -16,7 +15,6 @@ module ActiveRecord
           def type_cast_for_schema(value)
             value.is_a?(BigDecimal) ? value.to_s : value.inspect
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/float.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/float.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Float < ActiveRecord::Type::Float
-
           def type
             :float
           end
@@ -13,7 +12,6 @@ module ActiveRecord
           def sqlserver_type
             "float"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/integer.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/integer.rb
@@ -5,11 +5,9 @@ module ActiveRecord
     module SQLServer
       module Type
         class Integer < ActiveRecord::Type::Integer
-
           def sqlserver_type
             "int"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/json.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/json.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Json < ActiveRecord::Type::Json
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/money.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/money.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Money < Decimal
-
           def initialize(**args)
             super
             @precision = 19
@@ -19,7 +18,6 @@ module ActiveRecord
           def sqlserver_type
             "money"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/real.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/real.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Real < Float
-
           def type
             :real
           end
@@ -13,7 +12,6 @@ module ActiveRecord
           def sqlserver_type
             "real"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/small_integer.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/small_integer.rb
@@ -5,11 +5,9 @@ module ActiveRecord
     module SQLServer
       module Type
         class SmallInteger < Integer
-
           def sqlserver_type
             "smallint"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/small_money.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/small_money.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class SmallMoney < Money
-
           def initialize(**args)
             super
             @precision = 10
@@ -19,7 +18,6 @@ module ActiveRecord
           def sqlserver_type
             "smallmoney"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/smalldatetime.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class SmallDateTime < DateTime
-
           def type
             :smalldatetime
           end
@@ -23,7 +22,6 @@ module ActiveRecord
           def apply_seconds_precision(value)
             value.change usec: 0 if value
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/string.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/string.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class String < ActiveRecord::Type::String
-
           def changed_in_place?(raw_old_value, new_value)
             if raw_old_value.is_a?(Data)
               raw_old_value.value != new_value
@@ -13,7 +12,6 @@ module ActiveRecord
               super
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/text.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/text.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Text < VarcharMax
-
           def type
             :text_basic
           end
@@ -13,7 +12,6 @@ module ActiveRecord
           def sqlserver_type
             "text"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Time < ActiveRecord::Type::Time
-
           include TimeValueFractional2
 
           def serialize(value)
@@ -45,7 +44,6 @@ module ActiveRecord
           def fractional_scale
             precision
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/timestamp.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/timestamp.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Timestamp < Binary
-
           def type
             :ss_timestamp
           end
@@ -13,7 +12,6 @@ module ActiveRecord
           def sqlserver_type
             "timestamp"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/tiny_integer.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/tiny_integer.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class TinyInteger < Integer
-
           def sqlserver_type
             "tinyint"
           end
@@ -19,7 +18,6 @@ module ActiveRecord
           def min_value
             0
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_char.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_char.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class UnicodeChar < UnicodeString
-
           def type
             :nchar
           end
@@ -16,7 +15,6 @@ module ActiveRecord
               type
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_string.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_string.rb
@@ -5,8 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class UnicodeString < String
-
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_text.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_text.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class UnicodeText < UnicodeVarcharMax
-
           def type
             :ntext
           end
@@ -13,7 +12,6 @@ module ActiveRecord
           def sqlserver_type
             "ntext"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class UnicodeVarchar < UnicodeChar
-
           def initialize(**args)
             super
             @limit = 4000 if @limit.to_i == 0
@@ -21,7 +20,6 @@ module ActiveRecord
               type
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/unicode_varchar_max.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class UnicodeVarcharMax < UnicodeVarchar
-
           def initialize(**args)
             super
             @limit = 2_147_483_647
@@ -18,7 +17,6 @@ module ActiveRecord
           def sqlserver_type
             "nvarchar(max)"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/uuid.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/uuid.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Uuid < String
-
           ACCEPTABLE_UUID = %r{\A\{?([a-fA-F0-9]{4}-?){8}\}?\z}x
 
           alias_method :serialize, :deserialize
@@ -30,7 +29,6 @@ module ActiveRecord
           def quoted(value)
             Utils.quote_string_single(value) if value
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/varbinary.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varbinary.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Varbinary < Binary
-
           def initialize(**args)
             super
             @limit = 8000 if @limit.to_i == 0
@@ -21,7 +20,6 @@ module ActiveRecord
               type
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/varbinary_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varbinary_max.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class VarbinaryMax < Varbinary
-
           def initialize(**args)
             super
             @limit = 2_147_483_647
@@ -18,7 +17,6 @@ module ActiveRecord
           def sqlserver_type
             "varbinary(max)"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/varchar.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varchar.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class Varchar < Char
-
           def initialize(**args)
             super
             @limit = 8000 if @limit.to_i == 0
@@ -21,7 +20,6 @@ module ActiveRecord
               type
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/type/varchar_max.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/varchar_max.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module Type
         class VarcharMax < Varchar
-
           def initialize(**args)
             super
             @limit = 2_147_483_647
@@ -18,7 +17,6 @@ module ActiveRecord
           def sqlserver_type
             "varchar(max)"
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -13,7 +13,6 @@ module ActiveRecord
         # Inspiried from Rails PostgreSQL::Name adapter object in their own Utils.
         #
         class Name
-
           SEPARATOR = "."
           UNQUOTED_SCANNER = /\]?\./
           QUOTED_SCANNER   = /\A\[.*?\]\./
@@ -113,7 +112,6 @@ module ActiveRecord
           def parts
             @parts
           end
-
         end
 
         extend self

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -34,7 +34,6 @@ require "active_record/tasks/sqlserver_database_tasks"
 module ActiveRecord
   module ConnectionAdapters
     class SQLServerAdapter < AbstractAdapter
-
       include SQLServer::Version,
               SQLServer::Quoting,
               SQLServer::DatabaseStatements,

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -3,7 +3,6 @@
 module ActiveRecord
   module ConnectionAdapters
     class SQLServerColumn < Column
-
       def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, **sqlserver_options)
         @sqlserver_options = sqlserver_options
         super
@@ -28,7 +27,6 @@ module ActiveRecord
       def case_sensitive?
         collation && collation.match(/_CS/)
       end
-
     end
   end
 end

--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -9,7 +9,6 @@ module ActiveRecord
   module Tasks
 
     class SQLServerDatabaseTasks
-
       DEFAULT_COLLATION = "SQL_Latin1_General_CP1_CI_AS"
 
       delegate :connection, :establish_connection, :clear_active_connections!,
@@ -93,7 +92,6 @@ module ActiveRecord
       def establish_master_connection
         establish_connection configuration.merge("database" => "master")
       end
-
     end
 
     module DatabaseTasksSQLServer

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -3,7 +3,6 @@
 module Arel
   module Visitors
     class SQLServer < Arel::Visitors::ToSql
-
       OFFSET = " OFFSET "
       ROWS = " ROWS"
       FETCH = " FETCH NEXT "

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -8,7 +8,6 @@ require "models/subscriber"
 require "models/minimalistic"
 
 class AdapterTestSQLServer < ActiveRecord::TestCase
-
   fixtures :tasks
 
   let(:basic_insert_sql) { "INSERT INTO [funny_jokes] ([name]) VALUES('Knock knock')" }
@@ -492,6 +491,5 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       end
     end
   end
-
 end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -580,7 +580,6 @@ module ActiveRecord
         end
       end
     end
-
   end
 
   class DatabaseTasksCollationTest < ActiveRecord::TestCase
@@ -1533,7 +1532,6 @@ end
 
 require "models/task"
 class QueryCacheExpiryTest < ActiveRecord::TestCase
-
   # SQL Server does not support skipping or upserting duplicates.
   coerce_tests! :test_insert_all
   def test_insert_all_coerced

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class ColumnTestSQLServer < ActiveRecord::TestCase
-
   it "#table_name" do
     assert SSTestDatatype.columns.all? { |c| c.table_name == "sst_datatypes" }
     assert SSTestCustomersView.columns.all? { |c| c.table_name == "customers" }
@@ -838,5 +837,4 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
   end
-
 end

--- a/test/cases/connection_test_sqlserver.rb
+++ b/test/cases/connection_test_sqlserver.rb
@@ -5,7 +5,6 @@ require "models/reply"
 require "models/topic"
 
 class ConnectionTestSQLServer < ActiveRecord::TestCase
-
   self.use_transactional_tests = false
 
   fixtures :topics, :accounts
@@ -69,5 +68,4 @@ class ConnectionTestSQLServer < ActiveRecord::TestCase
       connection.raw_connection.close rescue nil
     end
   end
-
 end

--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
-
   it "execute a simple procedure" do
     tables = ActiveRecord::Base.execute_procedure :sp_tables
     assert_instance_of Array, tables
@@ -42,5 +41,4 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
     date_base = connection.select_value("select GETUTCDATE()")
     assert_equal date_base.change(usec: 0), date_proc.change(usec: 0)
   end
-
 end

--- a/test/cases/fetch_test_sqlserver.rb
+++ b/test/cases/fetch_test_sqlserver.rb
@@ -4,7 +4,6 @@ require "cases/helper_sqlserver"
 require "models/book"
 
 class FetchTestSqlserver < ActiveRecord::TestCase
-
   let(:books) { @books }
 
   before { create_10_books }
@@ -54,6 +53,5 @@ class FetchTestSqlserver < ActiveRecord::TestCase
     Book.delete_all
     @books = (1..10).map { |i| Book.create! name: "Name-#{i}" }
   end
-
 end
 

--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
-
   describe "local server" do
 
     it "should use table name in select projections" do
@@ -74,5 +73,4 @@ class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
     end
 
   end
-
 end

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -16,7 +16,6 @@ require "mocha/minitest"
 
 module ActiveRecord
   class TestCase < ActiveSupport::TestCase
-
     SQLServer = ActiveRecord::ConnectionAdapters::SQLServer
 
     include ARTest::SQLServer::CoerceableTest,
@@ -50,7 +49,6 @@ module ActiveRecord
     ensure
       klass.use_output_inserted = true
     end
-
   end
 end
 

--- a/test/cases/index_test_sqlserver.rb
+++ b/test/cases/index_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class IndexTestSQLServer < ActiveRecord::TestCase
-
   before do
     connection.create_table(:testings) do |t|
       t.column :foo, :string, limit: 100
@@ -45,5 +44,4 @@ class IndexTestSQLServer < ActiveRecord::TestCase
     connection.execute "ALTER TABLE [testings] ADD [first_name_upper] AS UPPER([first_name])"
     connection.add_index "testings", "first_name_upper"
   end
-
 end

--- a/test/cases/json_test_sqlserver.rb
+++ b/test/cases/json_test_sqlserver.rb
@@ -4,7 +4,6 @@ require "cases/helper_sqlserver"
 
 if ActiveRecord::Base.connection.supports_json?
 class JsonTestSQLServer < ActiveRecord::TestCase
-
   before do
     @o1 = SSTestDatatypeMigrationJson.create! json_col: { "a" => "a", "b" => "b", "c" => "c" }
     @o2 = SSTestDatatypeMigrationJson.create! json_col: { "a" => nil, "b" => "b", "c" => "c" }
@@ -29,6 +28,5 @@ class JsonTestSQLServer < ActiveRecord::TestCase
   it "can use JSON_VALUE function" do
     _(SSTestDatatypeMigrationJson.where("JSON_VALUE(json_col, '$.b') = 'b'").count).must_equal 2
   end
-
 end
 end

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -4,7 +4,6 @@ require "cases/helper_sqlserver"
 require "models/person"
 
 class MigrationTestSQLServer < ActiveRecord::TestCase
-
   describe "For transactions" do
 
     before do
@@ -69,5 +68,4 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
     end
 
   end
-
 end

--- a/test/cases/order_test_sqlserver.rb
+++ b/test/cases/order_test_sqlserver.rb
@@ -4,7 +4,6 @@ require "cases/helper_sqlserver"
 require "models/post"
 
 class OrderTestSQLServer < ActiveRecord::TestCase
-
   fixtures :posts
 
   it "not mangel complex order clauses" do
@@ -144,6 +143,4 @@ class OrderTestSQLServer < ActiveRecord::TestCase
     assert_equal post1, Post.order(Arel.sql(order)).first
     assert_equal post2, Post.order(Arel.sql(order)).second
   end
-
-
 end

--- a/test/cases/pessimistic_locking_test_sqlserver.rb
+++ b/test/cases/pessimistic_locking_test_sqlserver.rb
@@ -5,7 +5,6 @@ require "models/person"
 require "models/reader"
 
 class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
-
   fixtures :people, :readers
 
   before do
@@ -105,5 +104,4 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
     end
 
   end
-
 end

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class SQLServerRakeTest < ActiveRecord::TestCase
-
   self.use_transactional_tests = false
 
   cattr_accessor :azure_skip
@@ -36,11 +35,9 @@ class SQLServerRakeTest < ActiveRecord::TestCase
       connection.drop_database(new_database) rescue nil
     end
   end
-
 end
 
 class SQLServerRakeCreateTest < SQLServerRakeTest
-
   self.azure_skip = false
 
   it "establishes connection to database after create " do
@@ -63,11 +60,9 @@ class SQLServerRakeCreateTest < SQLServerRakeTest
     message = capture(:stderr) { db_tasks.create configuration }
     _(message).must_match %r{activerecord_unittest_tasks.*already exists}
   end
-
 end
 
 class SQLServerRakeDropTest < SQLServerRakeTest
-
   self.azure_skip = false
 
   it "drops database and uses master" do
@@ -82,11 +77,9 @@ class SQLServerRakeDropTest < SQLServerRakeTest
     message = capture(:stderr) { db_tasks.drop configuration.merge("database" => "doesnotexist") }
     _(message).must_match %r{'doesnotexist' does not exist}
   end
-
 end
 
 class SQLServerRakePurgeTest < SQLServerRakeTest
-
   before do
     quietly { db_tasks.create(configuration) }
     connection.create_table :users, force: true do |t|
@@ -102,11 +95,9 @@ class SQLServerRakePurgeTest < SQLServerRakeTest
     _(connection.current_database).must_equal(new_database)
     _(connection.tables).wont_include "users"
   end
-
 end
 
 class SQLServerRakeCharsetTest < SQLServerRakeTest
-
   before do
     quietly { db_tasks.create(configuration) }
   end
@@ -114,11 +105,9 @@ class SQLServerRakeCharsetTest < SQLServerRakeTest
   it "retrieves charset" do
     _(db_tasks.charset(configuration)).must_equal "iso_1"
   end
-
 end
 
 class SQLServerRakeCollationTest < SQLServerRakeTest
-
   before do
     quietly { db_tasks.create(configuration) }
   end
@@ -126,11 +115,9 @@ class SQLServerRakeCollationTest < SQLServerRakeTest
   it "retrieves collation" do
     _(db_tasks.collation(configuration)).must_equal "SQL_Latin1_General_CP1_CI_AS"
   end
-
 end
 
 class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
-
   let(:filename) { File.join ARTest::SQLServer.migrations_root, "structure.sql" }
   let(:filedata) { File.read(filename) }
 
@@ -167,5 +154,4 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
     db_tasks.load_schema configuration, :sql, filename
     _(connection.tables).must_include "users"
   end
-
 end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class SchemaDumperTestSQLServer < ActiveRecord::TestCase
-
   before { all_tables }
 
   let(:all_tables)   { ActiveRecord::Base.connection.tables }
@@ -182,7 +181,6 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
   end
 
   class SchemaLine
-
     LINE_PARSER = %r{t\.(\w+)\s+"(.*?)"[,\s+](.*)}
 
     attr_reader :line,
@@ -230,8 +228,6 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     rescue SyntaxError
       {}
     end
-
   end
-
 end
 

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class SchemaTestSQLServer < ActiveRecord::TestCase
-
   describe "When table is dbo schema" do
 
     it "find primary key for tables with odd schema" do
@@ -50,7 +49,5 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
     end
 
   end
-
-
 end
 

--- a/test/cases/scratchpad_test_sqlserver.rb
+++ b/test/cases/scratchpad_test_sqlserver.rb
@@ -3,8 +3,6 @@
 require "cases/helper_sqlserver"
 
 class ScratchpadTestSQLServer < ActiveRecord::TestCase
-
   it "helps debug things" do
   end
-
 end

--- a/test/cases/showplan_test_sqlserver.rb
+++ b/test/cases/showplan_test_sqlserver.rb
@@ -4,7 +4,6 @@ require "cases/helper_sqlserver"
 require "models/car"
 
 class ShowplanTestSQLServer < ActiveRecord::TestCase
-
   fixtures :cars
 
   describe "Unprepare previously prepared SQL" do
@@ -75,5 +74,4 @@ class ShowplanTestSQLServer < ActiveRecord::TestCase
   ensure
     ActiveRecord::ConnectionAdapters::SQLServerAdapter.showplan_option = old_option
   end
-
 end

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
-
   after { SSTestEdgeSchema.delete_all }
 
   it "handle dollar symbols" do
@@ -168,5 +167,4 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
     assert_equal "field_1", connection.columns("test.sst_schema_test_mulitple_schema").detect(&:is_primary?).name
     assert_equal "field_2", connection.columns("test2.sst_schema_test_mulitple_schema").detect(&:is_primary?).name
   end
-
 end

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -5,7 +5,6 @@ require "models/ship"
 require "models/developer"
 
 class TransactionTestSQLServer < ActiveRecord::TestCase
-
   self.use_transactional_tests = false
 
   before { delete_ships }
@@ -88,5 +87,4 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
   def assert_no_ships
     assert Ship.count.zero?, "Expected Ship to have no models but it did have:\n#{Ship.all.inspect}"
   end
-
 end

--- a/test/cases/utils_test_sqlserver.rb
+++ b/test/cases/utils_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class UtilsTestSQLServer < ActiveRecord::TestCase
-
   it ".quote_string" do
     _(SQLServer::Utils.quote_string("I'll store this in C:\\Users")).must_equal "I''ll store this in C:\\Users"
   end
@@ -127,5 +126,4 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
   def extract_identifiers(name)
     SQLServer::Utils.extract_identifiers(name)
   end
-
 end

--- a/test/cases/uuid_test_sqlserver.rb
+++ b/test/cases/uuid_test_sqlserver.rb
@@ -3,7 +3,6 @@
 require "cases/helper_sqlserver"
 
 class SQLServerUuidTest < ActiveRecord::TestCase
-
   let(:acceptable_uuid) { ActiveRecord::ConnectionAdapters::SQLServer::Type::Uuid::ACCEPTABLE_UUID }
 
   it "has a uuid primary key" do
@@ -44,5 +43,4 @@ class SQLServerUuidTest < ActiveRecord::TestCase
     obj = with_use_output_inserted_disabled { SSTestUuid.create!(name: "😢") }
     _(obj.id).must_be :nil?
   end
-
 end

--- a/test/migrations/transaction_table/1_table_will_never_be_created.rb
+++ b/test/migrations/transaction_table/1_table_will_never_be_created.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class TableWillNeverBeCreated < ActiveRecord::Migration
-
   def self.up
     create_table(:sqlserver_trans_table1) {  }
     create_table(:sqlserver_trans_table2) { raise("HELL") }
@@ -9,5 +8,4 @@ class TableWillNeverBeCreated < ActiveRecord::Migration
 
   def self.down
   end
-
 end

--- a/test/models/sqlserver/edge_schema.rb
+++ b/test/models/sqlserver/edge_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class SSTestEdgeSchema < ActiveRecord::Base
-
   self.table_name = "sst_edge_schemas"
 
   def with_spaces
@@ -11,5 +10,4 @@ class SSTestEdgeSchema < ActiveRecord::Base
   def with_spaces=(value)
     write_attribute :'with spaces', value
   end
-
 end


### PR DESCRIPTION
Following #826, this PR enables `Layout/EmptyLinesAroundClassBody` cop and fixes all existing offenses.

