### PR TITLE
Rails 6.1 fixes: coerce bind param test and fix pool spec access

### DIFF
--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -65,8 +65,8 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     arunit_connection = Topic.connection
     arunit2_connection = College.connection
 
-    arunit_database = arunit_connection.pool.spec.config[:database]
-    arunit2_database = arunit2_connection.pool.spec.config[:database]
+    arunit_database = arunit_connection.pool.db_config.database
+    arunit2_database = arunit2_connection.pool.db_config.database
 
     # Assert that connections use different default databases schemas.
     assert_not_equal arunit_database, arunit2_database

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -217,6 +217,55 @@ module ActiveRecord
     coerce_tests! :test_statement_cache_with_find_by
     coerce_tests! :test_statement_cache_with_in_clause
     coerce_tests! :test_statement_cache_with_sql_string_literal
+
+    # Same as original coerced test except prepared statements include `EXEC sp_executesql` wrapper.
+    coerce_tests! :test_bind_params_to_sql_with_prepared_statements, :test_bind_params_to_sql_with_unprepared_statements
+    def test_bind_params_to_sql_with_prepared_statements_coerced
+      assert_bind_params_to_sql_coerced(prepared: true)
+    end
+
+    def test_bind_params_to_sql_with_unprepared_statements_coerced
+      @connection.unprepared_statement do
+        assert_bind_params_to_sql_coerced(prepared: false)
+      end
+    end
+
+    private
+
+    def assert_bind_params_to_sql_coerced(prepared:)
+      table = Author.quoted_table_name
+      pk = "#{table}.#{Author.quoted_primary_key}"
+
+      # prepared_statements: true
+      #
+      #   EXEC sp_executesql N'SELECT [authors].* FROM [authors] WHERE [authors].[id] IN (@0, @1, @2) OR [authors].[id] IS NULL)', N'@0 bigint, @1 bigint, @2 bigint', @0 = 1, @1 = 2, @2 = 3
+      #
+      # prepared_statements: false
+      #
+      #   SELECT [authors].* FROM [authors] WHERE ([authors].[id] IN (1, 2, 3) OR [authors].[id] IS NULL)
+      #
+      sql_unprepared = "SELECT #{table}.* FROM #{table} WHERE (#{pk} IN (#{bind_params(1..3)}) OR #{pk} IS NULL)"
+      sql_prepared = "EXEC sp_executesql N'SELECT #{table}.* FROM #{table} WHERE (#{pk} IN (#{bind_params(1..3)}) OR #{pk} IS NULL)', N'@0 bigint, @1 bigint, @2 bigint', @0 = 1, @1 = 2, @2 = 3"
+
+      authors = Author.where(id: [1, 2, 3, nil])
+      assert_equal sql_unprepared, @connection.to_sql(authors.arel)
+      assert_sql(prepared ? sql_prepared : sql_unprepared) { assert_equal 3, authors.length }
+
+      # prepared_statements: true
+      #
+      #   EXEC sp_executesql N'SELECT [authors].* FROM [authors] WHERE [authors].[id] IN (@0, @1, @2)', N'@0 bigint, @1 bigint, @2 bigint', @0 = 1, @1 = 2, @2 = 3
+      #
+      # prepared_statements: false
+      #
+      #   SELECT [authors].* FROM [authors] WHERE [authors].[id] IN (1, 2, 3)
+      #
+      sql_unprepared = "SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})"
+      sql_prepared = "EXEC sp_executesql N'SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})', N'@0 bigint, @1 bigint, @2 bigint', @0 = 1, @1 = 2, @2 = 3"
+
+      authors = Author.where(id: [1, 2, 3, 9223372036854775808])
+      assert_equal sql_unprepared, @connection.to_sql(authors.arel)
+      assert_sql(prepared ? sql_prepared : sql_unprepared) { assert_equal 3, authors.length }
+    end
   end
 end
 


### PR DESCRIPTION
This PR contains two fixes:

1. use `db_config` to access connection_pool database configuration. Pool is not instantiated with ConnectionSpecification anymore (see https://github.com/rails/rails/commit/48c716bbfa971668cedd0fffa874459044459ea1#diff-642b90553b888bd2c724c093a1a685a5408a7d8293f3751366c25dc548936eb7)
2. coerce some bind_params tests. We include 'EXEC sp_executesql' on prepared statements