### PR TITLE
Rails 6.1: Coerce tests that check for LIMIT in SQL

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -695,6 +695,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_member_on_unloaded_relation_without_match
   def test_member_on_unloaded_relation_without_match_coerced
     assert_sql(/1 AS one.*FETCH NEXT @2 ROWS ONLY.*@2 = 1/) do
       assert_equal false, Customer.where(name: "David").member?(customers(:mary))

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -620,7 +620,11 @@ class EagerAssociationTest < ActiveRecord::TestCase
 end
 
 require "models/topic"
+require "models/customer"
+require "models/non_primary_key"
 class FinderTest < ActiveRecord::TestCase
+  fixtures :customers, :topics, :authors
+
   # We have implicit ordering, via FETCH.
   coerce_tests! %r{doesn't have implicit ordering},
                 :test_find_doesnt_have_implicit_ordering
@@ -664,6 +668,83 @@ class FinderTest < ActiveRecord::TestCase
         assert_equal topic, Topic.where(written_on: topic.written_on.getlocal).first
       end
     end
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_include_on_unloaded_relation_with_match
+  def test_include_on_unloaded_relation_with_match_coerced
+    assert_sql(/1 AS one.*FETCH NEXT @2 ROWS ONLY.*@2 = 1/) do
+      assert_equal true, Customer.where(name: "David").include?(customers(:david))
+    end
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_include_on_unloaded_relation_without_match
+  def test_include_on_unloaded_relation_without_match_coerced
+    assert_sql(/1 AS one.*FETCH NEXT @2 ROWS ONLY.*@2 = 1/) do
+      assert_equal false, Customer.where(name: "David").include?(customers(:mary))
+    end
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_member_on_unloaded_relation_with_match
+  def test_member_on_unloaded_relation_with_match_coerced
+    assert_sql(/1 AS one.*FETCH NEXT @2 ROWS ONLY.*@2 = 1/) do
+      assert_equal true, Customer.where(name: "David").member?(customers(:david))
+    end
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  def test_member_on_unloaded_relation_without_match_coerced
+    assert_sql(/1 AS one.*FETCH NEXT @2 ROWS ONLY.*@2 = 1/) do
+      assert_equal false, Customer.where(name: "David").member?(customers(:mary))
+    end
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_implicit_order_column_is_configurable
+  def test_implicit_order_column_is_configurable_coerced
+    old_implicit_order_column = Topic.implicit_order_column
+    Topic.implicit_order_column = "title"
+
+    assert_equal topics(:fifth), Topic.first
+    assert_equal topics(:third), Topic.last
+
+    c = Topic.connection
+    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.title"))} DESC, #{Regexp.escape(c.quote_table_name("topics.id"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
+      Topic.last
+    }
+  ensure
+    Topic.implicit_order_column = old_implicit_order_column
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_implicit_order_set_to_primary_key
+  def test_implicit_order_set_to_primary_key_coerced
+    old_implicit_order_column = Topic.implicit_order_column
+    Topic.implicit_order_column = "id"
+
+    c = Topic.connection
+    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
+      Topic.last
+    }
+  ensure
+    Topic.implicit_order_column = old_implicit_order_column
+  end
+
+  # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
+  coerce_tests! :test_implicit_order_for_model_without_primary_key
+  def test_implicit_order_for_model_without_primary_key_coerced
+    old_implicit_order_column = NonPrimaryKey.implicit_order_column
+    NonPrimaryKey.implicit_order_column = "created_at"
+
+    c = NonPrimaryKey.connection
+
+    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("non_primary_keys.created_at"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
+      NonPrimaryKey.last
+    }
+  ensure
+    NonPrimaryKey.implicit_order_column = old_implicit_order_column
   end
 end
 


### PR DESCRIPTION
Coerced some failing `FinderTest` tests that were checking for `LIMIT` in the generated SQL. The SQL Server adapter uses `FETCH NEXT x ROWS ONLY` instead of `LIMIT`.

**Before**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2382157889
7130 runs, 20222 assertions, 28 failures, 33 errors, 36 skips

**After**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/886/checks?check_run_id=2381988705
7125 runs, 20207 assertions, 22 failures, 36 errors, 37 skips