### PR TITLE
Rubocop: Configure Naming cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,13 @@ Naming/FileName:
   Exclude:
     - lib/activerecord-sqlserver-adapter.rb
 
+Naming/MethodName:
+  IgnoredPatterns:
+    - visit_.*
+    - primary_Key_From_Table
+    - table_From_Statement
+    - distinct_One_As_One_Is_So_Not_Fetch
+    - make_Fetch_Possible_And_Deterministic
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,9 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
+Naming/FileName:
+  Exclude:
+    - lib/activerecord-sqlserver-adapter.rb
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,5 +22,8 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: false
 
+Naming/PredicateName:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,5 +19,8 @@ Naming/MethodName:
     - distinct_One_As_One_Is_So_Not_Fetch
     - make_Fetch_Possible_And_Deterministic
 
+Naming/MethodParameterName:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
+Naming/AccessorMethodName:
+  Enabled: false
+
 Naming/FileName:
   Exclude:
     - lib/activerecord-sqlserver-adapter.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 #### Fixed
 
 - [#720](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/720) quoted_date doesn't work for Type::DateTime
+
+#### Changed
+
 - [#826](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/826) Rubocop: Enable Style/StringLiterals cop
 - [#827](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/827) Rubocop: Enable Layout/EmptyLinesAroundClassBody cop
 - [#828](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/828) Rubocop: Enable Layout/EmptyLines cop
@@ -12,6 +15,7 @@
 - [#832](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/832) Rubocop: Enable Bundler cops
 - [#833](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/833) Rubocop: Enable Layout/* cops
 - [#834](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/834) Rubocop: Enable Lint/UselessAssignment cop
+- [#835](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/835) Rubocop: Configure Naming cops
 
 ## v6.0.0.rc1
 

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -61,8 +61,8 @@ module ActiveRecord
             quote @raw_name
           end
 
-          def ==(o)
-            o.class == self.class && o.parts == parts
+          def ==(other)
+            other.class == self.class && other.parts == parts
           end
           alias_method :eql?, :==
 

--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -21,8 +21,8 @@ module ActiveRecord
         establish_master_connection unless master_established
         connection.create_database configuration["database"], configuration.merge("collation" => default_collation)
         establish_connection configuration
-      rescue ActiveRecord::StatementInvalid => error
-        if /database .* already exists/i === error.message
+      rescue ActiveRecord::StatementInvalid => e
+        if /database .* already exists/i === e.message
           raise DatabaseAlreadyExists
         else
           raise

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -759,12 +759,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Basic set and save.
-      binary_data_20 = binary_data.to(20)
-      _(binary_data_20.encoding).must_equal Encoding::BINARY
-      obj.varbinary_49 = binary_data_20
-      _(obj.varbinary_49).must_equal binary_data_20
+      binary_data20 = binary_data.to(20)
+      _(binary_data20.encoding).must_equal Encoding::BINARY
+      obj.varbinary_49 = binary_data20
+      _(obj.varbinary_49).must_equal binary_data20
       obj.save!
-      _(obj.reload.varbinary_49).must_equal binary_data_20
+      _(obj.reload.varbinary_49).must_equal binary_data20
     end
 
     it "varbinary(max)" do


### PR DESCRIPTION
Following #826, this PR configures `Naming/*` cops and fixes all existing offenses.

- `Naming/MethodParameterName`
- `Naming/MethodName`
- `Naming/AccessorMethodName`
- `Naming/PredicateName`
- `Naming/BinaryOperatorParameterName`
- `Naming/FileName`
- `Naming/RescuedExceptionsVariableName`
- `Naming/VariableNumber`
