### PR TITLE
insert_all/upsert_implementation using MERGE

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -169,7 +169,7 @@ module ActiveRecord
       end
 
       def supports_insert_on_duplicate_skip?
-        false
+        true
       end
 
       def supports_insert_on_duplicate_update?

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1555,3 +1555,8 @@ class ReloadModelsTest < ActiveRecord::TestCase
   # `activesupport/lib/active_support/testing/isolation.rb` exceeds what Windows can handle.
   coerce_tests! :test_has_one_with_reload if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
 end
+
+class InsertAllTest < ActiveRecord::TestCase
+  # Skip this until upsert is supported
+  coerce_tests! :test_insert
+end

--- a/test/cases/insert_all_test_sqlserver.rb
+++ b/test/cases/insert_all_test_sqlserver.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+require "models/book"
+
+class InsertAllTestSQLServer < ActiveRecord::TestCase
+  fixtures :books
+
+  # Issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/847
+  it "execute insert_all with a single element" do
+    assert_difference "Book.count", +1 do
+      Book.insert_all [{ name: "Rework", author_id: 1 }]
+    end
+  end
+end


### PR DESCRIPTION
This PR resolves the issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/859. Since it adds support to `insert_on_duplicate_skip` it also resolves https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/847.

The PR is in early stages. I'm exploring adding `supports_insert_on_duplicate_skip` first (insert_all). Upsert_all is still pending.

At this stage this test is falling with `ActiveRecord::RecordNotUnique: TinyTds::Error: Cannot insert duplicate key row in object 'dbo.books' with unique index 'index_books_on_author_id_and_name'. The duplicate key value is (8, Refactoring).
`
```ruby
def test_insert_all_with_skip_duplicates_and_autonumber_id_given
  skip unless supports_insert_on_duplicate_skip?

  assert_difference "Book.count", 1 do
    Book.insert_all [
      { id: 200, author_id: 8, name: "Refactoring" },
      { id: 201, author_id: 8, name: "Refactoring" }
    ]
  end
end
```

The test produces the following query
```sql
SET IDENTITY_INSERT [books] ON;
MERGE INTO [books] WITH (UPDLOCK, HOLDLOCK) AS target 
USING (SELECT DISTINCT * FROM (VALUES (200, 8, N'Refactoring'), (201, 8, N'Refactoring')) AS t1 ([id],[author_id],[name])) AS source 
ON (target.[author_id] = source.[author_id] AND target.[name] = source.[name]) OR (target.[id] = source.[id]) 
WHEN NOT MATCHED BY TARGET THEN 
  INSERT ([id],[author_id],[name]) VALUES (source.[id], source.[author_id], source.[name]) 
OUTPUT INSERTED.[id];
SET IDENTITY_INSERT [books] OFF;
```

SQL Server computes the source and target join and then applies the conditions to decide if a record from the joined table matches or not. In this case, both records are inserted.

I'm having doubts if implementing insert_all using merge is possible. 

upsert_all seems more challenging. Besides this problem, `WHEN MATCHED` can only update a row once.

For reference, table schema is
```ruby
create_table :books, id: :integer, force: true do |t|
    default_zero = { default: 0 }
    t.references :author
    t.string :format
    t.column :name, :string
    t.column :status, :integer, **default_zero
    t.column :read_status, :integer, **default_zero
    t.column :nullable_status, :integer
    t.column :language, :integer, **default_zero
    t.column :author_visibility, :integer, **default_zero
    t.column :illustrator_visibility, :integer, **default_zero
    t.column :font_size, :integer, **default_zero
    t.column :difficulty, :integer, **default_zero
    t.column :cover, :string, default: "hard"
    t.string :isbn, **case_sensitive_options
    t.datetime :published_on
    t.index [:author_id, :name], unique: true
    t.index :isbn, where: "published_on IS NOT NULL", unique: true
  end
```