### PR TITLE
Rails 6.1: Fix 'TypeError: can't quote ActiveRecord::Relation::QueryAttribute'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#879](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/879) Added visit method for HomogeneousIn
 - [#880](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880) Handle any default column class when deduplicating
 - [#861](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/861) Fix Rails 6.1 database config
+- [#883](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/885) Fix quoting of ActiveRecord::Relation::QueryAttribute and ActiveModel::Attributes
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
             binds.each_with_index do |bind, index|
 
-              value = if ::ActiveModel::Attribute === bind then
+              value = if bind.is_a?(::ActiveModel::Attribute)  then
                 connection.quote(bind.value_for_database)
               else
                 connection.quote(bind)

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -27,7 +27,12 @@ module ActiveRecord
             executesql = executesql.match(SQLSERVER_STATEMENT_REGEXP).to_a[1]
 
             binds.each_with_index do |bind, index|
-              value = connection.quote(bind)
+
+              value = if ::ActiveModel::Attribute === bind then
+                connection.quote(bind.value_for_database)
+              else
+                connection.quote(bind)
+              end
               executesql = executesql.sub("@#{index}", value)
             end
 

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -79,7 +79,7 @@ module Arel
 
         if values.empty?
           collector << @connection.quote(nil)
-        else
+        elsif @connection.prepared_statements
           # Monkey-patch start. Add query attribute bindings rather than just values.
           column_name = o.column_name
           column_type = o.attribute.relation.type_for_attribute(o.column_name)
@@ -87,6 +87,8 @@ module Arel
 
           collector.add_binds(attrs, &bind_block)
           # Monkey-patch end.
+        else
+          collector.add_binds(values, &bind_block)
         end
 
         collector << ")"


### PR DESCRIPTION
There are some test failing due to `TypeError: can't quote ActiveRecord::Relation::QueryAttribute`.

I found two places where this was happening:

1. `visit_Arel_Nodes_HomogeneousIn` is binding `ActiveRecord::Relation::QueryAttribute` even for unprepared statements (.i.e `Post.where(author: [1, 2]).to_sql`). Unprepared statement uses [`Arel::Collectors::SubstituteBinds`](https://github.com/rails/rails/blob/v6.1.0/activerecord/lib/arel/collectors/substitute_binds.rb) which quote the binded value (see [abstract_adapter](https://github.com/rails/rails/blob/v6.1.0/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L729) to confirm what I'm saying)
2. explain receives instances of `::ActiveModel::Attribute` (not only by `visit_Arel_Nodes_HomogeneousIn` hack).
