### PR TITLE
Rubocop: Enable Layout/Layout/EmptyLinesAround* cops

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,22 +9,18 @@ task test: ["test:dblib"]
 task default: [:test]
 
 namespace :test do
-
   %w(dblib).each do |mode|
-
     Rake::TestTask.new(mode) do |t|
       t.libs = ARTest::SQLServer.test_load_paths
       t.test_files = test_files
       t.warning = !!ENV["WARNING"]
       t.verbose = false
     end
-
   end
 
   task "dblib:env" do
     ENV["ARCONN"] = "dblib"
   end
-
 end
 
 task "test:dblib" => "test:dblib:env"

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/active_record.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/active_record.rb
@@ -5,11 +5,9 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module ActiveRecord
-
           extend ActiveSupport::Concern
 
           module ClassMethods
-
             def execute_procedure(proc_name, *variables)
               if connection.respond_to?(:execute_procedure)
                 connection.execute_procedure(proc_name, *variables)
@@ -17,9 +15,7 @@ module ActiveRecord
                 []
               end
             end
-
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
@@ -7,7 +7,6 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module AttributeMethods
-
           private
 
           def attributes_for_update(attribute_names)
@@ -16,7 +15,6 @@ module ActiveRecord
               column && column.respond_to?(:is_identity?) && column.is_identity?
             end
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -8,7 +8,6 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module Calculations
-
           # Same as original except we don't perform PostgreSQL hack that removes ordering.
           def calculate(operation, column_name)
             if has_include?(column_name)

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -5,7 +5,6 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module Explain
-
           SQLSERVER_STATEMENT_PREFIX = "EXEC sp_executesql "
           SQLSERVER_STATEMENT_REGEXP = /N'(.+)', N'(.+)', (.+)/
 
@@ -34,7 +33,6 @@ module ActiveRecord
 
             executesql
           end
-
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
@@ -8,7 +8,6 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module FinderMethods
-
           private
 
           # Same as original except we order by values in distinct select if present.

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/query_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/query_methods.rb
@@ -8,7 +8,6 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module QueryMethods
-
           private
 
           # Copy of original from Rails master.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -454,7 +454,6 @@ module ActiveRecord
           end
           handle
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module DatabaseTasks
-
         def create_database(database, options = {})
           name = SQLServer::Utils.extract_identifiers(database)
           db_options = create_database_options(options)
@@ -60,7 +59,6 @@ module ActiveRecord
           edition_options = "( #{edition_options} )" if edition_options.present?
           edition_options
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/errors.rb
+++ b/lib/active_record/connection_adapters/sqlserver/errors.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-
   class DeadlockVictim < WrappedDatabaseException
   end
-
 end

--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module Quoting
-
         QUOTED_TRUE  = "1".freeze
         QUOTED_FALSE = "0".freeze
         QUOTED_STRING_PREFIX = "N".freeze
@@ -130,7 +129,6 @@ module ActiveRecord
             super
           end
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -4,7 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module SchemaStatements
-
         def native_database_types
           @native_database_types ||= initialize_native_database_types.freeze
         end
@@ -561,7 +560,6 @@ module ActiveRecord
         def create_table_definition(*args, **options)
           SQLServer::TableDefinition.new(self, *args, **options)
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/showplan.rb
+++ b/lib/active_record/connection_adapters/sqlserver/showplan.rb
@@ -7,7 +7,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module Showplan
-
         OPTION_ALL  = "SHOWPLAN_ALL"
         OPTION_TEXT = "SHOWPLAN_TEXT"
         OPTION_XML  = "SHOWPLAN_XML"
@@ -61,7 +60,6 @@ module ActiveRecord
           else PrinterTable
           end
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -3,9 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-
       module ColumnMethods
-
         def primary_key(name, type = :primary_key, **options)
           if [:integer, :bigint].include?(type)
             options[:is_identity] = true unless options.key?(:default)
@@ -97,7 +95,6 @@ module ActiveRecord
         def json(*names, **options)
           names.each { |name| column(name, :text, **options) }
         end
-
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -4,9 +4,7 @@ require "active_record/connection_adapters/abstract/transaction"
 
 module ActiveRecord
   module ConnectionAdapters
-
     module SQLServerTransaction
-
       private
 
       def sqlserver?
@@ -25,13 +23,11 @@ module ActiveRecord
           level.upcase
         end
       end
-
     end
 
     Transaction.send :prepend, SQLServerTransaction
 
     module SQLServerRealTransaction
-
       attr_reader :starting_isolation_level
 
       def initialize(connection, options, **args)
@@ -57,7 +53,6 @@ module ActiveRecord
           connection.set_transaction_isolation_level(starting_isolation_level)
         end
       end
-
     end
 
     RealTransaction.send :prepend, SQLServerRealTransaction

--- a/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
@@ -4,9 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module Type
-
         module TimeValueFractional
-
           private
 
           def apply_seconds_precision(value)
@@ -47,11 +45,9 @@ module ActiveRecord
           def fractional_scale
             3
           end
-
         end
 
         module TimeValueFractional2
-
           include TimeValueFractional
 
           private
@@ -84,9 +80,7 @@ module ActiveRecord
           def fractional_scale_max
             ("9" * fractional_scale) + ("0" * (fractional_digits - fractional_scale))
           end
-
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -6,7 +6,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module Utils
-
         QUOTED_STRING_PREFIX = "N"
 
         # Value object to return identifiers from SQL Server names http://bit.ly/1CZ3EiL
@@ -139,7 +138,6 @@ module ActiveRecord
         def extract_identifiers(name)
           SQLServer::Utils::Name.new(name)
         end
-
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/version.rb
+++ b/lib/active_record/connection_adapters/sqlserver/version.rb
@@ -4,9 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module Version
-
         VERSION = File.read(File.expand_path("../../../../../VERSION", __FILE__)).chomp
-
       end
     end
   end

--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -7,7 +7,6 @@ require "socket"
 
 module ActiveRecord
   module Tasks
-
     class SQLServerDatabaseTasks
       DEFAULT_COLLATION = "SQL_Latin1_General_CP1_CI_AS"
 
@@ -94,11 +93,9 @@ module ActiveRecord
     end
 
     module DatabaseTasksSQLServer
-
       extend ActiveSupport::Concern
 
       module ClassMethods
-
         LOCAL_IPADDR = [
           IPAddr.new("192.168.0.0/16"),
           IPAddr.new("10.0.0.0/8"),
@@ -120,13 +117,10 @@ module ActiveRecord
           return false unless host_ip
           LOCAL_IPADDR.any? { |ip| ip.include?(host_ip) }
         end
-
       end
-
     end
 
     DatabaseTasks.register_task %r{sqlserver}, SQLServerDatabaseTasks
     DatabaseTasks.send :include, DatabaseTasksSQLServer
-
   end
 end

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -86,7 +86,6 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
   end
 
   describe "with different language" do
-
     before do
       @default_language = connection.user_options_language
     end
@@ -116,11 +115,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
         Task.create! starting: starting, ending: ending
       end
     end
-
   end
 
   describe "testing #lowercase_schema_reflection" do
-
     before do
       SSTestUpper.delete_all
       SSTestUpper.create COLUMN1: "Got a minute?", COLUMN2: 419
@@ -145,11 +142,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal "Favorite number?", SSTestUppered.last.column1
       assert SSTestUppered.columns_hash["column2"]
     end
-
   end
 
   describe "identity inserts" do
-
     before do
       @identity_insert_sql = "INSERT INTO [funny_jokes] ([id],[name]) VALUES(420,'Knock knock')"
       @identity_insert_sql_unquoted = "INSERT INTO funny_jokes (id, name) VALUES(420, 'Knock knock')"
@@ -183,11 +178,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     it "return an empty array when calling #identity_columns for a table_name with no identity" do
       _(connection.send(:identity_columns, Subscriber.table_name)).must_equal []
     end
-
   end
 
   describe "quoting" do
-
     it "return 1 for #quoted_true" do
       assert_equal "1", connection.quoted_true
     end
@@ -224,11 +217,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     it "escape all single quotes by repeating them" do
       assert_equal "N'''quotation''s'''", connection.quote("'quotation's'")
     end
-
   end
 
   describe "disabling referential integrity" do
-
     before do
       connection.disable_referential_integrity { SSTestHasPk.delete_all; SSTestHasFk.delete_all }
       @parent = SSTestHasPk.create!
@@ -255,11 +246,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       tables = SSTestHasPk.connection.tables_with_referential_integrity
       assert_equal tables.size, tables.uniq.size
     end
-
   end
 
   describe "database statements" do
-
     it "run the database consistency checker useroptions command" do
       skip "on azure" if connection_sqlserver_azure?
       keys = [:textsize, :language, :isolation_level, :dateformat]
@@ -276,11 +265,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal "read committed", user_options["isolation_level"]
       assert_equal "read committed", user_options[:isolation_level]
     end
-
   end
 
   describe "schema statements" do
-
     it "create integers when no limit supplied" do
       assert_equal "integer", connection.type_to_sql(:integer)
     end
@@ -311,11 +298,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     it "create floats when no limit supplied" do
       assert_equal "float", connection.type_to_sql(:float)
     end
-
   end
 
   describe "views" do
-
     # Using connection.views
 
     it "return an array" do
@@ -415,11 +400,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal "null", SSTestStringDefaultsBigView.new.pretend_null,
         SSTestStringDefaultsBigView.columns_hash["pretend_null"].inspect
     end
-
   end
 
   describe "database_prefix_remote_server?" do
-
     after do
       connection_options.delete(:database_prefix)
     end
@@ -437,7 +420,6 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       connection_options[:database_prefix] = "server.database.schema"
       assert_equal false, connection.database_prefix_remote_server?
     end
-
   end
 
   it "in_memory_oltp" do

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -9,7 +9,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
   end
 
   describe "ActiveRecord::ConnectionAdapters::SQLServer::Type" do
-
     let(:obj) { SSTestDatatype.new }
 
     Type = ActiveRecord::ConnectionAdapters::SQLServer::Type
@@ -835,6 +834,5 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       obj.attributes
       _(obj.changed?).must_equal false
     end
-
   end
 end

--- a/test/cases/connection_test_sqlserver.rb
+++ b/test/cases/connection_test_sqlserver.rb
@@ -35,7 +35,6 @@ class ConnectionTestSQLServer < ActiveRecord::TestCase
   end unless connection_sqlserver_azure?
 
   describe "Connection management" do
-
     it "set spid on connect" do
       _(["Fixnum", "Integer"]).must_include connection.spid.class.name
     end
@@ -56,7 +55,6 @@ class ConnectionTestSQLServer < ActiveRecord::TestCase
       connection.reconnect!
       assert connection.active?
     end
-
   end
 
   private

--- a/test/cases/fetch_test_sqlserver.rb
+++ b/test/cases/fetch_test_sqlserver.rb
@@ -14,7 +14,6 @@ class FetchTestSqlserver < ActiveRecord::TestCase
   end
 
   describe "count" do
-
     it "gauntlet" do
       books[0].destroy
       books[1].destroy
@@ -30,11 +29,9 @@ class FetchTestSqlserver < ActiveRecord::TestCase
       assert_equal 0, Book.limit(3).offset(7).count
       assert_equal 0, Book.limit(3).offset(8).count
     end
-
   end
 
   describe "order" do
-
     it "gauntlet" do
       Book.where(name:"Name-10").delete_all
       _(Book.order(:name).limit(1).offset(1).map(&:name)).must_equal ["Name-2"]
@@ -43,7 +40,6 @@ class FetchTestSqlserver < ActiveRecord::TestCase
       _(Book.order(:name).limit(3).offset(7).map(&:name)).must_equal ["Name-8", "Name-9"]
       _(Book.order(:name).limit(3).offset(9).map(&:name)).must_equal []
     end
-
   end
 
   protected

--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -4,17 +4,14 @@ require "cases/helper_sqlserver"
 
 class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
   describe "local server" do
-
     it "should use table name in select projections" do
       table = Arel::Table.new(:table)
       expected_sql = "SELECT [table].[name] FROM [table]"
       assert_equal expected_sql, table.project(table[:name]).to_sql
     end
-
   end
 
   describe "remote server" do
-
     before do
       connection_options[:database_prefix] = "[my.server].db.schema."
     end
@@ -71,6 +68,5 @@ class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
       expected_sql = "DELETE FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
       quietly { assert_equal expected_sql, manager.to_sql }
     end
-
   end
 end

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -5,7 +5,6 @@ require "models/person"
 
 class MigrationTestSQLServer < ActiveRecord::TestCase
   describe "For transactions" do
-
     before do
       @trans_test_table1 = "sqlserver_trans_table1"
       @trans_test_table2 = "sqlserver_trans_table2"
@@ -28,11 +27,9 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
       _(connection.tables).wont_include @trans_test_table1
       _(connection.tables).wont_include @trans_test_table2
     end
-
   end
 
   describe "For changing column" do
-
     it "not raise exception when column contains default constraint" do
       lock_version_column = Person.columns_hash["lock_version"]
       assert_equal :integer, lock_version_column.type
@@ -66,6 +63,5 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
     it "change null and default" do
       assert_nothing_raised { connection.change_column :people, :first_name, :text, null: true, default: nil }
     end
-
   end
 end

--- a/test/cases/pessimistic_locking_test_sqlserver.rb
+++ b/test/cases/pessimistic_locking_test_sqlserver.rb
@@ -19,7 +19,6 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
   end
 
   describe "For simple finds with default lock option" do
-
     it "lock with simple find" do
       assert_nothing_raised do
         Person.transaction do
@@ -54,7 +53,6 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
     end
 
     describe "joining tables" do
-
       it "joined tables use updlock by default" do
         assert_sql %r|SELECT \[people\]\.\* FROM \[people\] WITH\(UPDLOCK\) INNER JOIN \[readers\] WITH\(UPDLOCK\)\s+ON \[readers\]\.\[person_id\] = \[people\]\.\[id\]| do
           Person.lock(true).joins(:readers).load
@@ -78,13 +76,10 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
           Person.lock("WITH(NOLOCK)").left_joins(:readers).load
         end
       end
-
     end
-
   end
 
   describe "For paginated finds" do
-
     before do
       Person.delete_all
       20.times { |n| Person.create!(first_name: "Thing_#{n}") }
@@ -102,6 +97,5 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
         _(people[4].first_name).must_equal "Thing_14"
       end
     end
-
   end
 end

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -4,15 +4,12 @@ require "cases/helper_sqlserver"
 
 class SchemaTestSQLServer < ActiveRecord::TestCase
   describe "When table is dbo schema" do
-
     it "find primary key for tables with odd schema" do
       _(connection.primary_key("sst_natural_pk_data")).must_equal "legacy_id"
     end
-
   end
 
   describe "When table is in non-dbo schema" do
-
     it "work with table exists" do
       assert connection.data_source_exists?("test.sst_schema_natural_id")
       assert connection.data_source_exists?("[test].[sst_schema_natural_id]")
@@ -47,7 +44,6 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       assert_equal 255, columns.find {|c| c.name == "n_name"}.limit
       assert_equal 1000, columns.find {|c| c.name == "n_description"}.limit
     end
-
   end
 end
 

--- a/test/cases/showplan_test_sqlserver.rb
+++ b/test/cases/showplan_test_sqlserver.rb
@@ -7,7 +7,6 @@ class ShowplanTestSQLServer < ActiveRecord::TestCase
   fixtures :cars
 
   describe "Unprepare previously prepared SQL" do
-
     it "from simple statement" do
       plan = Car.where(id: 1).explain
       _(plan).must_include "SELECT [cars].* FROM [cars] WHERE [cars].[id] = 1"
@@ -38,11 +37,9 @@ class ShowplanTestSQLServer < ActiveRecord::TestCase
       _(plan).must_include " SELECT [cars].* FROM [cars] WHERE [cars].[name] IN (N'honda', N'zyke')"
       _(plan).must_include "Clustered Index Scan", "make sure we do not showplan the sp_executesql"
     end
-
   end
 
   describe "With SHOWPLAN_TEXT option" do
-
     it "use simple table printer" do
       with_showplan_option("SHOWPLAN_TEXT") do
         plan = Car.where(id: 1).explain
@@ -50,18 +47,15 @@ class ShowplanTestSQLServer < ActiveRecord::TestCase
         _(plan).must_include "Clustered Index Seek", "make sure we do not showplan the sp_executesql"
       end
     end
-
   end
 
   describe "With SHOWPLAN_XML option" do
-
     it "show formatted xml" do
       with_showplan_option("SHOWPLAN_XML") do
         plan = Car.where(id: 1).explain
         _(plan).must_include "ShowPlanXML"
       end
     end
-
   end
 
   private

--- a/test/cases/utils_test_sqlserver.rb
+++ b/test/cases/utils_test_sqlserver.rb
@@ -16,7 +16,6 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
   end
 
   describe ".extract_identifiers constructor and thus SQLServer::Utils::Name value object" do
-
     let(:valid_names) { valid_names_unquoted + valid_names_quoted }
 
     let(:valid_names_unquoted) {[
@@ -54,7 +53,6 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
     end
 
     [:schema, :database, :server].each do |part|
-
       it "extracts and returns #{part} identifier unquoted by default or quoted as needed" do
         present, blank = send(:"#{part}_names")
         present.each do |n|
@@ -68,7 +66,6 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
           _(name.send(:"#{part}_quoted")).must_be_nil "With #{n.inspect} for ##{part}_quoted method"
         end
       end
-
     end
 
     it "does not blow up on nil or blank string name" do
@@ -118,7 +115,6 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
       name = extract_identifiers("server.database.schema.object")
       _(name.fully_qualified_database_quoted).must_equal "[server].[database]"
     end
-
   end
 
   private

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-
   # Exhaustive Data Types
 
   execute File.read(ARTest::SQLServer.schema_datatypes_2012_file)
@@ -278,5 +277,4 @@ ActiveRecord::Schema.define do
       field_2 int NOT NULL PRIMARY KEY,
     )
   SCHEMATESTMULTIPLESCHEMA
-
 end

--- a/test/support/coerceable_test_sqlserver.rb
+++ b/test/support/coerceable_test_sqlserver.rb
@@ -3,7 +3,6 @@
 module ARTest
   module SQLServer
     module CoerceableTest
-
       extend ActiveSupport::Concern
 
       included do
@@ -12,7 +11,6 @@ module ARTest
       end
 
       module ClassMethods
-
         def coerce_tests!(*methods)
           methods.each do |method|
             self.coerced_tests.push(method)
@@ -50,9 +48,7 @@ module ARTest
             end
           end
         end
-
       end
-
     end
   end
 end

--- a/test/support/connection_reflection.rb
+++ b/test/support/connection_reflection.rb
@@ -3,7 +3,6 @@
 module ARTest
   module SQLServer
     module ConnectionReflection
-
       extend ActiveSupport::Concern
 
       included { extend ConnectionReflection }
@@ -29,7 +28,6 @@ module ARTest
       def connection_sqlserver_azure?
         connection.sqlserver_azure?
       end
-
     end
   end
 end

--- a/test/support/load_schema_sqlserver.rb
+++ b/test/support/load_schema_sqlserver.rb
@@ -2,7 +2,6 @@
 
 module ARTest
   module SQLServer
-
     extend self
 
     def schema_root
@@ -24,7 +23,6 @@ module ARTest
     ensure
       $stdout = original_stdout
     end
-
   end
 end
 

--- a/test/support/paths_sqlserver.rb
+++ b/test/support/paths_sqlserver.rb
@@ -2,7 +2,6 @@
 
 module ARTest
   module SQLServer
-
     extend self
 
     def root_sqlserver
@@ -44,7 +43,6 @@ module ARTest
     def arconfig_file_env!
       ENV["ARCONFIG"] = arconfig_file
     end
-
   end
 end
 

--- a/test/support/sql_counter_sqlserver.rb
+++ b/test/support/sql_counter_sqlserver.rb
@@ -2,16 +2,13 @@
 
 module ARTest
   module SQLServer
-
     module SqlCounterSqlserver
-
       # Only return the log vs. log_all
       def capture_sql_ss
         ActiveRecord::SQLCounter.clear_log
         yield
         ActiveRecord::SQLCounter.log.dup
       end
-
     end
 
     ignored_sql = [
@@ -26,6 +23,5 @@ module ARTest
 
     sqlcounter = ObjectSpace.each_object(ActiveRecord::SQLCounter).to_a.first
     sqlcounter.instance_variable_set :@ignore, Regexp.union(ignored_sql.push(sqlcounter.ignore))
-
   end
 end


### PR DESCRIPTION
Following #826, this PR enables `Layout/EmptyLinesAroundBlockBody` and `Layout/EmptyLinesAroundModuleBody` cops and fixes all existing offenses.