### PR TITLE
Rails 6.1: change schema dumper condition to only dump explicit default for non identity integers

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         private
 
         def explicit_primary_key_default?(column)
-          column.is_primary? && !column.is_identity?
+          column.type == :integer && !column.is_identity?
         end
 
         def schema_limit(column)

--- a/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_dumper.rb
@@ -37,7 +37,7 @@ module ActiveRecord
         end
 
         def default_primary_key?(column)
-          super && column.is_primary? && column.is_identity?
+          super && column.is_identity?
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -332,7 +332,7 @@ module ActiveRecord
         def initialize_native_database_types
           {
             primary_key: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY",
-            primary_key_nonclustered: "int NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED",
+            primary_key_nonclustered: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED",
             integer: { name: "int", limit: 4 },
             bigint: { name: "bigint" },
             boolean: { name: "bit" },

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -9,7 +9,6 @@ module ActiveRecord
             options[:is_identity] = true unless options.key?(:default)
           elsif type == :uuid
             options[:default] = options.fetch(:default, "NEWID()")
-            options[:primary_key] = true
           end
           super
         end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1509,25 +1509,6 @@ class RelationMergingTest < ActiveRecord::TestCase
     relation = Post.all.merge(Post.order([Arel.sql("title LIKE ?"), "%suffix"]))
     assert_equal ["title LIKE N'%suffix'"], relation.order_values
   end
-
-  # Same as original but change first regexp to match sp_executesql binding syntax
-  coerce_tests! :test_merge_doesnt_duplicate_same_clauses
-  def test_merge_doesnt_duplicate_same_clauses_coerced
-    david, mary, bob = authors(:david, :mary, :bob)
-
-    non_mary_and_bob = Author.where.not(id: [mary, bob])
-
-    author_id = Author.connection.quote_table_name("authors.id")
-    assert_sql(/WHERE #{Regexp.escape(author_id)} NOT IN \((@\d), \g<1>\)'/) do
-      assert_equal [david], non_mary_and_bob.merge(non_mary_and_bob)
-    end
-
-    only_david = Author.where("#{author_id} IN (?)", david)
-
-    assert_sql(/WHERE \(#{Regexp.escape(author_id)} IN \(1\)\)\z/) do
-      assert_equal [david], only_david.merge(only_david)
-    end
-  end
 end
 
 module ActiveRecord

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1686,3 +1686,13 @@ class MarshalSerializationTest < ActiveRecord::TestCase
     )
   end
 end
+
+class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
+  # Same as original but add 'default: nil' option
+  coerce_tests! %r{schema dump primary key includes type and options}
+  test "schema dump primary key includes type and options coerced" do
+    schema = dump_table_schema "barcodes"
+    assert_match %r/create_table "barcodes", primary_key: "code", id: { type: :string, limit: 42, default: nil }/, schema
+    assert_no_match %r{t\.index \["code"\]}, schema
+  end
+end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1732,13 +1732,3 @@ class BasePreventWritesLegacyTest < ActiveRecord::TestCase
     end
   end
 end
-
-class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
-  # Same as original but add 'default: nil' option
-  coerce_tests! %r{schema dump primary key includes type and options}
-  test "schema dump primary key includes type and options coerced" do
-    schema = dump_table_schema "barcodes"
-    assert_match %r/create_table "barcodes", primary_key: "code", id: { type: :string, limit: 42, default: nil }/, schema
-    assert_no_match %r{t\.index \["code"\]}, schema
-  end
-end

--- a/test/cases/primary_keys_test_sqlserver.rb
+++ b/test/cases/primary_keys_test_sqlserver.rb
@@ -82,7 +82,7 @@ class PrimaryKeyIntegerTest < ActiveRecord::TestCase
     assert_match %r/create_table "widgets", force: :cascade do/, schema
   end
 
-  test "don't set itentity to integer and bigint when there is a default" do
+  test "don't set identity to integer and bigint when there is a default" do
     @connection.create_table(:barcodes, id: :integer, default: nil, force: true)
     @connection.create_table(:widgets, id: :bigint, default: nil, force: true)
 

--- a/test/cases/primary_keys_test_sqlserver.rb
+++ b/test/cases/primary_keys_test_sqlserver.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+require "support/schema_dumping_helper"
+
+class PrimaryKeyUuidTypeTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  self.use_transactional_tests = false
+
+  class Barcode < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:barcodes, primary_key: "code", id: :uuid, force: true)
+  end
+
+  teardown do
+    @connection.drop_table(:barcodes, if_exists: true)
+  end
+
+  def test_any_type_primary_key
+    assert_equal "code", Barcode.primary_key
+
+    column = Barcode.column_for_attribute(Barcode.primary_key)
+    assert_not column.null
+    assert_equal :uuid, column.type
+    assert_not_predicate column, :is_identity?
+    assert_predicate column, :is_primary?
+  ensure
+    Barcode.reset_column_information
+  end
+
+  test "schema dump primary key includes default" do
+    schema = dump_table_schema "barcodes"
+    assert_match %r/create_table "barcodes", primary_key: "code", id: :uuid, default: -> { "newid\(\)" }/, schema
+  end
+end
+
+class PrimaryKeyIntegerTest < ActiveRecord::TestCase
+  include SchemaDumpingHelper
+
+  self.use_transactional_tests = false
+
+  class Barcode < ActiveRecord::Base
+  end
+
+  class Widget < ActiveRecord::Base
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+  end
+
+  teardown do
+    @connection.drop_table :barcodes, if_exists: true
+    @connection.drop_table :widgets, if_exists: true
+  end
+
+  test "integer primary key without default" do
+    @connection.create_table(:widgets, id: :integer, force: true)
+    column = @connection.columns(:widgets).find { |c| c.name == "id" }
+    assert_predicate column, :is_primary?
+    assert_predicate column, :is_identity?
+    assert_equal :integer, column.type
+    assert_not_predicate column, :bigint?
+
+    schema = dump_table_schema "widgets"
+    assert_match %r/create_table "widgets", id: :integer, force: :cascade do/, schema
+  end
+
+  test "bigint primary key without default" do
+    @connection.create_table(:widgets, id: :bigint, force: true)
+    column = @connection.columns(:widgets).find { |c| c.name == "id" }
+    assert_predicate column, :is_primary?
+    assert_predicate column, :is_identity?
+    assert_equal :integer, column.type
+    assert_predicate column, :bigint?
+
+    schema = dump_table_schema "widgets"
+    assert_match %r/create_table "widgets", force: :cascade do/, schema
+  end
+
+  test "don't set itentity to integer and bigint when there is a default" do
+    @connection.create_table(:barcodes, id: :integer, default: nil, force: true)
+    @connection.create_table(:widgets, id: :bigint, default: nil, force: true)
+
+    column = @connection.columns(:widgets).find { |c| c.name == "id" }
+    assert_predicate column, :is_primary?
+    assert_not_predicate column, :is_identity?
+
+    schema = dump_table_schema "widgets"
+    assert_match %r/create_table "widgets", id: :bigint, default: nil, force: :cascade do/, schema
+
+    column = @connection.columns(:barcodes).find { |c| c.name == "id" }
+    assert_predicate column, :is_primary?
+    assert_not_predicate column, :is_identity?
+
+    schema = dump_table_schema "barcodes"
+    assert_match %r/create_table "barcodes", id: :integer, default: nil, force: :cascade do/, schema
+  end
+end


### PR DESCRIPTION
PR fixes:

```
PrimaryKeyAnyTypeTest#test_0001_schema dump primary key includes type and options [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/primary_keys_test.rb:315]:
Expected /create_table "barcodes", primary_key: "code", id: { type: :string, limit: 42 }/ to match "....ActiveRecord::Schema.define(version: 0) do\n\n  create_table \"barcodes\", primary_key: \"code\", id: { type: :string, limit: 42, default: nil }, force: :cascade do |t|\n  end\n\nend\n"
```