### PR TITLE
Rubocop: Enable Spacing cops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
     require "yaml"
 
     spec = eval(File.read("activerecord-sqlserver-adapter.gemspec"))
-    ver  = spec.dependencies.detect{ |d|d.name == "activerecord" }.requirement.requirements.first.last.version
+    ver  = spec.dependencies.detect { |d| d.name == "activerecord" }.requirement.requirements.first.last.version
     major, minor, tiny, pre = ver.split(".")
 
     if pre

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -16,7 +16,7 @@ module ActiveRecord
               if operation.to_s.downcase == "count"
                 unless distinct_value || distinct_select?(column_name || select_for_count)
                   relation.distinct!
-                  relation.select_values = [ klass.primary_key || table[Arel.star] ]
+                  relation.select_values = [klass.primary_key || table[Arel.star]]
                 end
               end
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -143,7 +143,7 @@ module ActiveRecord
           sql = +"INSERT #{insert.into}"
 
           if returning = insert.send(:insert_all).returning
-            sql << " OUTPUT " << returning.map {|column| "INSERTED.#{quote_column_name(column)}" }.join(", ")
+            sql << " OUTPUT " << returning.map { |column| "INSERTED.#{quote_column_name(column)}" }.join(", ")
           end
 
           sql << " #{insert.values_list}"
@@ -198,7 +198,7 @@ module ActiveRecord
             if row.instance_of? Hash
               set_option = row.values[0].gsub(/\s+/, "_")
               user_value = row.values[1]
-            elsif  row.instance_of? Array
+            elsif row.instance_of? Array
               set_option = row[0].gsub(/\s+/, "_")
               user_value = row[1]
             end
@@ -341,7 +341,7 @@ module ActiveRecord
             end
           else
             types = quote(types.join(", "))
-            params = params.map.with_index{ |p, i| "@#{i} = #{p}" }.join(", ") # Only p is needed, but with @i helps explain regexp.
+            params = params.map.with_index { |p, i| "@#{i} = #{p}" }.join(", ") # Only p is needed, but with @i helps explain regexp.
             sql = "EXEC sp_executesql #{quote(sql)}"
             sql += ", #{types}, #{params}" unless params.empty?
           end

--- a/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_tasks.rb
@@ -31,20 +31,20 @@ module ActiveRecord
 
         private
 
-        def create_database_options(options={})
+        def create_database_options(options = {})
           keys  = [:collate]
           copts = @connection_options
           options = {
             collate: copts[:collation]
           }.merge(options.symbolize_keys).select { |_, v|
             v.present?
-          }.slice(*keys).map { |k,v|
+          }.slice(*keys).map { |k, v|
             "#{k.to_s.upcase} #{v}"
           }.join(" ")
           options
         end
 
-        def create_database_edition_options(options={})
+        def create_database_edition_options(options = {})
           keys  = [:maxsize, :edition, :service_objective]
           copts = @connection_options
           edition_options = {
@@ -53,7 +53,7 @@ module ActiveRecord
             service_objective: copts[:azure_service_objective]
           }.merge(options.symbolize_keys).select { |_, v|
             v.present?
-          }.slice(*keys).map { |k,v|
+          }.slice(*keys).map { |k, v|
             "#{k.to_s.upcase} = #{v}"
           }.join(", ")
           edition_options = "( #{edition_options} )" if edition_options.present?

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -248,7 +248,7 @@ module ActiveRecord
         end
 
         def columns_for_distinct(columns, orders)
-          order_columns = orders.reject(&:blank?).map{ |s|
+          order_columns = orders.reject(&:blank?).map { |s|
               s = s.to_sql unless s.is_a?(String)
               s.gsub(/\s+(?:ASC|DESC)\b/i, "")
                .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")

--- a/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time_value_fractional.rb
@@ -23,7 +23,7 @@ module ActiveRecord
             return 0 if fractional_scale == 0
             frac_seconds = seconds_precision(value)
             seconds = (frac_seconds.to_f / fractional_operator.to_f).round(fractional_scale)
-            seconds.to_d.to_s.split(".").last.to(fractional_scale-1)
+            seconds.to_d.to_s.split(".").last.to(fractional_scale - 1)
           end
 
           def fractional_property
@@ -35,7 +35,7 @@ module ActiveRecord
           end
 
           def fractional_operator
-            10 ** fractional_digits
+            10**fractional_digits
           end
 
           def fractional_precision

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           end
 
           def quoted
-            parts.map{ |p| quote(p) if p }.join SEPARATOR
+            parts.map { |p| quote(p) if p }.join SEPARATOR
           end
 
           def quoted_raw

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -293,7 +293,7 @@ module ActiveRecord
       # === Abstract Adapter (Misc Support) =========================== #
 
       def initialize_type_map(m = type_map)
-        m.register_type              %r{.*},            SQLServer::Type::UnicodeString.new
+        m.register_type              %r{.*}, SQLServer::Type::UnicodeString.new
         # Exact Numerics
         register_class_with_limit m, "bigint(8)",         SQLServer::Type::BigInteger
         m.alias_type                 "bigint",            "bigint(8)"
@@ -326,11 +326,11 @@ module ActiveRecord
             SQLServer::Type::DateTime.new
           end
         end
-        m.register_type              %r{\Adatetimeoffset}i do |sql_type|
+        m.register_type %r{\Adatetimeoffset}i do |sql_type|
           precision = extract_precision(sql_type)
           SQLServer::Type::DateTimeOffset.new precision: precision
         end
-        m.register_type              "smalldatetime",     SQLServer::Type::SmallDateTime.new
+        m.register_type              "smalldatetime", SQLServer::Type::SmallDateTime.new
         m.register_type              %r{\Atime}i do |sql_type|
           precision = extract_precision(sql_type) || DEFAULT_TIME_PRECISION
           SQLServer::Type::Time.new precision: precision
@@ -456,9 +456,9 @@ module ActiveRecord
         config[:encoding].present? ? config[:encoding] : nil
       end
 
-      def configure_connection ; end
+      def configure_connection; end
 
-      def configure_application_name ; end
+      def configure_application_name; end
 
       def initialize_dateformatter
         @database_dateformat = user_options_dateformat

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -14,7 +14,7 @@ module Arel
       # SQLServer ToSql/Visitor (Overides)
 
       def visit_Arel_Nodes_BindParam o, collector
-        collector.add_bind(o.value) { |i| "@#{i-1}" }
+        collector.add_bind(o.value) { |i| "@#{i - 1}" }
       end
 
       def visit_Arel_Nodes_Bin o, collector
@@ -70,7 +70,7 @@ module Arel
           collector = visit o.with, collector
           collector << " "
         end
-        collector = o.cores.inject(collector) { |c,x|
+        collector = o.cores.inject(collector) { |c, x|
           visit_Arel_Nodes_SelectCore(x, c)
         }
         collector = visit_Orders_And_Let_Fetch_Happen o, collector

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -54,10 +54,10 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
   end
 
   it "return true to insert sql query for inserts only" do
-    assert connection.send(:insert_sql?,"INSERT...")
+    assert connection.send(:insert_sql?, "INSERT...")
     assert connection.send(:insert_sql?, "EXEC sp_executesql N'INSERT INTO [fk_test_has_fks] ([fk_id]) VALUES (@0); SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident', N'@0 int', @0 = 0")
-    assert !connection.send(:insert_sql?,"UPDATE...")
-    assert !connection.send(:insert_sql?,"SELECT...")
+    assert !connection.send(:insert_sql?, "UPDATE...")
+    assert !connection.send(:insert_sql?, "SELECT...")
   end
 
   it "return unquoted table name object from basic INSERT UPDATE and SELECT statements" do
@@ -155,17 +155,17 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
 
     it "return quoted table_name to #query_requires_identity_insert? when INSERT sql contains id column" do
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql)
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted)
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered)
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql_sp)
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql_unquoted_sp)
-      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?,@identity_insert_sql_unordered_sp)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unquoted)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unordered)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_sp)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unquoted_sp)
+      assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unordered_sp)
     end
 
     it "return false to #query_requires_identity_insert? for normal SQL" do
       [basic_insert_sql, basic_update_sql, basic_select_sql].each do |sql|
-        assert !connection.send(:query_requires_identity_insert?,sql), "SQL was #{sql}"
+        assert !connection.send(:query_requires_identity_insert?, sql), "SQL was #{sql}"
       end
     end
 
@@ -227,7 +227,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
 
     it "NOT ALLOW by default the deletion of a referenced parent" do
-      SSTestHasPk.connection.disable_referential_integrity { }
+      SSTestHasPk.connection.disable_referential_integrity {}
       assert_raise(ActiveRecord::StatementInvalid) { @parent.destroy }
     end
 
@@ -237,7 +237,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
     it "again NOT ALLOW deletion of referenced parent after #disable_referential_integrity block" do
       assert_raise(ActiveRecord::StatementInvalid) do
-        SSTestHasPk.connection.disable_referential_integrity { }
+        SSTestHasPk.connection.disable_referential_integrity {}
         @parent.destroy
       end
     end
@@ -318,27 +318,27 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
 
     it "not contain system views" do
-      systables = ["sysconstraints","syssegments"]
+      systables = ["sysconstraints", "syssegments"]
       systables.each do |systable|
         assert !connection.views.include?(systable), "This systable #{systable} should not be in the views array."
       end
     end
 
     it "allow the connection#view_information method to return meta data on the view" do
-      view_info = connection.send(:view_information,"sst_customers_view")
+      view_info = connection.send(:view_information, "sst_customers_view")
       assert_equal("sst_customers_view", view_info["TABLE_NAME"])
       assert_match(/CREATE VIEW sst_customers_view/, view_info["VIEW_DEFINITION"])
     end
 
     it "allow the connection#view_table_name method to return true table_name for the view" do
-      assert_equal "customers", connection.send(:view_table_name,"sst_customers_view")
-      assert_equal "topics", connection.send(:view_table_name,"topics"), "No view here, the same table name should come back."
+      assert_equal "customers", connection.send(:view_table_name, "sst_customers_view")
+      assert_equal "topics", connection.send(:view_table_name, "topics"), "No view here, the same table name should come back."
     end
 
     # With same column names
 
     it "have matching column objects" do
-      columns = ["id","name","balance"]
+      columns = ["id", "name", "balance"]
       assert !SSTestCustomersView.columns.blank?
       assert_equal columns.size, SSTestCustomersView.columns.size
       columns.each do |colname|
@@ -365,7 +365,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     # With aliased column names
 
     it "have matching column objects" do
-      columns = ["id","pretend_null"]
+      columns = ["id", "pretend_null"]
       assert !SSTestStringDefaultsView.columns.blank?
       assert_equal columns.size, SSTestStringDefaultsView.columns.size
       columns.each do |colname|

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -329,14 +329,14 @@ module ActiveRecord
       coerce_tests! :test_quote_ar_object
       def test_quote_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "'02-14-2017 12:34:56.79'",  @connection.quote(value)
+        assert_equal "'02-14-2017 12:34:56.79'", @connection.quote(value)
       end
 
       # Use our date format.
       coerce_tests! :test_type_cast_ar_object
       def test_type_cast_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "02-14-2017 12:34:56.79",  @connection.type_cast(value)
+        assert_equal "02-14-2017 12:34:56.79", @connection.type_cast(value)
       end
     end
   end
@@ -883,7 +883,7 @@ class QueryCacheTest < ActiveRecord::TestCase
         Task.find(1)
       end
 
-      assert_includes ActiveRecord::SQLCounter.log_all.first , "TC.CONSTRAINT_TYPE = N''PRIMARY KEY''"
+      assert_includes ActiveRecord::SQLCounter.log_all.first, "TC.CONSTRAINT_TYPE = N''PRIMARY KEY''"
     end
   end
 end
@@ -986,7 +986,7 @@ class SanitizeTest < ActiveRecord::TestCase
         where("title LIKE ?", sanitize_sql_like(term, "!"))
       end
 
-      scope :search_as_scope, -> (term) {
+      scope :search_as_scope, ->(term) {
         where("title LIKE ?", sanitize_sql_like(term, "!"))
       }
     end
@@ -1121,7 +1121,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
   coerce_tests! :test_datetime_precision_is_truncated_on_assignment
   def test_datetime_precision_is_truncated_on_assignment_coerced
     @connection.create_table(:foos, force: true)
-    @connection.add_column :foos, :created_at,  :datetime, precision: 0
+    @connection.add_column :foos, :created_at, :datetime, precision: 0
     @connection.add_column :foos, :updated_at, :datetime, precision: 6
 
     time = ::Time.now.change(nsec: 123456789)

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -13,8 +13,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
 
     Type = ActiveRecord::ConnectionAdapters::SQLServer::Type
 
-    def new_obj ; SSTestDatatype.new ; end
-    def column(name) ; SSTestDatatype.columns_hash[name] ; end
+    def new_obj; SSTestDatatype.new; end
+    def column(name); SSTestDatatype.columns_hash[name]; end
     def assert_obj_set_and_save(attribute, value)
       obj.send :"#{attribute}=", value
       _(obj.send(attribute)).must_equal value
@@ -101,7 +101,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.bit).must_equal                true
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Boolean
+      _(type).must_be_instance_of Type::Boolean
       _(type.limit).must_be_nil
       obj.bit = 0
       _(obj.bit).must_equal false
@@ -122,12 +122,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.decimal_9_2).must_equal        BigDecimal("12345.01")
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Decimal
+      _(type).must_be_instance_of Type::Decimal
       _(type.limit).must_be_nil
       _(type.precision).must_equal         9
       _(type.scale).must_equal             2
       obj.decimal_9_2 = "1234567.8901"
-      _(obj.decimal_9_2).must_equal        BigDecimal("1234567.89")
+      _(obj.decimal_9_2).must_equal BigDecimal("1234567.89")
       obj.save!
       _(obj.reload.decimal_9_2).must_equal BigDecimal("1234567.89")
     end
@@ -142,7 +142,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_equal         16
       _(type.scale).must_equal             4
       obj.decimal_16_4 = "1234567.8901001"
-      _(obj.decimal_16_4).must_equal        BigDecimal("1234567.8901")
+      _(obj.decimal_16_4).must_equal BigDecimal("1234567.8901")
       obj.save!
       _(obj.reload.decimal_16_4).must_equal BigDecimal("1234567.8901")
     end
@@ -156,12 +156,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.numeric_18_0).must_equal       BigDecimal("191")
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Decimal
+      _(type).must_be_instance_of Type::Decimal
       _(type.limit).must_be_nil
       _(type.precision).must_equal         18
       _(type.scale).must_equal             0
       obj.numeric_18_0 = "192.1"
-      _(obj.numeric_18_0).must_equal        BigDecimal("192")
+      _(obj.numeric_18_0).must_equal BigDecimal("192")
       obj.save!
       _(obj.reload.numeric_18_0).must_equal BigDecimal("192")
     end
@@ -175,12 +175,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.numeric_36_2).must_equal       BigDecimal("12345678901234567890.01")
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Decimal
+      _(type).must_be_instance_of Type::Decimal
       _(type.limit).must_be_nil
       _(type.precision).must_equal         36
       _(type.scale).must_equal             2
       obj.numeric_36_2 = "192.123"
-      _(obj.numeric_36_2).must_equal        BigDecimal("192.12")
+      _(obj.numeric_36_2).must_equal BigDecimal("192.12")
       obj.save!
       _(obj.reload.numeric_36_2).must_equal BigDecimal("192.12")
     end
@@ -194,14 +194,14 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.money).must_equal              BigDecimal("4.20")
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Money
+      _(type).must_be_instance_of Type::Money
       _(type.limit).must_be_nil
       _(type.precision).must_equal         19
       _(type.scale).must_equal             4
       obj.money = "922337203685477.58061"
-      _(obj.money).must_equal              BigDecimal("922337203685477.5806")
+      _(obj.money).must_equal BigDecimal("922337203685477.5806")
       obj.save!
-      _(obj.reload.money).must_equal       BigDecimal("922337203685477.5806")
+      _(obj.reload.money).must_equal BigDecimal("922337203685477.5806")
     end
 
     it "smallmoney" do
@@ -213,12 +213,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.smallmoney).must_equal         BigDecimal("4.20")
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::SmallMoney
+      _(type).must_be_instance_of Type::SmallMoney
       _(type.limit).must_be_nil
       _(type.precision).must_equal         10
       _(type.scale).must_equal             4
       obj.smallmoney = "214748.36461"
-      _(obj.smallmoney).must_equal        BigDecimal("214748.3646")
+      _(obj.smallmoney).must_equal BigDecimal("214748.3646")
       obj.save!
       _(obj.reload.smallmoney).must_equal BigDecimal("214748.3646")
     end
@@ -236,12 +236,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.float).must_equal              123.00000001
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Float
+      _(type).must_be_instance_of Type::Float
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       obj.float = "214748.36461"
-      _(obj.float).must_equal        214748.36461
+      _(obj.float).must_equal 214748.36461
       obj.save!
       _(obj.reload.float).must_equal 214748.36461
     end
@@ -255,14 +255,14 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.real).must_be_close_to         123.45, 0.01
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Real
+      _(type).must_be_instance_of Type::Real
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       obj.real = "214748.36461"
-      _(obj.real).must_be_close_to         214748.36461, 0.01
+      _(obj.real).must_be_close_to 214748.36461, 0.01
       obj.save!
-      _(obj.reload.real).must_be_close_to  214748.36461, 0.01
+      _(obj.reload.real).must_be_close_to 214748.36461, 0.01
     end
 
     # Date and Time
@@ -276,31 +276,31 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.date).must_equal               Date.civil(0001, 1, 1)
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Date
+      _(type).must_be_instance_of Type::Date
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Can cast strings. SQL Server format.
       obj.date = "04-01-0001"
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       obj.save!
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       obj.reload
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       # Can cast strings. ISO format.
       obj.date = "0001-04-01"
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       obj.save!
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       obj.reload
-      _(obj.date).must_equal               Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(0001, 4, 1)
       # Can keep and return assigned date.
       assert_obj_set_and_save :date, Date.civil(1972, 04, 14)
       # Can accept and cast time objects.
       obj.date = Time.utc(2010, 4, 14, 12, 34, 56, 3000)
       _(obj.date).must_equal               Date.civil(2010, 4, 14)
       obj.save!
-      _(obj.reload.date).must_equal        Date.civil(2010, 4, 14)
+      _(obj.reload.date).must_equal Date.civil(2010, 4, 14)
     end
 
     it "datetime" do
@@ -313,7 +313,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.datetime).must_equal           time, "Microseconds were <#{obj.datetime.usec}> vs <123000>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::DateTime
+      _(type).must_be_instance_of Type::DateTime
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
@@ -322,21 +322,21 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       # Can save to proper accuracy and return again.
       time = Time.utc 2010, 04, 01, 12, 34, 56, 3000
       obj.datetime = time
-      _(obj.datetime).must_equal           time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
+      _(obj.datetime).must_equal time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
       obj.save!
-      _(obj.datetime).must_equal           time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
+      _(obj.datetime).must_equal time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
       obj.reload
-      _(obj.datetime).must_equal           time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
+      _(obj.datetime).must_equal time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
       _(obj).must_equal obj.class.where(datetime: time).first
       # Will cast to true DB value on attribute write, save and return again.
-      time  = Time.utc 2010, 04, 01, 12, 34, 56, 234567
+      time = Time.utc 2010, 04, 01, 12, 34, 56, 234567
       time2 = Time.utc 2010, 04, 01, 12, 34, 56, 233000
       obj.datetime = time
-      _(obj.datetime).must_equal           time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
+      _(obj.datetime).must_equal time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
       obj.save!
-      _(obj.datetime).must_equal           time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
+      _(obj.datetime).must_equal time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
       obj.reload
-      _(obj.datetime).must_equal           time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
+      _(obj.datetime).must_equal time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
       _(obj).must_equal obj.class.where(datetime: time).first
       _(obj).must_equal obj.class.where(datetime: time2).first
       # Set and find nil.
@@ -358,30 +358,30 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.datetime2_7).must_equal        time, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <999999900>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::DateTime2
+      _(type).must_be_instance_of Type::DateTime2
       _(type.limit).must_be_nil
-      _(type.precision).must_equal         7
+      _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       obj.save!
       _(obj).must_equal obj.class.where(datetime2_7: time).first
       # Can save 100 nanosecond precisoins and return again.
-      time  = Time.utc 9999, 12, 31, 23, 59, 59, Rational(123456755, 1000)
+      time = Time.utc 9999, 12, 31, 23, 59, 59, Rational(123456755, 1000)
       time2 = Time.utc 9999, 12, 31, 23, 59, 59, Rational(123456800, 1000)
       obj.datetime2_7 = time
-      _(obj.datetime2_7).must_equal           time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
+      _(obj.datetime2_7).must_equal time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
       obj.save!
-      _(obj.datetime2_7).must_equal           time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
+      _(obj.datetime2_7).must_equal time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
       obj.reload
-      _(obj.datetime2_7).must_equal           time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
+      _(obj.datetime2_7).must_equal time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <123456800>"
       _(obj).must_equal obj.class.where(datetime2_7: time).first
       _(obj).must_equal obj.class.where(datetime2_7: time2).first
       # Can save small fraction nanosecond precisoins and return again.
-      time  = Time.utc 2008, 6, 21, 13, 30, 0, Rational(15020, 1000)
+      time = Time.utc 2008, 6, 21, 13, 30, 0, Rational(15020, 1000)
       time2 = Time.utc 2008, 6, 21, 13, 30, 0, Rational(15000, 1000)
       obj.datetime2_7 = time
-      _(obj.datetime2_7).must_equal           time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <15000>"
+      _(obj.datetime2_7).must_equal time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <15000>"
       obj.save!
-      _(obj.reload.datetime2_7).must_equal    time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <15000>"
+      _(obj.reload.datetime2_7).must_equal time2, "Nanoseconds were <#{obj.datetime2_7.nsec}> vs <15000>"
       _(obj).must_equal obj.class.where(datetime2_7: time).first
       _(obj).must_equal obj.class.where(datetime2_7: time2).first
       # datetime2_3
@@ -390,7 +390,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(connection.lookup_cast_type_from_column(col).precision).must_equal 3
       obj.datetime2_3 = time
       _(obj.datetime2_3).must_equal time.change(nsec: 123000000), "Nanoseconds were <#{obj.datetime2_3.nsec}> vs <123000000>"
-      obj.save! ; obj.reload
+      obj.save!; obj.reload
       _(obj.datetime2_3).must_equal time.change(nsec: 123000000), "Nanoseconds were <#{obj.datetime2_3.nsec}> vs <123000000>"
       _(obj).must_equal obj.class.where(datetime2_3: time).first
       # datetime2_1
@@ -398,7 +398,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(connection.lookup_cast_type_from_column(col).precision).must_equal 1
       obj.datetime2_1 = time
       _(obj.datetime2_1).must_equal time.change(nsec: 100000000), "Nanoseconds were <#{obj.datetime2_1.nsec}> vs <100000000>"
-      obj.save! ; obj.reload
+      obj.save!; obj.reload
       _(obj.datetime2_1).must_equal time.change(nsec: 100000000), "Nanoseconds were <#{obj.datetime2_1.nsec}> vs <100000000>"
       _(obj).must_equal obj.class.where(datetime2_1: time).first
       # datetime2_0
@@ -407,7 +407,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       time = Time.utc 2016, 4, 19, 16, 45, 40, 771036
       obj.datetime2_0 = time
       _(obj.datetime2_0).must_equal time.change(nsec: 0), "Nanoseconds were <#{obj.datetime2_0.nsec}> vs <0>"
-      obj.save! ; obj.reload
+      obj.save!; obj.reload
       _(obj.datetime2_0).must_equal time.change(nsec: 0), "Nanoseconds were <#{obj.datetime2_0.nsec}> vs <0>"
       _(obj).must_equal obj.class.where(datetime2_0: time).first
     end
@@ -422,17 +422,17 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.datetimeoffset_7).must_equal   Time.new(1984, 01, 24, 04, 20, 00, -28800).change(nsec: 123456700), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <999999900>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::DateTimeOffset
+      _(type).must_be_instance_of Type::DateTimeOffset
       _(type.limit).must_be_nil
-      _(type.precision).must_equal         7
+      _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Can save 100 nanosecond precisoins and return again.
       obj.datetimeoffset_7 = Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456755)
-      _(obj.datetimeoffset_7).must_equal   Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       obj.save!
-      _(obj.datetimeoffset_7).must_equal   Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       obj.reload
-      _(obj.datetimeoffset_7).must_equal   Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       # Maintains the timezone
       time = ActiveSupport::TimeZone["America/Los_Angeles"].local 2010, 12, 31, 23, 59, 59, Rational(123456800, 1000)
       obj.datetimeoffset_7 = time
@@ -465,17 +465,17 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.smalldatetime).must_equal      Time.utc(1901, 01, 01, 15, 45, 00, 000)
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::SmallDateTime
+      _(type).must_be_instance_of Type::SmallDateTime
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Will remove fractional seconds and return again.
       obj.smalldatetime = Time.utc(2078, 06, 05, 4, 20, 00, 3000)
-      _(obj.smalldatetime).must_equal      Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.smalldatetime.usec}> vs <0>"
+      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.smalldatetime.usec}> vs <0>"
       obj.save!
-      _(obj.smalldatetime).must_equal      Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
+      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
       obj.reload
-      _(obj.smalldatetime).must_equal      Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
+      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
     end
 
     it "time(7)" do
@@ -487,27 +487,27 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.default).must_equal            Time.utc(1900, 01, 01, 04, 20, 00, Rational(288321500, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <288321500>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Time
+      _(type).must_be_instance_of Type::Time
       _(type.limit).must_be_nil
-      _(type.precision).must_equal         7
+      _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Time's #usec precision (low micro)
       obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, 300)
       _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
       _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
-      obj.save! ; obj.reload
+      obj.save!; obj.reload
       _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
       _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
       # Time's #usec precision (high micro)
       obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, 234567)
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
-      obj.save! ; obj.reload
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
+      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
+      obj.save!; obj.reload
+      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
       # Time's #usec precision (high nano rounded)
       obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321545, 1000))
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
-      obj.save! ; obj.reload
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
+      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
+      obj.save!; obj.reload
+      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
     end
 
     it "time(2)" do
@@ -519,25 +519,25 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.default).must_be_nil
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Time
+      _(type).must_be_instance_of Type::Time
       _(type.limit).must_be_nil
-      _(type.precision).must_equal         2
+      _(type.precision).must_equal 2
       _(type.scale).must_be_nil
       # Always uses TinyTDS/Windows 2000-01-01 convention too.
       obj.time_2 = Time.utc(2015, 01, 10, 15, 45, 00, 0)
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0)
-      obj.save! ; obj.reload
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0)
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0)
+      obj.save!; obj.reload
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0)
       # Time's #usec precision (barely in 2 precision equal to 0.03 seconds)
       obj.time_2 = Time.utc(2000, 01, 01, 15, 45, 00, 30000)
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
-      obj.save! ; obj.reload
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
+      obj.save!; obj.reload
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
       # Time's #usec precision (below 2 precision)
       obj.time_2 = Time.utc(2000, 01, 01, 15, 45, 00, 4000)
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
-      obj.save! ; obj.reload
-      _(obj.time_2).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
+      obj.save!; obj.reload
+      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
     end
 
     it "time using default precision" do
@@ -549,27 +549,27 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.default).must_equal            Time.utc(1900, 01, 01, 15, 03, 42, Rational(62197800, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <62197800>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Time
+      _(type).must_be_instance_of Type::Time
       _(type.limit).must_be_nil
-      _(type.precision).must_equal         7
+      _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Time's #usec precision (low micro)
       obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 300)
       _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
       _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
-      obj.save! ; obj.reload
+      obj.save!; obj.reload
       _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
       _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
       # Time's #usec precision (high micro)
       obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 234567)
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
-      obj.save! ; obj.reload
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      obj.save!; obj.reload
+      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
       # Time's #usec precision (high nano rounded)
       obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321545, 1000))
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
-      obj.save! ; obj.reload
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
+      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
+      obj.save!; obj.reload
+      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
     end
 
     # Character Strings
@@ -589,9 +589,9 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.scale).must_be_nil
       # Basic set and save.
       obj.char_10 = "012345"
-      _(obj.char_10.strip).must_equal         "012345"
+      _(obj.char_10.strip).must_equal "012345"
       obj.save!
-      _(obj.reload.char_10.strip).must_equal  "012345"
+      _(obj.reload.char_10.strip).must_equal "012345"
     end
 
     it "varchar(50)" do
@@ -662,9 +662,9 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.scale).must_be_nil
       # Basic set and save.
       obj.nchar_10 = "五六"
-      _(obj.nchar_10.strip).must_equal         "五六"
+      _(obj.nchar_10.strip).must_equal "五六"
       obj.save!
-      _(obj.reload.nchar_10.strip).must_equal  "五六"
+      _(obj.reload.nchar_10.strip).must_equal "五六"
     end
 
     it "nvarchar(50)" do
@@ -790,21 +790,21 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.type).must_equal               :uuid
       _(col.null).must_equal               true
       _(col.default).must_be_nil
-      _(col.default_function).must_equal   "newid()"
+      _(col.default_function).must_equal "newid()"
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Uuid
+      _(type).must_be_instance_of Type::Uuid
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Basic set and save.
       obj.uniqueidentifier = "this will not qualify as valid"
       _(obj.uniqueidentifier).must_be_nil
-      obj.save! ; obj.reload
-      _(obj.uniqueidentifier).must_match   Type::Uuid::ACCEPTABLE_UUID
+      obj.save!; obj.reload
+      _(obj.uniqueidentifier).must_match Type::Uuid::ACCEPTABLE_UUID
       obj.uniqueidentifier = "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-      _(obj.uniqueidentifier).must_equal   "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-      obj.save! ; obj.reload
-      _(obj.uniqueidentifier).must_equal   "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+      _(obj.uniqueidentifier).must_equal "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+      obj.save!; obj.reload
+      _(obj.uniqueidentifier).must_equal "6F9619FF-8B86-D011-B42D-00C04FC964FF"
     end
 
     it "timestamp" do
@@ -815,14 +815,14 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.default).must_be_nil
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of          Type::Timestamp
+      _(type).must_be_instance_of Type::Timestamp
       _(type.limit).must_be_nil
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Basic read.
       _(obj.timestamp).must_be_nil
-      obj.save! ; obj.reload
-      _(obj.timestamp).must_match   %r|\000|
+      obj.save!; obj.reload
+      _(obj.timestamp).must_match %r|\000|
       obj.timestamp
       # Can set another attribute
       obj.uniqueidentifier = "6F9619FF-8B86-D011-B42D-00C04FC964FF"

--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -18,7 +18,7 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
   end
 
   it "allow multiple result sets to be returned" do
-    results1, results2 = ActiveRecord::Base.execute_procedure("sp_helpconstraint","accounts")
+    results1, results2 = ActiveRecord::Base.execute_procedure("sp_helpconstraint", "accounts")
     assert_instance_of Array, results1
     assert results1.first.respond_to?(:keys)
     assert results1.first["Object Name"]

--- a/test/cases/fetch_test_sqlserver.rb
+++ b/test/cases/fetch_test_sqlserver.rb
@@ -10,7 +10,7 @@ class FetchTestSqlserver < ActiveRecord::TestCase
 
   it "work with fully qualified table and columns in select" do
     books = Book.select("books.id, books.name").limit(3).offset(5)
-    assert_equal Book.all[5,3].map(&:id), books.map(&:id)
+    assert_equal Book.all[5, 3].map(&:id), books.map(&:id)
   end
 
   describe "count" do
@@ -33,7 +33,7 @@ class FetchTestSqlserver < ActiveRecord::TestCase
 
   describe "order" do
     it "gauntlet" do
-      Book.where(name:"Name-10").delete_all
+      Book.where(name: "Name-10").delete_all
       _(Book.order(:name).limit(1).offset(1).map(&:name)).must_equal ["Name-2"]
       _(Book.order(:name).limit(2).offset(2).map(&:name)).must_equal ["Name-3", "Name-4"]
       _(Book.order(:name).limit(2).offset(7).map(&:name)).must_equal ["Name-8", "Name-9"]

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -8,7 +8,7 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
     before do
       @trans_test_table1 = "sqlserver_trans_table1"
       @trans_test_table2 = "sqlserver_trans_table2"
-      @trans_tables = [@trans_test_table1,@trans_test_table2]
+      @trans_tables = [@trans_test_table1, @trans_test_table2]
     end
 
     after do

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -31,7 +31,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :datetime2_3,       type: "datetime",     limit: nil,           precision: 3,     scale: nil,  default: nil
     assert_line :datetime2_1,       type: "datetime",     limit: nil,           precision: 1,     scale: nil,  default: nil
     end
-    assert_line :smalldatetime,     type: "smalldatetime",limit: nil,           precision: nil,   scale: nil,  default: "01-01-1901 15:45:00.0"
+    assert_line :smalldatetime, type: "smalldatetime", limit: nil, precision: nil, scale: nil, default: "01-01-1901 15:45:00.0"
     if connection_dblib_73?
       assert_line :time_7,            type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
     assert_line :time_2,            type: "time",         limit: nil,           precision: 2,     scale: nil,  default: nil
@@ -157,7 +157,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     @schema_lines[column_name.to_s]
   end
 
-  def assert_line(column_name, options={})
+  def assert_line(column_name, options = {})
     line = line(column_name)
     assert line, "Count not find line with column name: #{column_name.inspect} in schema:\n#{schema}"
     [:type, :limit, :precision, :scale, :collation, :default].each do |key|

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -22,7 +22,7 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
     it "have only one identity column" do
       columns = connection.columns("test.sst_schema_identity")
       assert_equal 2, columns.size
-      assert_equal 1, columns.select{ |c| c.is_identity? }.size
+      assert_equal 1, columns.select { |c| c.is_identity? }.size
     end
 
     it "read only column properties for table in specific schema" do
@@ -32,17 +32,17 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       assert_equal 7, test_columns.size
       assert_equal 2, dbo_columns.size
       assert_equal 2, columns.size
-      assert_equal 1, test_columns.select{ |c| c.is_identity? }.size
-      assert_equal 1, dbo_columns.select{ |c| c.is_identity? }.size
-      assert_equal 1, columns.select{ |c| c.is_identity? }.size
+      assert_equal 1, test_columns.select { |c| c.is_identity? }.size
+      assert_equal 1, dbo_columns.select { |c| c.is_identity? }.size
+      assert_equal 1, columns.select { |c| c.is_identity? }.size
     end
 
     it "return correct varchar and nvarchar column limit length when table is in non dbo schema" do
       columns = connection.columns("test.sst_schema_columns")
-      assert_equal 255, columns.find {|c| c.name == "name"}.limit
-      assert_equal 1000, columns.find {|c| c.name == "description"}.limit
-      assert_equal 255, columns.find {|c| c.name == "n_name"}.limit
-      assert_equal 1000, columns.find {|c| c.name == "n_description"}.limit
+      assert_equal 255, columns.find { |c| c.name == "name" }.limit
+      assert_equal 1000, columns.find { |c| c.name == "description" }.limit
+      assert_equal 255, columns.find { |c| c.name == "n_name" }.limit
+      assert_equal 1000, columns.find { |c| c.name == "n_description" }.limit
     end
   end
 end

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -145,11 +145,11 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
     SSTestEdgeSchema.create! description: "A"
     SSTestEdgeSchema.create! description: "B"
     SSTestEdgeSchema.create! description: "C"
-    assert_equal ["A","B","C"], SSTestEdgeSchema.order("description").map(&:description)
-    assert_equal ["A","B","C"], SSTestEdgeSchema.order("description asc").map(&:description)
-    assert_equal ["A","B","C"], SSTestEdgeSchema.order("description ASC").map(&:description)
-    assert_equal ["C","B","A"], SSTestEdgeSchema.order("description desc").map(&:description)
-    assert_equal ["C","B","A"], SSTestEdgeSchema.order("description DESC").map(&:description)
+    assert_equal ["A", "B", "C"], SSTestEdgeSchema.order("description").map(&:description)
+    assert_equal ["A", "B", "C"], SSTestEdgeSchema.order("description asc").map(&:description)
+    assert_equal ["A", "B", "C"], SSTestEdgeSchema.order("description ASC").map(&:description)
+    assert_equal ["C", "B", "A"], SSTestEdgeSchema.order("description desc").map(&:description)
+    assert_equal ["C", "B", "A"], SSTestEdgeSchema.order("description DESC").map(&:description)
   end
 
   # For uniqueidentifier model helpers

--- a/test/cases/trigger_test_sqlserver.rb
+++ b/test/cases/trigger_test_sqlserver.rb
@@ -3,7 +3,7 @@
 require "cases/helper_sqlserver"
 
 class SQLServerTriggerTest < ActiveRecord::TestCase
-  after  { exclude_output_inserted_table_names.clear }
+  after { exclude_output_inserted_table_names.clear }
 
   let(:exclude_output_inserted_table_names) do
     ActiveRecord::ConnectionAdapters::SQLServerAdapter.exclude_output_inserted_table_names

--- a/test/cases/utils_test_sqlserver.rb
+++ b/test/cases/utils_test_sqlserver.rb
@@ -18,7 +18,7 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
   describe ".extract_identifiers constructor and thus SQLServer::Utils::Name value object" do
     let(:valid_names) { valid_names_unquoted + valid_names_quoted }
 
-    let(:valid_names_unquoted) {[
+    let(:valid_names_unquoted) { [
       "server.database.schema.object",
       "server.database..object",
       "server..schema.object",
@@ -29,7 +29,7 @@ class UtilsTestSQLServer < ActiveRecord::TestCase
       "object"
     ]}
 
-    let(:valid_names_quoted) {[
+    let(:valid_names_quoted) { [
       "[server].[database].[schema].[object]",
       "[server].[database]..[object]",
       "[server]..[schema].[object]",

--- a/test/migrations/transaction_table/1_table_will_never_be_created.rb
+++ b/test/migrations/transaction_table/1_table_will_never_be_created.rb
@@ -2,7 +2,7 @@
 
 class TableWillNeverBeCreated < ActiveRecord::Migration
   def self.up
-    create_table(:sqlserver_trans_table1) {  }
+    create_table(:sqlserver_trans_table1) {}
     create_table(:sqlserver_trans_table2) { raise("HELL") }
   end
 

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define do
   execute "IF EXISTS (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME = 'sst_quoted-view1') DROP VIEW [sst_quoted-view1]"
   execute "CREATE VIEW [sst_quoted-view1] AS SELECT * FROM [sst_quoted-table]"
   execute "IF EXISTS (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME = 'sst_quoted-view2') DROP VIEW [sst_quoted-view2]"
-  execute "CREATE VIEW [sst_quoted-view2] AS \n /*#{'x'*4000}}*/ \n SELECT * FROM [sst_quoted-table]"
+  execute "CREATE VIEW [sst_quoted-view2] AS \n /*#{'x' * 4000}}*/ \n SELECT * FROM [sst_quoted-table]"
 
   create_table :sst_string_defaults, force: true do |t|
     t.column :string_with_null_default, :string, default: nil
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define do
     t.column(:fk_id2, :bigint)
   end
 
-  create_table(:sst_has_pks, force: true) { }
+  create_table(:sst_has_pks, force: true) {}
   execute <<-ADDFKSQL
     ALTER TABLE sst_has_fks
     ADD CONSTRAINT FK__sst_has_fks_id
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define do
   execute <<-STRINGDEFAULTSBIGVIEW
     CREATE VIEW sst_string_defaults_big_view AS
       SELECT id, string_with_pretend_null_one as pretend_null
-      /*#{'x'*4000}}*/
+      /*#{'x' * 4000}}*/
       FROM sst_string_defaults
   STRINGDEFAULTSBIGVIEW
 
@@ -227,7 +227,7 @@ ActiveRecord::Schema.define do
   # Another schema.
 
   create_table :sst_schema_columns, force: true do |t|
-    t.column :field1 , :integer
+    t.column :field1, :integer
   end
 
   execute "IF NOT EXISTS(SELECT * FROM sys.schemas WHERE name = 'test') EXEC sp_executesql N'CREATE SCHEMA test'"

--- a/test/support/rake_helpers.rb
+++ b/test/support/rake_helpers.rb
@@ -23,7 +23,7 @@ end
 
 def ar_cases
   @ar_cases ||= begin
-    Dir.glob("#{ARTest::SQLServer.root_activerecord}/test/cases/**/*_test.rb").reject{ |x| x =~ /\/adapters\// }.sort
+    Dir.glob("#{ARTest::SQLServer.root_activerecord}/test/cases/**/*_test.rb").reject { |x| x =~ /\/adapters\// }.sort
   end
 end
 


### PR DESCRIPTION
Following #826, this PR enables the following cops and fixes all existing offenses:

- `Layout/ExtraSpacing`
- `Layout/SpaceBeforeFirstArg`
- `Layout/SpaceAfterComma`
- `Layout/SpaceBeforeSemicolon`
- `Layout/SpaceInsideBlockBraces`
- `Layout/SpaceBeforeBlockBraces`
- `Layout/SpaceAroundOperators`
- `Layout/SpaceAroundEqualsInParameterDefault`
- `Layout/SpaceBeforeComma`
- `Layout/SpaceInsideArrayLiteralBrackets`
- `Layout/SpaceAfterColon`
- `Layout/SpaceAroundBlockParameters`
- `Layout/SpaceInLambdaLiteral`