### PR TITLE
feat: add helpers to create/alter/drop a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 #### Added
 
-- ...
+- [#855](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/855) Add helpers to create/change/drop a schema.
 
 ## v6.0.1
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ Depending on your user and schema setup, it may be needed to use a table name pr
 ActiveRecord::Base.table_name_prefix = 'dbo.'
 ```
 
+It's also possible to create/change/drop a schema in the migration file as in the example below:
+
+```ruby
+class CreateFooSchema < ActiveRecord::Migration[6.0]
+  def up
+    create_schema('foo')
+
+    # Or you could move a table to a different schema
+
+    change_table_schema('foo', 'dbo.admin')
+  end
+
+  def down
+    drop_schema('foo')
+  end
+end
+```
+
 
 #### Configure Connection & App Name
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -281,6 +281,21 @@ module ActiveRecord
           SQLServer::SchemaDumper.create(self, options)
         end
 
+        def create_schema(schema_name, authorization = nil)
+          sql = "CREATE SCHEMA [#{schema_name}]"
+          sql += " AUTHORIZATION [#{authorization}]" if authorization
+
+          execute sql
+        end
+
+        def change_table_schema(schema_name, table_name)
+          execute "ALTER SCHEMA [#{schema_name}] TRANSFER [#{table_name}]"
+        end
+
+        def drop_schema(schema_name)
+          execute "DROP SCHEMA [#{schema_name}]"
+        end
+
         private
 
         def data_source_sql(name = nil, type: nil)


### PR DESCRIPTION
## Motivation
The native PostgreSQLAdapter from rails implement the following functions:

[create_schema](https://apidock.com/rails/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter/SchemaStatements/create_schema)
[drop_schema](https://apidock.com/rails/v4.1.8/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter/SchemaStatements/drop_schema)

So this PR aims to provide a similar interface to work with MSSQL schemas. Besides these two functions, I also created another one:

`alter_schema`
It can be useful to transfer a table from a schema to another. Read [more](https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-schema-transact-sql?view=sql-server-ver15)