### PR TITLE
Rails 6.1 fixes: Use renamed connection_config method and rewrite coerced tests using unsafe raw SQL

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1233,19 +1233,18 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   # Use LEN() vs length() function.
   coerce_tests! %r{order: always allows Arel}
   test "order: always allows Arel" do
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order(Arel.sql("len(title)")).pluck(:title) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order(Arel.sql("len(title)")).pluck(:title) }
+    titles = Post.order(Arel.sql("len(title)")).pluck(:title)
 
-    assert_equal ids_depr, ids_disabled
+    assert_not_empty titles
   end
 
   # Use LEN() vs length() function.
   coerce_tests! %r{pluck: always allows Arel}
   test "pluck: always allows Arel" do
-    values_depr     = with_unsafe_raw_sql_deprecated { Post.includes(:comments).pluck(:title, Arel.sql("len(title)")) }
-    values_disabled = with_unsafe_raw_sql_disabled   { Post.includes(:comments).pluck(:title, Arel.sql("len(title)")) }
+    excepted_values = Post.includes(:comments).pluck(:title).map { |title| [title, title.size] }
+    values = Post.includes(:comments).pluck(:title, Arel.sql("len(title)"))
 
-    assert_equal values_depr, values_disabled
+    assert_equal excepted_values, values
   end
 
   # Use LEN() vs length() function.
@@ -1253,91 +1252,73 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows valid Array arguments" do
     ids_expected = Post.order(Arel.sql("author_id, len(title)")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order(["author_id", "len(title)"]).pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order(["author_id", "len(title)"]).pluck(:id) }
+    ids = Post.order(["author_id", "len(title)"]).pluck(:id)
 
-    assert_equal ids_expected, ids_depr
-    assert_equal ids_expected, ids_disabled
+    assert_equal ids_expected, ids
   end
 
   test "order: allows string column names that are quoted" do
     ids_expected = Post.order(Arel.sql("id")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order("[id]").pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order("[id]").pluck(:id) }
+    ids = Post.order("[id]").pluck(:id)
 
-    assert_equal ids_expected, ids_depr
-    assert_equal ids_expected, ids_disabled
+    assert_equal ids_expected, ids
   end
 
   test "order: allows string column names that are quoted with table" do
     ids_expected = Post.order(Arel.sql("id")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order("[posts].[id]").pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order("[posts].[id]").pluck(:id) }
+    ids = Post.order("[posts].[id]").pluck(:id)
 
-    assert_equal ids_expected, ids_depr
-    assert_equal ids_expected, ids_disabled
+    assert_equal ids_expected, ids
   end
 
   test "order: allows string column names that are quoted with table and user" do
     ids_expected = Post.order(Arel.sql("id")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order("[dbo].[posts].[id]").pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order("[dbo].[posts].[id]").pluck(:id) }
+    ids = Post.order("[dbo].[posts].[id]").pluck(:id)
 
-    assert_equal ids_expected, ids_depr
-    assert_equal ids_expected, ids_disabled
+    assert_equal ids_expected, ids
   end
 
   test "order: allows string column names that are quoted with table, user and database" do
     ids_expected = Post.order(Arel.sql("id")).pluck(:id)
 
-    ids_depr     = with_unsafe_raw_sql_deprecated { Post.order("[activerecord_unittest].[dbo].[posts].[id]").pluck(:id) }
-    ids_disabled = with_unsafe_raw_sql_disabled   { Post.order("[activerecord_unittest].[dbo].[posts].[id]").pluck(:id) }
+    ids = Post.order("[activerecord_unittest].[dbo].[posts].[id]").pluck(:id)
 
-    assert_equal ids_expected, ids_depr
-    assert_equal ids_expected, ids_disabled
+    assert_equal ids_expected, ids
   end
 
   test "pluck: allows string column name that are quoted" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles_depr     = with_unsafe_raw_sql_deprecated { Post.pluck("[title]") }
-    titles_disabled = with_unsafe_raw_sql_disabled   { Post.pluck("[title]") }
+    titles = Post.pluck("[title]")
 
-    assert_equal titles_expected, titles_depr
-    assert_equal titles_expected, titles_disabled
+    assert_equal titles_expected, titles
   end
 
   test "pluck: allows string column name that are quoted with table" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles_depr     = with_unsafe_raw_sql_deprecated { Post.pluck("[posts].[title]") }
-    titles_disabled = with_unsafe_raw_sql_disabled   { Post.pluck("[posts].[title]") }
+    titles = Post.pluck("[posts].[title]")
 
-    assert_equal titles_expected, titles_depr
-    assert_equal titles_expected, titles_disabled
+    assert_equal titles_expected, titles
   end
 
   test "pluck: allows string column name that are quoted with table and user" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles_depr     = with_unsafe_raw_sql_deprecated { Post.pluck("[dbo].[posts].[title]") }
-    titles_disabled = with_unsafe_raw_sql_disabled   { Post.pluck("[dbo].[posts].[title]") }
+    titles = Post.pluck("[dbo].[posts].[title]")
 
-    assert_equal titles_expected, titles_depr
-    assert_equal titles_expected, titles_disabled
+    assert_equal titles_expected, titles
   end
 
   test "pluck: allows string column name that are quoted with table, user and database" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    titles_depr     = with_unsafe_raw_sql_deprecated { Post.pluck("[activerecord_unittest].[dbo].[posts].[title]") }
-    titles_disabled = with_unsafe_raw_sql_disabled   { Post.pluck("[activerecord_unittest].[dbo].[posts].[title]") }
+    titles = Post.pluck("[activerecord_unittest].[dbo].[posts].[title]")
 
-    assert_equal titles_expected, titles_depr
-    assert_equal titles_expected, titles_disabled
+    assert_equal titles_expected, titles
   end
 end
 

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -10,7 +10,7 @@ class SQLServerRakeTest < ActiveRecord::TestCase
 
   let(:db_tasks)              { ActiveRecord::Tasks::DatabaseTasks }
   let(:new_database)          { "activerecord_unittest_tasks" }
-  let(:default_configuration) { ARTest.connection_config["arunit"] }
+  let(:default_configuration) { ARTest.test_configuration_hashes["arunit"] }
   let(:configuration)         { default_configuration.merge("database" => new_database) }
 
   before { skip "on azure" if azure_skip }


### PR DESCRIPTION
This PR contains two fixes:

1. ARTest.connfiguration_config was renamed (see https://github.com/rails/rails/pull/38007)
2. Rewrite `UnsafeRawSqlTest` coerced tests because unsafe raw SQL support was removed (see https://github.com/rails/rails/commit/317465a4a8f8c0ebaf9534921350c4540584c03c)