### PR TITLE
Rails 6.1: Fixes related to `while_preventing_writes`

### DIFF
--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -469,12 +469,11 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
   describe "block writes to a database" do
     def setup
       @conn = ActiveRecord::Base.connection
-      @connection_handler = ActiveRecord::Base.connection_handler
     end
 
     def test_errors_when_an_insert_query_is_called_while_preventing_writes
       assert_raises(ActiveRecord::ReadOnlyError) do
-        @connection_handler.while_preventing_writes do
+        ActiveRecord::Base.while_preventing_writes do
           @conn.insert("INSERT INTO [subscribers] ([nick]) VALUES ('aido')")
         end
       end
@@ -484,7 +483,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       @conn.insert("INSERT INTO [subscribers] ([nick]) VALUES ('aido')")
 
       assert_raises(ActiveRecord::ReadOnlyError) do
-        @connection_handler.while_preventing_writes do
+        ActiveRecord::Base.while_preventing_writes do
           @conn.update("UPDATE [subscribers] SET [subscribers].[name] = 'Aidan' WHERE [subscribers].[nick] = 'aido'")
         end
       end
@@ -494,7 +493,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       @conn.execute("INSERT INTO [subscribers] ([nick]) VALUES ('aido')")
 
       assert_raises(ActiveRecord::ReadOnlyError) do
-        @connection_handler.while_preventing_writes do
+        ActiveRecord::Base.while_preventing_writes do
           @conn.execute("DELETE FROM [subscribers] WHERE [subscribers].[nick] = 'aido'")
         end
       end
@@ -503,7 +502,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
       @conn.execute("INSERT INTO [subscribers] ([nick]) VALUES ('aido')")
 
-      @connection_handler.while_preventing_writes do
+      ActiveRecord::Base.while_preventing_writes do
         assert_equal 1, @conn.execute("SELECT * FROM [subscribers] WHERE [subscribers].[nick] = 'aido'")
       end
     end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -159,7 +159,7 @@ class BasicsTest < ActiveRecord::TestCase
   # SQL Server does not have query for release_savepoint
   coerce_tests! %r{an empty transaction does not raise if preventing writes}
   test "an empty transaction does not raise if preventing writes coerced" do
-    ActiveRecord::Base.connection_handler.while_preventing_writes do
+    ActiveRecord::Base.while_preventing_writes do
       assert_queries(1, ignore_none: true) do
         Bird.transaction do
           ActiveRecord::Base.connection.materialize_transactions

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -48,6 +48,17 @@ module ActiveRecord
 end
 
 module ActiveRecord
+  class AdapterPreventWritesTest < ActiveRecord::TestCase
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
+    coerce_tests! :test_errors_when_an_insert_query_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_is_called_while_preventing_writes_coerced
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_is_called_while_preventing_writes
+    end
+  end
+end
+
+module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     # SQL Server does not allow truncation of tables that are referenced by foreign key
     # constraints. So manually remove/add foreign keys in test.

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -59,6 +59,22 @@ module ActiveRecord
 end
 
 module ActiveRecord
+  class AdapterPreventWritesLegacyTest < ActiveRecord::TestCase
+    # We do some read queries. Remove assert_no_queries
+    coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes_coerced
+      @connection_handler.while_preventing_writes do
+        @connection.transaction do
+          assert_raises(ActiveRecord::ReadOnlyError) do
+            @connection.insert("/* some comment */ INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          end
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
   class AdapterTestWithoutTransaction < ActiveRecord::TestCase
     # SQL Server does not allow truncation of tables that are referenced by foreign key
     # constraints. So manually remove/add foreign keys in test.


### PR DESCRIPTION
In Rails 6.1 while_preventing_writes moved to be called on Base since we no longer have multiple connection_handlers. See https://github.com/rails/rails/pull/40489

**Before**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2384484016?check_suite_focus=true
7137 runs, 20305 assertions, 18 failures, 18 errors, 36 skips

**After**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2384587422?check_suite_focus=true
7137 runs, 20302 assertions, 15 failures, 16 errors, 36 skips