### PR TITLE
Rails 6.1: Fix the quoting of ActiveModel attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [#879](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/879) Added visit method for HomogeneousIn
 - [#880](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880) Handle any default column class when deduplicating
 - [#861](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/861) Fix Rails 6.1 database config
-- [#885](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/885) Fix when quoting ActiveModel::Attribute
+- [#885](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/885) Fix the quoting of ActiveModel attributes
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#879](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/879) Added visit method for HomogeneousIn
 - [#880](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/880) Handle any default column class when deduplicating
 - [#861](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/861) Fix Rails 6.1 database config
+- [#885](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/885) Fix when quoting ActiveModel::Attribute
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -118,6 +118,8 @@ module ActiveRecord
             value.quoted
           when String, ActiveSupport::Multibyte::Chars
             "#{QUOTED_STRING_PREFIX}#{super}"
+          when ActiveModel::Attribute
+            quote(value.value_for_database)
           else
             super
           end


### PR DESCRIPTION
PR fixes the `TypeError: can't quote ActiveRecord::Relation::QueryAttribute` errors in the tests. 

This is an alternative fix to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/883