### PR TITLE
Dump column collation to schema.rb and allow collation changes using column_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#879](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/879) Added visit method for HomogeneousIn
 - [#880](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880) Handle any default column class when deduplicating
 - [#861](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/861) Fix Rails 6.1 database config
+- [#881](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/881) Dump column collation to schema.rb and allow collation changes using column_change
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -38,6 +38,9 @@ module ActiveRecord
           if options[:null] == false
             sql << " NOT NULL"
           end
+          if options[:collation].present?
+            sql << " COLLATE #{options[:collation]}"
+          end
           if options[:is_identity] == true
             sql << " IDENTITY(1,1)"
           end

--- a/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
@@ -27,7 +27,13 @@ module ActiveRecord
         def schema_collation(column)
           return unless column.collation
 
-          column.collation if column.collation != @connection.collation
+          # use inspect to ensure collation is dumped as string. Without this it's dumped as
+          # a constant ('collation: SQL_Latin1_General_CP1_CI_AS')
+          collation = column.collation.inspect
+          # use inspect to ensure string comparison
+          default_collation = @connection.collation.inspect
+
+          collation if collation != default_collation
         end
 
         def default_primary_key?(column)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -156,6 +156,7 @@ module ActiveRecord
           end
           sql_commands << "UPDATE #{quote_table_name(table_name)} SET #{quote_column_name(column_name)}=#{quote_default_expression(options[:default], column_object)} WHERE #{quote_column_name(column_name)} IS NULL" if !options[:null].nil? && options[:null] == false && !options[:default].nil?
           alter_command = "ALTER TABLE #{quote_table_name(table_name)} ALTER COLUMN #{quote_column_name(column_name)} #{type_to_sql(type, limit: options[:limit], precision: options[:precision], scale: options[:scale])}"
+          alter_command += " COLLATE #{options[:collation]}" if options[:collation].present?
           alter_command += " NOT NULL" if !options[:null].nil? && options[:null] == false
           sql_commands << alter_command
           if without_constraints

--- a/test/cases/change_column_collation_test_sqlserver.rb
+++ b/test/cases/change_column_collation_test_sqlserver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+require "migrations/create_clients_and_change_column_collation"
+
+class ChangeColumnCollationTestSqlServer < ActiveRecord::TestCase
+  before do
+    @old_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+    CreateClientsAndChangeColumnCollation.new.up
+  end
+
+  after do
+    CreateClientsAndChangeColumnCollation.new.down
+    ActiveRecord::Migration.verbose = @old_verbose
+  end
+
+  def find_column(table, name)
+    table.find { |column| column.name == name }
+  end
+
+  let(:clients_table) { connection.columns("clients") }
+  let(:name_column) { find_column(clients_table, "name") }
+  let(:code_column) { find_column(clients_table, "code") }
+
+  it "change column collation to other than default" do
+    _(name_column.collation).must_equal "SQL_Latin1_General_CP1_CS_AS"
+  end
+
+  it "change column collation to default" do
+    _(code_column.collation).must_equal "SQL_Latin1_General_CP1_CI_AS"
+  end
+end

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -63,6 +63,13 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
     it "change null and default" do
       assert_nothing_raised { connection.change_column :people, :first_name, :text, null: true, default: nil }
     end
+
+    it "change collation" do
+      assert_nothing_raised { connection.change_column :sst_string_collation, :string_with_collation, :varchar, collation: :SQL_Latin1_General_CP437_BIN }
+
+      SstStringCollation.reset_column_information
+      assert_equal "SQL_Latin1_General_CP437_BIN", SstStringCollation.columns_hash['string_with_collation'].collation
+    end
   end
 
   describe "#create_schema" do

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -119,6 +119,15 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :json_col,          type: "text",           limit: nil,           precision: nil,   scale: nil,  default: nil
   end
 
+  it "dump column collation" do
+    generate_schema_for_table('sst_string_collation')
+
+    assert_line :string_without_collation, type: "string", limit: nil, default: nil, collation: nil
+    assert_line :string_default_collation, type: "varchar", limit: nil, default: nil, collation: nil
+    assert_line :string_with_collation, type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
+    assert_line :varchar_with_collation, type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
+  end
+
   # Special Cases
 
   it "honor nonstandard primary keys" do

--- a/test/migrations/create_clients_and_change_column_collation.rb
+++ b/test/migrations/create_clients_and_change_column_collation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateClientsAndChangeColumnCollation < ActiveRecord::Migration[5.2]
+  def up
+    create_table :clients do |t|
+      t.string :name
+      t.string :code, collation: :SQL_Latin1_General_CP1_CS_AS
+
+      t.timestamps
+    end
+
+    change_column :clients, :name, :string, collation: 'SQL_Latin1_General_CP1_CS_AS'
+    change_column :clients, :code, :string, collation: 'SQL_Latin1_General_CP1_CI_AS'
+  end
+
+  def down
+    drop_table :clients
+  end
+end

--- a/test/models/sqlserver/sst_string_collation.rb
+++ b/test/models/sqlserver/sst_string_collation.rb
@@ -1,0 +1,3 @@
+class SstStringCollation < ActiveRecord::Base
+  self.table_name = "sst_string_collation"
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -95,6 +95,13 @@ ActiveRecord::Schema.define do
     t.column :string_with_multiline_default, :string, default: "Some long default with a\nnew line."
   end
 
+  create_table :sst_string_collation, collation: :SQL_Latin1_General_CP1_CI_AS, force: true do |t|
+    t.string :string_without_collation
+    t.varchar :string_default_collation, collation: :SQL_Latin1_General_CP1_CI_AS
+    t.varchar :string_with_collation, collation: :SQL_Latin1_General_CP1_CS_AS
+    t.varchar :varchar_with_collation, collation: :SQL_Latin1_General_CP1_CS_AS
+  end
+
   create_table :sst_edge_schemas, force: true do |t|
     t.string :description
     t.column "crazy]]quote", :string


### PR DESCRIPTION
This PR address https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/848. 

It also adds support to change collation `change_column :customers, :name, collation: :xxx`. Before this change, collation changes were skipped/ignored.
