### PR TITLE
Rails 6.1: remove deprecation warnings

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -190,7 +190,7 @@ module ActiveRecord
         end
 
         def rename_index(table_name, old_name, new_name)
-          raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters" if new_name.length > allowed_index_name_length
+          raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters" if new_name.length > index_name_length
 
           identifier = SQLServer::Utils.extract_identifiers("#{table_name}.#{old_name}")
           execute_procedure :sp_rename, identifier.quoted, new_name, "INDEX"

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -53,7 +53,8 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert Topic.table_exists?, "Topics table name of 'dbo.topics' should return true for exists."
 
       # Test when database and owner included in table name.
-      Topic.table_name = "#{ActiveRecord::Base.configurations["arunit"]['database']}.dbo.topics"
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      Topic.table_name = "#{db_config.database}.dbo.topics"
       assert Topic.table_exists?, "Topics table name of '[DATABASE].dbo.topics' should return true for exists."
     ensure
       Topic.table_name = "topics"
@@ -100,21 +101,23 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   it "test bad connection" do
     assert_raise ActiveRecord::NoDatabaseError do
-      config = ActiveRecord::Base.configurations["arunit"].merge(database: "inexistent_activerecord_unittest")
-      ActiveRecord::Base.sqlserver_connection config
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      configuration = db_config.configuration_hash.merge(database: "inexistent_activerecord_unittest")
+      ActiveRecord::Base.sqlserver_connection configuration
     end
   end
 
   it "test database exists returns false if database does not exist" do
-    config = ActiveRecord::Base.configurations["arunit"].merge(database: "inexistent_activerecord_unittest")
-    assert_not ActiveRecord::ConnectionAdapters::SQLServerAdapter.database_exists?(config),
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+    configuration = db_config.configuration_hash.merge(database: "inexistent_activerecord_unittest")
+    assert_not ActiveRecord::ConnectionAdapters::SQLServerAdapter.database_exists?(configuration),
                "expected database to not exist"
   end
 
   it "test database exists returns true when the database exists" do
-    config = ActiveRecord::Base.configurations["arunit"]
-    assert ActiveRecord::ConnectionAdapters::SQLServerAdapter.database_exists?(config),
-           "expected database #{config[:database]} to exist"
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+    assert ActiveRecord::ConnectionAdapters::SQLServerAdapter.database_exists?(db_config.configuration_hash),
+           "expected database #{db_config.database} to exist"
   end
 
   describe "with different language" do

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -329,14 +329,18 @@ module ActiveRecord
       coerce_tests! :test_quote_ar_object
       def test_quote_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "'02-14-2017 12:34:56.79'", @connection.quote(value)
+        assert_deprecated do
+          assert_equal "'02-14-2017 12:34:56.79'", @connection.quote(value)
+        end
       end
 
       # Use our date format.
       coerce_tests! :test_type_cast_ar_object
       def test_type_cast_ar_object_coerced
         value = DatetimePrimaryKey.new(id: @time)
-        assert_equal "02-14-2017 12:34:56.79", @connection.type_cast(value)
+        assert_deprecated do
+          assert_equal "02-14-2017 12:34:56.79", @connection.type_cast(value)
+        end
       end
     end
   end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -900,7 +900,14 @@ class RelationTest < ActiveRecord::TestCase
   coerce_tests! :test_reorder_with_first
   def test_reorder_with_first_coerced
     sql_log = capture_sql do
-      assert Post.order(:title).reorder(nil).first
+      message = <<~MSG.squish
+        `.reorder(nil)` with `.first` / `.first!` no longer
+        takes non-deterministic result in Rails 6.2.
+        To continue taking non-deterministic result, use `.take` / `.take!` instead.
+      MSG
+      assert_deprecated(message) do
+        assert Post.order(:title).reorder(nil).first
+      end
     end
     assert sql_log.none? { |sql| /order by [posts].[title]/i.match?(sql) }, "ORDER BY title was used in the query: #{sql_log}"
     assert sql_log.all?  { |sql| /order by \[posts\]\.\[id\]/i.match?(sql) }, "default ORDER BY ID was not used in the query: #{sql_log}"


### PR DESCRIPTION
This PR deals with 4 deprecation warnings by looking at the deprecation commit and applying a similar update.

1. `allowed_index_name_length is deprecated and will be removed from Rails 6.2` (source https://github.com/rails/rails/commit/ab2d859e6c5430326a22a1328cc296c8cbae8727)
2. `[] is deprecated and will be removed from Rails 6.2 (Use configs_for)` (source https://github.com/rails/rails/commit/2a53fe638de2c485c2655b6b7236ec1ab7dca5ad)
3. `Passing an Active Record object to directly is deprecated and will be no longer quoted as id value in Rails 6.2` (source https://github.com/rails/rails/commit/87886c93dc22d528d8529d8b63873f699beaf695)
4. `.reorder(nil) with .first / .first! no longer takes non-deterministic result in Rails 6.2. To continue taking non-deterministic result, use / instead.` (source https://github.com/rails/rails/commit/eec562dbcf5624e38085b8262512a6584784dfdc)
