### PR TITLE
Use native String#end_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 - [#872](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/872) Use native String#start_with
+- [#876](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/876) Use native String#end_with
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -51,7 +51,7 @@ module ActiveRecord
               index[:index_keys].split(",").each do |column|
                 column.strip!
 
-                if column.ends_with?("(-)")
+                if column.end_with?("(-)")
                   column.gsub! "(-)", ""
                   orders[column] = :desc
                 end


### PR DESCRIPTION
Use native `String#end_with`. 

https://pipelines.actions.githubusercontent.com/OGQvFf2eDbGUprKdJ5qsq3TsAFLfKWDWAJCyTHn8ess0fbvp0X/_apis/pipelines/1/runs/53/signedlogcontent/5?urlExpires=2021-04-14T12%3A49%3A18.6442657Z&urlSigningMethod=HMACV1&urlSignature=Nj9xc83Vha%2BjgCoMNWk1PA2oxHAYlZxKZ6XEZZ%2FmdlI%3D
```
2021-04-14T11:16:33.3266361Z ActiveRecord::Migration::ReferencesForeignKeyTest#test_0006_foreign key column can be removed:
2021-04-14T11:16:33.3268084Z NoMethodError: undefined method `ends_with?' for "testing_parent_id":String
2021-04-14T11:16:33.3268734Z Did you mean?  end_with?
```