### PR TITLE
Rails 6.1: coerce tests when we produce more or less queries

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -47,10 +47,17 @@ end
 module ActiveRecord
   class AdapterPreventWritesTest < ActiveRecord::TestCase
     # Fix randomly failing test. The loading of the model's schema was affecting the test.
+    # Also, we do some read queries. Remove assert_no_queries
     coerce_tests! :test_errors_when_an_insert_query_is_called_while_preventing_writes
     def test_errors_when_an_insert_query_is_called_while_preventing_writes_coerced
       Subscriber.send(:load_schema!)
-      original_test_errors_when_an_insert_query_is_called_while_preventing_writes
+      assert_raises(ActiveRecord::ReadOnlyError) do
+        ActiveRecord::Base.while_preventing_writes do
+          @connection.transaction do
+            @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          end
+        end
+      end
     end
   end
 end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1674,3 +1674,31 @@ class MarshalSerializationTest < ActiveRecord::TestCase
     )
   end
 end
+
+class BasePreventWritesTest < ActiveRecord::TestCase
+  # We open one transaction, not two. Same as original but checking one query
+  coerce_tests! %r{an empty transaction does not raise if preventing writes}
+  test "an empty transaction does not raise if preventing writes coerced" do
+    ActiveRecord::Base.while_preventing_writes do
+      assert_queries(1, ignore_none: true) do
+        Bird.transaction do
+          ActiveRecord::Base.connection.materialize_transactions
+        end
+      end
+    end
+  end
+end
+
+class BasePreventWritesLegacyTest < ActiveRecord::TestCase
+  # We open one transaction, not two. Same as original but checking one query
+  coerce_tests! %r{an empty transaction does not raise if preventing writes}
+  test "an empty transaction does not raise if preventing writes coerced" do
+    ActiveRecord::Base.connection_handler.while_preventing_writes do
+      assert_queries(1, ignore_none: true) do
+        Bird.transaction do
+          ActiveRecord::Base.connection.materialize_transactions
+        end
+      end
+    end
+  end
+end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -47,17 +47,10 @@ end
 module ActiveRecord
   class AdapterPreventWritesTest < ActiveRecord::TestCase
     # Fix randomly failing test. The loading of the model's schema was affecting the test.
-    # Also, we do some read queries. Remove assert_no_queries
     coerce_tests! :test_errors_when_an_insert_query_is_called_while_preventing_writes
     def test_errors_when_an_insert_query_is_called_while_preventing_writes_coerced
       Subscriber.send(:load_schema!)
-      assert_raises(ActiveRecord::ReadOnlyError) do
-        ActiveRecord::Base.while_preventing_writes do
-          @connection.transaction do
-            @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
-          end
-        end
-      end
+      original_test_errors_when_an_insert_query_is_called_while_preventing_writes
     end
   end
 end
@@ -74,6 +67,12 @@ module ActiveRecord
           end
         end
       end
+    end
+
+    coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes_coerced
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
     end
   end
 end


### PR DESCRIPTION
PR fixes the following failures:

```
BasePreventWritesTest::BasePreventWritesLegacyTest#test_0006_an empty transaction does not raise if preventing writes [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/base_prevent_writes_test.rb:164]:
1 instead of 2 queries were executed.
```
```
BasePreventWritesTest#test_0006_an empty transaction does not raise if preventing writes [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/base_prevent_writes_test.rb:61]:
1 instead of 2 queries were executed.
```
```
ActiveRecord::AdapterPreventWritesLegacyTest#test_errors_when_an_insert_query_is_called_while_preventing_writes [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/adapter_prevent_writes_test.rb:181]:
6 instead of 0 queries were executed.
```