### PR TITLE
Rails 6.1: Coerce annotation tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1602,7 +1602,47 @@ class FixturesTest < ActiveRecord::TestCase
 end
 
 class ReloadModelsTest < ActiveRecord::TestCase
-  # Skip test on Windows. The number of arguements passed to `IO.popen` in
+  # Skip test on Windows. The number of arguments passed to `IO.popen` in
   # `activesupport/lib/active_support/testing/isolation.rb` exceeds what Windows can handle.
   coerce_tests! :test_has_one_with_reload if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+end
+
+require "models/post"
+class AnnotateTest < ActiveRecord::TestCase
+  # Same as original coerced test except our SQL starts with `EXEC sp_executesql`.
+  coerce_tests! :test_annotate_wraps_content_in_an_inline_comment
+  def test_annotate_wraps_content_in_an_inline_comment_coerced
+    quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
+
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+      posts = Post.select(:id).annotate("foo")
+      assert posts.first
+    end
+  end
+
+  # Same as original coerced test except our SQL starts with `EXEC sp_executesql`.
+  coerce_tests! :test_annotate_is_sanitized
+  def test_annotate_is_sanitized_coerced
+    quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
+
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+      posts = Post.select(:id).annotate("*/foo/*")
+      assert posts.first
+    end
+
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+      posts = Post.select(:id).annotate("**//foo//**")
+      assert posts.first
+    end
+
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/ /\* bar \*/}i) do
+      posts = Post.select(:id).annotate("*/foo/*").annotate("*/bar")
+      assert posts.first
+    end
+
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \+ MAX_EXECUTION_TIME\(1\) \*/}i) do
+      posts = Post.select(:id).annotate("+ MAX_EXECUTION_TIME(1)")
+      assert posts.first
+    end
+  end
 end


### PR DESCRIPTION
Need to coerce the Rails annotation tests as they assume the generated SQL starts with `SELECT` but the SQL Server adapter queries start with `EXEC sp_executesql N'SELECT`.

Example:
```sql
EXEC sp_executesql N'SELECT [posts].[id] FROM [posts] /* foo */ ORDER BY [posts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY', N'@0 int', @0 = 1
```
