### PR TITLE
Rails 6.1: Raise `ActiveRecord::ConnectionNotEstablished` on calls to execute with a disconnected connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#892](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/892) Add support for if_exists on remove_column
 - [#883](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/885) Fix quoting of ActiveRecord::Relation::QueryAttribute and ActiveModel::Attributes
 - [#893](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/893) Add Active Record Marshal forward compatibility tests
+- [#903](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903) Raise ActiveRecord::ConnectionNotEstablished on calls to execute with a disconnected connection
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/database_limits.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_limits.rb
@@ -37,10 +37,6 @@ module ActiveRecord
         end
         deprecate :columns_per_multicolumn_index
 
-        def in_clause_length
-          10_000
-        end
-
         def sql_query_length
           65_536 * 4_096
         end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -464,7 +464,7 @@ module ActiveRecord
         end
 
         def ensure_established_connection!
-          raise TinyTds::Error, 'SQL Server client is not connected' if @connection.nil? || !@connection.active?
+          raise TinyTds::Error, 'SQL Server client is not connected' unless @connection
 
           yield
         end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -464,7 +464,7 @@ module ActiveRecord
         end
 
         def ensure_established_connection!
-          raise ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected' unless @connection
+          raise ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected' if @connection.nil? || !@connection.active?
 
           yield
         end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -167,7 +167,7 @@ module ActiveRecord
           log(sql, name) do
             case @connection_options[:mode]
             when :dblib
-              result = ensure_established_connection! { @connection.execute(sql) }
+              result = ensure_established_connection! { dblib_execute(sql) }
               options = { as: :hash, cache_rows: true, timezone: ActiveRecord::Base.default_timezone || :utc }
               result.each(options) do |row|
                 r = row.with_indifferent_access
@@ -357,13 +357,7 @@ module ActiveRecord
         def raw_connection_do(sql)
           case @connection_options[:mode]
           when :dblib
-            result = ensure_established_connection! { @connection.execute(sql) }
-
-            # TinyTDS returns false instead of raising an exception if connection fails.
-            # Getting around this by raising an exception ourselves while this PR
-            # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
-            raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
-
+            result = ensure_established_connection! { dblib_execute(sql) }
             result.do
           end
         ensure
@@ -428,7 +422,7 @@ module ActiveRecord
         def raw_connection_run(sql)
           case @connection_options[:mode]
           when :dblib
-            ensure_established_connection! { @connection.execute(sql) }
+            ensure_established_connection! { dblib_execute(sql) }
           end
         end
 
@@ -461,6 +455,15 @@ module ActiveRecord
             handle.cancel if handle
           end
           handle
+        end
+
+        def dblib_execute(sql)
+          @connection.execute(sql).tap do |result|
+            # TinyTDS returns false instead of raising an exception if connection fails.
+            # Getting around this by raising an exception ourselves while this PR
+            # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
+            raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
+          end
         end
 
         def ensure_established_connection!

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -464,7 +464,7 @@ module ActiveRecord
         end
 
         def ensure_established_connection!
-          raise ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected' if @connection.nil? || !@connection.active?
+          raise TinyTds::Error, 'SQL Server client is not connected' if @connection.nil? || !@connection.active?
 
           yield
         end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -167,6 +167,8 @@ module ActiveRecord
           log(sql, name) do
             case @connection_options[:mode]
             when :dblib
+              raise ActiveRecord::ConnectionNotEstablished if @connection.nil?
+
               result = @connection.execute(sql)
               options = { as: :hash, cache_rows: true, timezone: ActiveRecord::Base.default_timezone || :utc }
               result.each(options) do |row|
@@ -357,6 +359,8 @@ module ActiveRecord
         def raw_connection_do(sql)
           case @connection_options[:mode]
           when :dblib
+            raise ActiveRecord::ConnectionNotEstablished if @connection.nil?
+
             result = @connection.execute(sql)
 
             # TinyTDS returns false instead of raising an exception if connection fails.
@@ -428,6 +432,8 @@ module ActiveRecord
         def raw_connection_run(sql)
           case @connection_options[:mode]
           when :dblib
+            raise ActiveRecord::ConnectionNotEstablished if @connection.nil?
+
             @connection.execute(sql)
           end
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -374,9 +374,9 @@ module ActiveRecord
       end
 
       def translate_exception(e, message:, sql:, binds:)
-        return e if e.is_a?(ActiveRecord::ConnectionNotEstablished)
-
         case message
+        when /SQL Server client is not connected/
+          ConnectionNotEstablished.new(message)
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds)
         when /(conflicted with the foreign key constraint) | (The DELETE statement conflicted with the REFERENCE constraint)/i

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -375,7 +375,7 @@ module ActiveRecord
 
       def translate_exception(e, message:, sql:, binds:)
         case message
-        when /SQL Server client is not connected/
+        when /(SQL Server client is not connected)|(failed to execute statement)/i
           ConnectionNotEstablished.new(message)
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -374,6 +374,8 @@ module ActiveRecord
       end
 
       def translate_exception(e, message:, sql:, binds:)
+        return ActiveRecord::ConnectionNotEstablished.new("SQLServer client is not connected") if e.is_a?(ActiveRecord::ConnectionNotEstablished)
+
         case message
         when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds)

--- a/test/cases/disconnected_test_sqlserver.rb
+++ b/test/cases/disconnected_test_sqlserver.rb
@@ -15,7 +15,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
     ActiveRecord::Base.establish_connection(db_config)
   end
 
-  test "can't execute procuderes while disconnected" do
+  test "can't execute procedures while disconnected" do
     @connection.execute_procedure :sp_tables, "sst_datatypes"
     @connection.disconnect!
     assert_raises(ActiveRecord::ConnectionNotEstablished, 'SQL Server client is not connected') do

--- a/test/cases/disconnected_test_sqlserver.rb
+++ b/test/cases/disconnected_test_sqlserver.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+
+class TestDisconnectedAdapter < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  teardown do
+    return if in_memory_db?
+    db_config = ActiveRecord::Base.connection_db_config
+    ActiveRecord::Base.establish_connection(db_config)
+  end
+
+  test "can't execute procuderes while disconnected" do
+    @connection.execute_procedure :sp_tables, "sst_datatypes"
+    @connection.disconnect!
+    assert_raises(ActiveRecord::ConnectionNotEstablished) do
+      @connection.execute_procedure :sp_tables, "sst_datatypes"
+    end
+  end
+
+  test "can't execute query while disconnected" do
+    sql = "SELECT count(*) from products WHERE id IN(@0, @1)"
+    binds = [
+      ActiveRecord::Relation::QueryAttribute.new("id", 2, ActiveRecord::Type::BigInteger.new),
+      ActiveRecord::Relation::QueryAttribute.new("id", 2, ActiveRecord::Type::BigInteger.new)
+    ]
+
+    @connection.exec_query sql, "TEST", binds
+    @connection.disconnect!
+    assert_raises(ActiveRecord::ConnectionNotEstablished) do
+      @connection.exec_query sql, "TEST", binds
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the failure:
```
TestDisconnectedAdapter#test_0001_can't execute statements while disconnected [/usr/local/bundle/bundler/gems/rails-8b63ea762239/activerecord/test/cases/disconnected_test.rb:25]:
[ActiveRecord::ConnectionNotEstablished] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"NoMethodError: undefined method `execute' for nil:NilClass\nDid you mean?  expects">
```
Rails 6.1 expects that we raise an instance of `ActiveRecord::ConnectionNotEstablished` (see https://github.com/rails/rails/blob/v6.1.0/activerecord/test/cases/disconnected_test.rb).
Rails 6.0 was expecting `ActiveRecord::StatementInvalid`. In fact, 6-0-stable raises that exception with the message: 
```
"NoMethodError: undefined method `execute' for nil:NilClass\nDid you mean?  expects" 
```

I use the fact that @connnection is nil to detect when to raise the exception.