### PR TITLE
Rails 6.1 support

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -31,15 +31,6 @@ module ActiveRecord
           def build_count_subquery(relation, column_name, distinct)
             super(relation.unscope(:order), column_name, distinct)
           end
-
-          def type_cast_calculated_value(value, type, operation = nil)
-            case operation
-            when "count"   then value.to_i
-            when "sum"     then type.deserialize(value || 0)
-            when "average" then value&.respond_to?(:to_d) ? value.to_d : value
-            else type.deserialize(value)
-            end
-          end
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -3,7 +3,11 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      BASE_SCHEMA_CREATION_CLASS = Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1 ?
+        SchemaCreation :
+        AbstractAdapter::SchemaCreation
+
+      class SchemaCreation < BASE_SCHEMA_CREATION_CLASS
         private
 
         def visit_TableDefinition(o)

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -3,11 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      BASE_SCHEMA_CREATION_CLASS = Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1 ?
-        SchemaCreation :
-        AbstractAdapter::SchemaCreation
-
-      class SchemaCreation < BASE_SCHEMA_CREATION_CLASS
+      class SchemaCreation < SchemaCreation
         private
 
         def visit_TableDefinition(o)

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,10 +31,18 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      def initialize(connection, **args)
-        @connection = connection
-        @starting_isolation_level = current_isolation_level if args[:isolation]
-        super
+      if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
+        def initialize(connection, **args)
+          @connection = connection
+          @starting_isolation_level = current_isolation_level if args[:isolation]
+          super
+        end
+      else
+        def initialize(connection, options, **args)
+          @connection = connection
+          @starting_isolation_level = current_isolation_level if options[:isolation]
+          super
+        end
       end
 
       def commit

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,9 +31,9 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      def initialize(connection, options, **args)
+      def initialize(connection, **args)
         @connection = connection
-        @starting_isolation_level = current_isolation_level if options[:isolation]
+        @starting_isolation_level = current_isolation_level if args[:isolation]
         super
       end
 

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,18 +31,10 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      if Rails::VERSION::MAJOR >= 6 && Rails::VERSION::MINOR >= 1
-        def initialize(connection, **args)
-          @connection = connection
-          @starting_isolation_level = current_isolation_level if args[:isolation]
-          super
-        end
-      else
-        def initialize(connection, options, **args)
-          @connection = connection
-          @starting_isolation_level = current_isolation_level if options[:isolation]
-          super
-        end
+      def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
+        @connection = connection
+        @starting_isolation_level = current_isolation_level if isolation
+        super
       end
 
       def commit


### PR DESCRIPTION
Adds Rails 6.1 support.
Changes:
- use `ActiveRecord::ConnectionAdapters::SchemaCreation` instead of `ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation`
- accept 2 arguments in `SQLServerRealTransaction#initialize` instead of 3

I don't know if that's all, but basic testing didn't reveal other issues.