### PR TITLE
Various fixes to get the tests running for Rails 6.1

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -54,7 +54,7 @@ module ActiveRecord
         end
 
         def begin_db_transaction
-          do_execute "BEGIN TRANSACTION"
+          do_execute "BEGIN TRANSACTION", "TRANSACTION"
         end
 
         def transaction_isolation_levels
@@ -67,25 +67,25 @@ module ActiveRecord
         end
 
         def set_transaction_isolation_level(isolation_level)
-          do_execute "SET TRANSACTION ISOLATION LEVEL #{isolation_level}"
+          do_execute "SET TRANSACTION ISOLATION LEVEL #{isolation_level}", "TRANSACTION"
         end
 
         def commit_db_transaction
-          do_execute "COMMIT TRANSACTION"
+          do_execute "COMMIT TRANSACTION", "TRANSACTION"
         end
 
         def exec_rollback_db_transaction
-          do_execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION"
+          do_execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION", "TRANSACTION"
         end
 
         include Savepoints
 
         def create_savepoint(name = current_savepoint_name)
-          do_execute "SAVE TRANSACTION #{name}"
+          do_execute "SAVE TRANSACTION #{name}", "TRANSACTION"
         end
 
         def exec_rollback_to_savepoint(name = current_savepoint_name)
-          do_execute "ROLLBACK TRANSACTION #{name}"
+          do_execute "ROLLBACK TRANSACTION #{name}", "TRANSACTION"
         end
 
         def release_savepoint(name = current_savepoint_name)

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -3,8 +3,12 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < SchemaCreation
         private
+
+        def supports_index_using?
+          false
+        end
 
         def visit_TableDefinition(o)
           if_not_exists = o.if_not_exists

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -27,7 +27,7 @@ module ActiveRecord
             end
           end
           if options[:if_exists] && @version_year < 2016
-            execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = #{quote(table_name)}) DROP TABLE #{quote_table_name(table_name)}"
+            execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = #{quote(table_name)}) DROP TABLE #{quote_table_name(table_name)}", "SCHEMA"
           else
             super
           end

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -31,9 +31,9 @@ module ActiveRecord
     module SQLServerRealTransaction
       attr_reader :starting_isolation_level
 
-      def initialize(connection, options, **args)
+      def initialize(connection, **args)
         @connection = connection
-        @starting_isolation_level = current_isolation_level if options[:isolation]
+        @starting_isolation_level = current_isolation_level if args[:isolation]
         super
       end
 

--- a/test/support/sql_counter_sqlserver.rb
+++ b/test/support/sql_counter_sqlserver.rb
@@ -11,17 +11,19 @@ module ARTest
       end
     end
 
-    ignored_sql = [
-      /INFORMATION_SCHEMA\.(TABLES|VIEWS|COLUMNS|KEY_COLUMN_USAGE)/im,
-      /sys.columns/i,
-      /SELECT @@version/,
-      /SELECT @@TRANCOUNT/,
-      /(BEGIN|COMMIT|ROLLBACK|SAVE) TRANSACTION/,
-      /SELECT CAST\(.* AS .*\) AS value/,
-      /SELECT DATABASEPROPERTYEX/im
-    ]
-
-    sqlcounter = ObjectSpace.each_object(ActiveRecord::SQLCounter).to_a.first
-    sqlcounter.instance_variable_set :@ignore, Regexp.union(ignored_sql.push(sqlcounter.ignore))
+    # TODO: Delete the code below after all Rails 6.1 tests passing.
+    #
+    # ignored_sql = [
+    #   /INFORMATION_SCHEMA\.(TABLES|VIEWS|COLUMNS|KEY_COLUMN_USAGE)/im,
+    #   /sys.columns/i,
+    #   /SELECT @@version/,
+    #   /SELECT @@TRANCOUNT/,
+    #   /(BEGIN|COMMIT|ROLLBACK|SAVE) TRANSACTION/,
+    #   /SELECT CAST\(.* AS .*\) AS value/,
+    #   /SELECT DATABASEPROPERTYEX/im
+    # ]
+    #
+    # sqlcounter = ObjectSpace.each_object(ActiveRecord::SQLCounter).to_a.first
+    # sqlcounter.instance_variable_set :@ignore, Regexp.union(ignored_sql.push(sqlcounter.ignore))
   end
 end


### PR DESCRIPTION
PR contains various fixes to get the tests running for Rails 6.1

Changes were:
- SQL Server doesn't support USING for schema creation (similar to SQLite3). See https://github.com/rails/rails/pull/39203/files#diff-414d80c69e0a30eb66d50bc71af4e80ceee02b666003e7a99a65f1c79a778c98R94
- The `ActiveRecord::SQLCounter` class used during testing no longer contains the `ignore` instance variable. Instead transaction SQL statements are ignored by labelling them as "TRANSACTION". See https://github.com/rails/rails/commit/6a32e8aa72ebcbd587d7845cf354724bf2fffd7b
- Fixed the constructor for `SQLServerRealTransaction`. Fix was taken from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/854/files#diff-d69f853a7b57d86a23028bef9f0a175de5c134adfb6c389f83782b3f29a82211R35
- Fixed the constructor for `ActiveRecord::ConnectionAdapters::SQLServer::SchemaCreation`. Fix taken from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/854/files#diff-eb032d4c01d0dcae2dc1378417cbc6ac8d5c8a69c54e8ef5019c3a28720f2ecbR10