### PR TITLE
Rubocop: Enable Layout/IndentationWidth and Layout/TrailingWhitespace cops

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -143,7 +143,7 @@ module ActiveRecord
           column_object = schema_cache.columns(table_name).find { |c| c.name.to_s == column_name.to_s }
           without_constraints = options.key?(:default) || options.key?(:limit)
           default = if !options.key?(:default) && column_object
-            column_object.default
+                      column_object.default
           else
             options[:default]
           end
@@ -415,8 +415,8 @@ module ActiveRecord
 
         def column_definitions_sql(database, identifier)
           object_name = prepared_statements ? "@0" : quote(identifier.object)
-          schema_name = if identifier.schema.blank? 
-                          "schema_name()" 
+          schema_name = if identifier.schema.blank?
+                          "schema_name()"
                         else
                           prepared_statements ? "@1" : quote(identifier.schema)
                         end
@@ -506,7 +506,7 @@ module ActiveRecord
 
         def get_table_name(sql)
           tn = if sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(\s]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
-            Regexp.last_match[3] || Regexp.last_match[4]
+                 Regexp.last_match[3] || Regexp.last_match[4]
           elsif sql =~ /FROM\s+([^\(\s]+)\s*/i
             Regexp.last_match[1]
           else

--- a/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/datetime.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           def serialize(value)
             value = super
             return value unless value.acts_like?(:time)
-            
+
             datetime = "#{value.to_s(:_sqlserver_datetime)}.#{quote_fractional(value)}"
 
             Data.new datetime, self

--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -12,7 +12,7 @@ module ActiveRecord
             return value unless value.acts_like?(:time)
 
             time = "#{value.to_s(:_sqlserver_time)}.#{quote_fractional(value)}"
-            
+
             Data.new time, self
           end
 

--- a/test/cases/json_test_sqlserver.rb
+++ b/test/cases/json_test_sqlserver.rb
@@ -3,30 +3,30 @@
 require "cases/helper_sqlserver"
 
 if ActiveRecord::Base.connection.supports_json?
-class JsonTestSQLServer < ActiveRecord::TestCase
-  before do
-    @o1 = SSTestDatatypeMigrationJson.create! json_col: { "a" => "a", "b" => "b", "c" => "c" }
-    @o2 = SSTestDatatypeMigrationJson.create! json_col: { "a" => nil, "b" => "b", "c" => "c" }
-    @o3 = SSTestDatatypeMigrationJson.create! json_col: { "x" => 1, "y" => 2, "z" => 3 }
-    @o4 = SSTestDatatypeMigrationJson.create! json_col: { "array" => [1, 2, 3] }
-    @o5 = SSTestDatatypeMigrationJson.create! json_col: nil
-  end
+  class JsonTestSQLServer < ActiveRecord::TestCase
+    before do
+      @o1 = SSTestDatatypeMigrationJson.create! json_col: { "a" => "a", "b" => "b", "c" => "c" }
+      @o2 = SSTestDatatypeMigrationJson.create! json_col: { "a" => nil, "b" => "b", "c" => "c" }
+      @o3 = SSTestDatatypeMigrationJson.create! json_col: { "x" => 1, "y" => 2, "z" => 3 }
+      @o4 = SSTestDatatypeMigrationJson.create! json_col: { "array" => [1, 2, 3] }
+      @o5 = SSTestDatatypeMigrationJson.create! json_col: nil
+    end
 
-  it "can return and save JSON data" do
-    _(SSTestDatatypeMigrationJson.find(@o1.id).json_col).must_equal({ "a" => "a", "b" => "b", "c" => "c" })
-    @o1.json_col = { "a" => "a" }
-    _(@o1.json_col).must_equal({ "a" => "a" })
-    @o1.save!
-    _(@o1.reload.json_col).must_equal({ "a" => "a" })
-  end
+    it "can return and save JSON data" do
+      _(SSTestDatatypeMigrationJson.find(@o1.id).json_col).must_equal({ "a" => "a", "b" => "b", "c" => "c" })
+      @o1.json_col = { "a" => "a" }
+      _(@o1.json_col).must_equal({ "a" => "a" })
+      @o1.save!
+      _(@o1.reload.json_col).must_equal({ "a" => "a" })
+    end
 
-  it "can use ISJSON function" do
-    _(SSTestDatatypeMigrationJson.where("ISJSON(json_col) > 0").count).must_equal 4
-    _(SSTestDatatypeMigrationJson.where("ISJSON(json_col) IS NULL").count).must_equal 1
-  end
+    it "can use ISJSON function" do
+      _(SSTestDatatypeMigrationJson.where("ISJSON(json_col) > 0").count).must_equal 4
+      _(SSTestDatatypeMigrationJson.where("ISJSON(json_col) IS NULL").count).must_equal 1
+    end
 
-  it "can use JSON_VALUE function" do
-    _(SSTestDatatypeMigrationJson.where("JSON_VALUE(json_col, '$.b') = 'b'").count).must_equal 2
+    it "can use JSON_VALUE function" do
+      _(SSTestDatatypeMigrationJson.where("JSON_VALUE(json_col, '$.b') = 'b'").count).must_equal 2
+    end
   end
-end
 end

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -55,11 +55,11 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
       assert default_after
       assert_equal default_before["constraint_keys"], default_after["constraint_keys"]
     end
-    
+
     it "change limit" do
       assert_nothing_raised { connection.change_column :people, :lock_version, :integer, limit: 8 }
     end
-    
+
     it "change null and default" do
       assert_nothing_raised { connection.change_column :people, :first_name, :text, null: true, default: nil }
     end

--- a/test/cases/pessimistic_locking_test_sqlserver.rb
+++ b/test/cases/pessimistic_locking_test_sqlserver.rb
@@ -38,12 +38,12 @@ class PessimisticLockingTestSQLServer < ActiveRecord::TestCase
     end
 
     it "lock with eager find" do
-       assert_nothing_raised do
-        Person.transaction do
-          person = Person.lock(true).includes(:readers).find(1)
-          _(person).must_equal Person.find(1)
-        end
-      end
+      assert_nothing_raised do
+       Person.transaction do
+         person = Person.lock(true).includes(:readers).find(1)
+         _(person).must_equal Person.find(1)
+       end
+     end
     end
 
     it "can add a custom lock directive" do

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -27,13 +27,13 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :date,              type: "date",         limit: nil,           precision: nil,   scale: nil,  default: "01-01-0001"
     assert_line :datetime,          type: "datetime",     limit: nil,           precision: nil,   scale: nil,  default: "01-01-1753 00:00:00.123"
     if connection_dblib_73?
-    assert_line :datetime2_7,       type: "datetime",     limit: nil,           precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"
+      assert_line :datetime2_7,       type: "datetime",     limit: nil,           precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"
     assert_line :datetime2_3,       type: "datetime",     limit: nil,           precision: 3,     scale: nil,  default: nil
     assert_line :datetime2_1,       type: "datetime",     limit: nil,           precision: 1,     scale: nil,  default: nil
     end
     assert_line :smalldatetime,     type: "smalldatetime",limit: nil,           precision: nil,   scale: nil,  default: "01-01-1901 15:45:00.0"
     if connection_dblib_73?
-    assert_line :time_7,            type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
+      assert_line :time_7,            type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
     assert_line :time_2,            type: "time",         limit: nil,           precision: 2,     scale: nil,  default: nil
     assert_line :time_default,      type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "15:03:42.0621978"
     end


### PR DESCRIPTION
Following #826, this PR enables `Layout/IndentationWidth` and `Layout/TrailingWhitespace` cops and fixes all existing offenses.