### PR TITLE
Rubocop: Enable Bundler cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 AllCops:
   TargetRubyVersion: 2.5
 
+Layout/LineLength:
+  Max: 120
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v6.0.0.rc2 (unreleased)
+
+#### Fixed
+
+- [#826](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/826) Rubocop: Enable Style/StringLiterals cop
+- [#827](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/827) Rubocop: Enable Layout/EmptyLinesAroundClassBody cop
+- [#828](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/828) Rubocop: Enable Layout/EmptyLines cop
+- [#829](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/829) Rubocop: Enable Layout/Layout/EmptyLinesAround* cops
+- [#830](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/830) Rubocop: Enable Layout/IndentationWidth and Layout/TrailingWhitespace cops
+- [#831](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/831) Rubocop: Enable Spacing cops
+- [#832](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/832) Rubocop: Enable Bundler cops
+
 ## v6.0.0.rc1
 
 #### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ else
   gem "rails", github: "rails/rails", tag: "v#{version}"
 end
 
+# rubocop:disable Bundler/DuplicatedGem
 group :tinytds do
   if ENV["TINYTDS_SOURCE"]
     gem "tiny_tds", path: ENV["TINYTDS_SOURCE"]
@@ -49,11 +50,12 @@ group :tinytds do
     gem "tiny_tds"
   end
 end
+# rubocop:enable Bundler/DuplicatedGem
 
 group :development do
-  gem "pry-byebug", platform: [:mri, :mingw, :x64_mingw]
-  gem "mocha"
   gem "minitest-spec-rails"
+  gem "mocha"
+  gem "pry-byebug", platform: [:mri, :mingw, :x64_mingw]
 end
 
 group :guard do


### PR DESCRIPTION
Following #826, this PR enables the following cops and fixes all existing offenses:

- `Bundler/DuplicatedGem`
- `Bundler/OrderedGems`