### PR TITLE
Deduplicate schema cache structures

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -10,14 +10,14 @@ module ActiveRecord
 
         def fetch_type_metadata(sql_type, sqlserver_options = {})
           cast_type = lookup_cast_type(sql_type)
-          SQLServer::SqlTypeMetadata.new(
+          simple_type = SqlTypeMetadata.new(
             sql_type: sql_type,
             type: cast_type.type,
             limit: cast_type.limit,
             precision: cast_type.precision,
-            scale: cast_type.scale,
-            sqlserver_options: sqlserver_options
+            scale: cast_type.scale
           )
+          SQLServer::TypeMetadata.new(simple_type, sqlserver_options: sqlserver_options)
         end
 
         def quote_string(s)

--- a/lib/active_record/connection_adapters/sqlserver/sql_type_metadata.rb
+++ b/lib/active_record/connection_adapters/sqlserver/sql_type_metadata.rb
@@ -3,16 +3,36 @@
 module ActiveRecord
   module ConnectionAdapters
     module SQLServer
-      class SqlTypeMetadata < ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        def initialize(**kwargs)
-          @sqlserver_options = kwargs.extract!(:sqlserver_options)
-          super(**kwargs)
+      class TypeMetadata < DelegateClass(SqlTypeMetadata)
+        undef to_yaml if method_defined?(:to_yaml)
+
+        include Deduplicable
+
+        attr_reader :sqlserver_options
+
+        def initialize(type_metadata, sqlserver_options: nil)
+          super(type_metadata)
+          @sqlserver_options = sqlserver_options
         end
 
-        protected
+        def ==(other)
+          other.is_a?(TypeMetadata) &&
+            __getobj__ == other.__getobj__ &&
+            sqlserver_options == other.sqlserver_options
+        end
+        alias eql? ==
 
-        def attributes_for_hash
-          super + [@sqlserver_options]
+        def hash
+          TypeMetadata.hash ^
+            __getobj__.hash ^
+            sqlserver_options.hash
+        end
+
+        private
+
+        def deduplicated
+          __setobj__(__getobj__.deduplicate)
+          super
         end
       end
     end


### PR DESCRIPTION
Updated `ActiveRecord::ConnectionAdapters::SQLServer::SqlTypeMetadata` to handle the schema cache deduplicateion introduced in https://github.com/rails/rails/pull/35891

The changes follow the same format used for the MySQL and PostgreSQL adapters.

**CI on Ruby 3.0.1 before PR**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2337409595
7133 runs, 7930 assertions, 47 failures, 3697 errors, 33 skips

**CI on Ruby 3.0.1 after PR**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2337409595
7133 runs, 9936 assertions, 41 failures, 2955 errors, 33 skips