### PR TITLE
Rails 6.1: Mark transaction as written if non-read SQL performed

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -17,6 +17,7 @@ module ActiveRecord
           end
 
           materialize_transactions
+          mark_transaction_written_if_write(sql)
 
           if id_insert_table_name = query_requires_identity_insert?(sql)
             with_identity_insert_enabled(id_insert_table_name) { do_execute(sql, name) }
@@ -31,6 +32,7 @@ module ActiveRecord
           end
 
           materialize_transactions
+          mark_transaction_written_if_write(sql)
 
           sp_executesql(sql, name, binds, prepare: prepare)
         end
@@ -291,6 +293,7 @@ module ActiveRecord
 
         def do_execute(sql, name = "SQL")
           materialize_transactions
+          mark_transaction_written_if_write(sql)
 
           log(sql, name) { raw_connection_do(sql) }
         end

--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -41,4 +41,13 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
     date_base = connection.select_value("select GETUTCDATE()")
     assert_equal date_base.change(usec: 0), date_proc.change(usec: 0)
   end
+
+  it 'test deprecation with transaction return when executing procedure' do
+    assert_deprecated do
+      ActiveRecord::Base.transaction do
+        connection.execute_procedure("my_getutcdate")
+        return
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixed the `Expected a deprecation warning within the block but received none` errors in the following tests:
- ConcurrentTransactionTest#test_deprecation_on_ruby_timeout
- ConcurrentTransactionTest#test_successful_with_return 
- TransactionTest#test_deprecation_on_ruby_timeout
- TransactionTest#test_successful_with_return

The tests were failing because of the changes made in https://github.com/rails/rails/pull/39453