### PR TITLE
Added DecimalWithoutScale type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#855](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/855) Add helpers to create/change/drop a schema.
 - [#857](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/857) Included WAITFOR as read query type.
 - [#865](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/865) Implemented optimizer hints.
+- [#870](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/870) Added DecimalWithoutScale type
 
 ## v6.0.1
 

--- a/lib/active_record/connection_adapters/sqlserver/type.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type.rb
@@ -11,6 +11,7 @@ require "active_record/connection_adapters/sqlserver/type/small_integer"
 require "active_record/connection_adapters/sqlserver/type/tiny_integer"
 require "active_record/connection_adapters/sqlserver/type/boolean"
 require "active_record/connection_adapters/sqlserver/type/decimal"
+require "active_record/connection_adapters/sqlserver/type/decimal_without_scale"
 require "active_record/connection_adapters/sqlserver/type/money"
 require "active_record/connection_adapters/sqlserver/type/small_money"
 # Approximate Numerics

--- a/lib/active_record/connection_adapters/sqlserver/type/decimal_without_scale.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/decimal_without_scale.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module Type
+        class DecimalWithoutScale < ActiveRecord::Type::DecimalWithoutScale
+          def sqlserver_type
+            "decimal".yield_self do |type|
+              type += "(#{precision.to_i},0)" if precision
+              type
+            end
+          end
+
+          def type_cast_for_schema(value)
+            value.is_a?(BigDecimal) ? value.to_s : value.inspect
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -396,39 +396,6 @@ module ActiveRecord
 end
 
 class MigrationTest < ActiveRecord::TestCase
-  # We do not have do the DecimalWithoutScale type.
-  coerce_tests! :test_add_table_with_decimals
-  def test_add_table_with_decimals_coerced
-    Person.connection.drop_table :big_numbers rescue nil
-    assert !BigNumber.table_exists?
-    GiveMeBigNumbers.up
-    BigNumber.reset_column_information
-    assert BigNumber.create(
-      :bank_balance => 1586.43,
-      :big_bank_balance => BigDecimal("1000234000567.95"),
-      :world_population => 6000000000,
-      :my_house_population => 3,
-      :value_of_e => BigDecimal("2.7182818284590452353602875")
-    )
-    b = BigNumber.first
-    assert_not_nil b
-    assert_not_nil b.bank_balance
-    assert_not_nil b.big_bank_balance
-    assert_not_nil b.world_population
-    assert_not_nil b.my_house_population
-    assert_not_nil b.value_of_e
-    assert_kind_of BigDecimal, b.world_population
-    assert_equal "6000000000.0", b.world_population.to_s
-    assert_kind_of Integer, b.my_house_population
-    assert_equal 3, b.my_house_population
-    assert_kind_of BigDecimal, b.bank_balance
-    assert_equal BigDecimal("1586.43"), b.bank_balance
-    assert_kind_of BigDecimal, b.big_bank_balance
-    assert_equal BigDecimal("1000234000567.95"), b.big_bank_balance
-    GiveMeBigNumbers.down
-    assert_raise(ActiveRecord::StatementInvalid) { BigNumber.first }
-  end
-
   # For some reason our tests set Rails.@_env which breaks test env switching.
   coerce_tests! :test_internal_metadata_stores_environment_when_other_data_exists
   coerce_tests! :test_internal_metadata_stores_environment

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -157,13 +157,16 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.default).must_equal            BigDecimal("191")
       _(obj.numeric_18_0).must_equal       BigDecimal("191")
       _(col.default_function).must_be_nil
+
       type = connection.lookup_cast_type_from_column(col)
-      _(type).must_be_instance_of Type::Decimal
+      _(type).must_be_instance_of Type::DecimalWithoutScale
       _(type.limit).must_be_nil
       _(type.precision).must_equal         18
-      _(type.scale).must_equal             0
+      _(type.scale).must_be_nil
+
       obj.numeric_18_0 = "192.1"
       _(obj.numeric_18_0).must_equal BigDecimal("192")
+
       obj.save!
       _(obj.reload.numeric_18_0).must_equal BigDecimal("192")
     end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -16,7 +16,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :tinyint,           type: "integer",      limit: 1,             precision: nil,   scale: nil,  default: 42
     assert_line :bit,               type: "boolean",      limit: nil,           precision: nil,   scale: nil,  default: true
     assert_line :decimal_9_2,       type: "decimal",      limit: nil,           precision: 9,     scale: 2,    default: 12345.01
-    assert_line :numeric_18_0,      type: "decimal",      limit: nil,           precision: 18,    scale: 0,    default: 191.0
+    assert_line :numeric_18_0,      type: "decimal",      limit: nil,           precision: 18,    scale: nil,  default: 191
     assert_line :numeric_36_2,      type: "decimal",      limit: nil,           precision: 36,    scale: 2,    default: 12345678901234567890.01
     assert_line :money,             type: "money",        limit: nil,           precision: 19,    scale: 4,    default: 4.2
     assert_line :smallmoney,        type: "smallmoney",   limit: nil,           precision: 10,    scale: 4,    default: 4.2
@@ -75,7 +75,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :integer_col,     type: "integer",      limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :bigint_col,      type: "bigint",       limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :boolean_col,     type: "boolean",      limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :decimal_col,     type: "decimal",      limit: nil,          precision: 18,   scale: 0,   default: nil
+    assert_line :decimal_col,     type: "decimal",      limit: nil,          precision: 18,   scale: nil, default: nil
     assert_line :float_col,       type: "float",        limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :string_col,      type: "string",       limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :text_col,        type: "text",         limit: nil,          precision: nil,  scale: nil, default: nil
@@ -166,13 +166,15 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
   def assert_line(column_name, options = {})
     line = line(column_name)
-    assert line, "Count not find line with column name: #{column_name.inspect} in schema:\n#{schema}"
+    assert line, "Could not find line with column name: #{column_name.inspect} in schema:\n#{schema}"
+
     [:type, :limit, :precision, :scale, :collation, :default].each do |key|
       next unless options.key?(key)
 
       actual   = key == :type ? line.send(:type_method) : line.send(key)
       expected = options[key]
       message  = "#{key.to_s.titleize} of #{expected.inspect} not found in:\n#{line}"
+
       if expected.nil?
         _(actual).must_be_nil message
       elsif expected.is_a?(Array)


### PR DESCRIPTION
Added the DecimalWithoutScale data type so that `MigrationTest#test_add_table_with_decimals` no longer needs to be coerced. This matches how the `ActiveRecord::ConnectionAdapters::AbstractAdapter` works (see https://github.com/rails/rails/blob/3dd0af563b5ebdccf1e3c1993f8a64f4ab5fce48/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L664). 

Without this change it would be necessary to run different tests based on whether you were running Ruby 3+ (see https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/868).