### PR TITLE
Rails 6.1: Remove coerced test no longer in Rails test suite

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -28,9 +28,6 @@ end
 require "models/event"
 module ActiveRecord
   class AdapterTest < ActiveRecord::TestCase
-    # I really don`t think we can support legacy binds.
-    coerce_tests! :test_insert_update_delete_with_legacy_binds
-
     # As far as I can tell, SQL Server does not support null bytes in strings.
     coerce_tests! :test_update_prepared_statement
 


### PR DESCRIPTION
Remove the coercing of the `ActiveRecord::AdapterTest#test_insert_update_delete_with_legacy_binds` test that is no longer in the Rails test suite.

This was missed in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/887 