### PR TITLE
Added missing changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Fixed
 
 - [#872](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/872) Use native String#start_with
+- [#873](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/873) Various fixes to get the tests running for Rails 6.1
+- [#874](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/874) Deduplicate schema cache structures
 
 #### Changed
 


### PR DESCRIPTION
Updated the changelog to include:

- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/873
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/874