### PR TITLE
Handle any default column class when deduplicating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#874](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/874) Deduplicate schema cache structures
 - [#875](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/875) Handle default boolean column values when deduplicating
 - [#879](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/879) Added visit method for HomogeneousIn
+- [#880](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880) Handle any default column class when deduplicating
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -30,13 +30,14 @@ module ActiveRecord
 
       private
 
-      # Handle when the default value is a boolean. Boolean's do not respond to the method `:-@`. Method now
-      # checks whether the default value is already frozen and if so it uses that, otherwise it calls `:-@` to
-      # freeze it.
+      # In the Rails version of this method there is an assumption that the `default` value will always be a
+      # `String` class, which must be true for the MySQL/PostgreSQL/SQLite adapters. However, in the SQL Server
+      # adapter the `default` value can also be Boolean/Date/Time/etc. Changed the implementation of this method
+      # to handle non-String `default` objects.
       def deduplicated
         @name = -name
         @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
-        @default = (default.frozen? ? default : -default) if default
+        @default = (default.is_a?(String) ? -default : default.dup.freeze) if default
         @default_function = -default_function if default_function
         @collation = -collation if collation
         @comment = -comment if comment


### PR DESCRIPTION
Previously in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/875 the column deduplication method was updated to handle default boolean values. The change did not handle other non-string classes such as Time/Date/Integer/etc. This is the cause of the `NoMethodError: undefined method '-@'` errors in the main CI build:

https://pipelines.actions.githubusercontent.com/OGQvFf2eDbGUprKdJ5qsq3TsAFLfKWDWAJCyTHn8ess0fbvp0X/_apis/pipelines/1/runs/67/signedlogcontent/6?urlExpires=2021-04-15T12%3A48%3A19.5876504Z&urlSigningMethod=HMACV1&urlSignature=BboOo2lvNJlxvLAzbOHeep1jlPH%2FtSuW75%2BiBiJvq1s%3D

Updated the `ActiveRecord::ConnectionAdapters::SQLServerColumn#deduplicated` method to create a frozen copy of any object that is not a String.

**Before**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2354091308
7133 runs, 18455 assertions, 26 failures, 145 errors, 37 skips

**After**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880/checks?check_run_id=2354573868
7133 runs, 20119 assertions, 25 failures, 80 errors, 37 skips
