### PR TITLE
Updated 'column_definitions_sql' to ensure that only primary key key constraints are queried for

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -472,6 +472,7 @@ module ActiveRecord
               AND c.default_object_id = d.object_id
             LEFT OUTER JOIN #{database}.sys.key_constraints k
               ON c.object_id = k.parent_object_id
+              AND k.type = 'PK'
             LEFT OUTER JOIN #{database}.sys.index_columns ic
               ON k.parent_object_id = ic.object_id
               AND k.unique_index_id = ic.index_id

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -135,6 +135,12 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :name, type: "string", limit: nil, default: nil, collation: nil
   end
 
+  it "dumps field with unique key constraints only once" do
+    output = generate_schema_for_table "unique_key_dumped_table"
+
+    _(output.scan('t.integer "unique_field"').length).must_equal(1)
+  end
+
   private
 
   def generate_schema_for_table(*table_names)

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -277,4 +277,14 @@ ActiveRecord::Schema.define do
       field_2 int NOT NULL PRIMARY KEY,
     )
   SCHEMATESTMULTIPLESCHEMA
+
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'unique_key_dumped_table') DROP TABLE unique_key_dumped_table"
+  execute <<-SQLSERVERUNIQUEKEYS
+    CREATE TABLE unique_key_dumped_table (
+      id int IDENTITY(1,1) NOT NULL,
+      unique_field int DEFAULT 0 NOT NULL,
+      CONSTRAINT IX_UNIQUE_KEY UNIQUE (unique_field),
+      CONSTRAINT PK_UNIQUE_KEY PRIMARY KEY (id)
+    );
+  SQLSERVERUNIQUEKEYS
 end


### PR DESCRIPTION
Fixes #850 

Upon investigation into this query, I discovered that the new query is looking at the table `sys.key_constraints` which includes both primary keys as well as unique constraints, which is not what we want. 

Originally, I tried adding this check to the `where` clause, but my schema dump was missing any table without a primary key. After adding this to the join, I was able to successfully dump my schema, build a test database, and run my specs successfully against the new test database. 

CC @wpolicarpo 