### PR TITLE
Rails 6.1: Removed deprecated in_clause_length method

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_limits.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_limits.rb
@@ -37,10 +37,6 @@ module ActiveRecord
         end
         deprecate :columns_per_multicolumn_index
 
-        def in_clause_length
-          10_000
-        end
-
         def sql_query_length
           65_536 * 4_096
         end


### PR DESCRIPTION
Remove deprecated `in_clause_length` method, which fixes:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2391966961#step:4:830
```
ActiveRecord::AdapterTest#test_in_clause_length_is_deprecated [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/adapter_test.rb:341]:
Expected a deprecation warning within the block but received none
```

**Before**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2391966961
7138 runs, 20328 assertions, 10 failures, 10 errors, 36 skips

**After**
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/900/checks?check_run_id=2392463332
7138 runs, 20350 assertions, 8 failures, 10 errors, 36 skips