### PR TITLE
Rubocop: Enable Lint/UselessAssignment cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#831](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/831) Rubocop: Enable Spacing cops
 - [#832](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/832) Rubocop: Enable Bundler cops
 - [#833](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/833) Rubocop: Enable Layout/* cops
+- [#834](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/834) Rubocop: Enable Lint/UselessAssignment cop
 
 ## v6.0.0.rc1
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ else
 
     spec = eval(File.read("activerecord-sqlserver-adapter.gemspec"))
     ver  = spec.dependencies.detect { |d| d.name == "activerecord" }.requirement.requirements.first.last.version
-    major, minor, tiny, pre = ver.split(".")
+    major, minor, _tiny, pre = ver.split(".")
 
     if pre
       ver
@@ -32,7 +32,7 @@ else
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       YAML.load(http.request(Net::HTTP::Get.new(uri.request_uri)).body).find do |data|
-        a, b, c = data["number"].split(".")
+        a, b, = data["number"].split(".")
         !data["prerelease"] && major == a && (minor.nil? || minor == b)
       end["number"]
     end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -480,7 +480,7 @@ module ActiveRecord
         return 2016 if sqlserver_version =~ /vNext/
 
         /SQL Server (\d+)/.match(sqlserver_version).to_a.last.to_s.to_i
-      rescue StandardError => e
+      rescue StandardError
         2016
       end
 

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -84,15 +84,17 @@ module Arel
         # Apparently, o.engine.connection can actually be a different adapter
         # than sqlserver. Can be removed if fixed in ActiveRecord. See:
         # github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/450
-        table_name = begin
-          if o.class.engine.connection.respond_to?(:sqlserver?) && o.class.engine.connection.database_prefix_remote_server?
-            remote_server_table_name(o)
-          else
+        table_name =
+          begin
+            if o.class.engine.connection.respond_to?(:sqlserver?) && o.class.engine.connection.database_prefix_remote_server?
+              remote_server_table_name(o)
+            else
+              quote_table_name(o.name)
+            end
+          rescue Exception
             quote_table_name(o.name)
           end
-                     rescue Exception => e
-                       quote_table_name(o.name)
-        end
+
         if o.table_alias
           collector << "#{table_name} #{quote_table_name o.table_alias}"
         else

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -619,7 +619,7 @@ class EachTest < ActiveRecord::TestCase
   # Quoting in tests does not cope with bracket quoting.
   coerce_tests! :test_find_in_batches_should_quote_batch_order
   def test_find_in_batches_should_quote_batch_order_coerced
-    c = Post.connection
+    Post.connection
     assert_sql(/ORDER BY \[posts\]\.\[id\]/) do
       Post.find_in_batches(:batch_size => 1) do |batch|
         assert_kind_of Array, batch
@@ -631,7 +631,7 @@ class EachTest < ActiveRecord::TestCase
   # Quoting in tests does not cope with bracket quoting.
   coerce_tests! :test_in_batches_should_quote_batch_order
   def test_in_batches_should_quote_batch_order_coerced
-    c = Post.connection
+    Post.connection
     assert_sql(/ORDER BY \[posts\]\.\[id\]/) do
       Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
@@ -758,7 +758,7 @@ class InheritanceTest < ActiveRecord::TestCase
   # Use Square brackets around column name
   coerce_tests! :test_eager_load_belongs_to_primary_key_quoting
   def test_eager_load_belongs_to_primary_key_quoting_coerced
-    con = Account.connection
+    Account.connection
     assert_sql(/\[companies\]\.\[id\] = @0.* @0 = 1/) do
       Account.all.merge!(:includes => :firm).find(1)
     end

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -23,13 +23,16 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
   end
 
   it "quote table names properly even when they are views" do
-    obj = SSTestQuotedTable.create!
+    SSTestQuotedTable.create!
     assert_nothing_raised { assert SSTestQuotedTable.first }
-    obj = SSTestQuotedTableUser.create!
+
+    SSTestQuotedTableUser.create!
     assert_nothing_raised { assert SSTestQuotedTableUser.first }
-    obj = SSTestQuotedView1.create!
+
+    SSTestQuotedView1.create!
     assert_nothing_raised { assert SSTestQuotedView1.first }
-    obj = SSTestQuotedView2.create!
+
+    SSTestQuotedView2.create!
     assert_nothing_raised { assert SSTestQuotedView2.first }
   end
 

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -26,7 +26,7 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
           raise "HELL"
         end
       end
-    rescue Exception => e
+    rescue Exception
       assert_no_ships
     end
   end


### PR DESCRIPTION
Following #826, this PR enables `Lint/UselessAssignment` cop and fixes all existing offenses.