### PR TITLE
Handle default boolean column values when deduplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 - [#872](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/872) Use native String#start_with
+- [#875](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/875) Handle default boolean column values when deduplicating
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -27,6 +27,22 @@ module ActiveRecord
       def case_sensitive?
         collation && collation.match(/_CS/)
       end
+
+      private
+
+      # Handle when the default value is a boolean. Boolean's do not respond to the method `:-@`. Method now
+      # checks whether the default value is already frozen and if so it uses that, otherwise it calls `:-@` to
+      # freeze it.
+      def deduplicated
+        @name = -name
+        @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
+        @default = (default.frozen? ? default : -default) if default
+        @default_function = -default_function if default_function
+        @collation = -collation if collation
+        @comment = -comment if comment
+
+        freeze
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed the "bit" type column error `NoMethodError: undefined method '-@' for true:TrueClass`.

Issue was that the default value for a column in the SQL Server adapter can be true/false. However, the true/false classes do not implement the '-@' method to return a frozen version of the value. However, since true/false are already frozen there is no need to call the `-@` method anyway. 

```
irb(main):0> 'test'.frozen?
=> false

irb(main):0> (-'test').frozen?
=> true

irb(main):0> -false
NoMethodError (undefined method `-@' for false:FalseClass)

irb(main):0> -true
NoMethodError (undefined method `-@' for true:TrueClass)

irb(main):0> false.frozen?
=> true

irb(main):0> true.frozen?
=> true
```

**Tests Before**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2342106156
7133 runs, 8923 assertions, 36 failures, 3373 errors, 33 skips

**Tests After**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/875/checks?check_run_id=2342446944
7133 runs, 14121 assertions, 38 failures, 1590 errors, 37 skips