### PR TITLE
Allow table existence to be tested across database schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixed
 
-- ...
+- [#858](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/858) Allow table existence to be tested across database schemas.
 
 #### Changed
 


### PR DESCRIPTION
If a database connection can access multiple database schemas then it should be able to check for table existence across those schemas.
