### PR TITLE
Rails 6.1: fix rake task

### DIFF
--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
       def create(master_established = false)
         establish_master_connection unless master_established
-        connection.create_database configuration.database, configuration_hash.merge("collation" => default_collation)
+        connection.create_database configuration.database, configuration_hash.merge(collation: default_collation)
         establish_connection configuration
       rescue ActiveRecord::StatementInvalid => e
         if /database .* already exists/i === e.message
@@ -54,14 +54,14 @@ module ActiveRecord
       end
 
       def structure_dump(filename, extra_flags)
-        server_arg = "-S #{Shellwords.escape(configuration_hash['host'])}"
-        server_arg += ":#{Shellwords.escape(configuration_hash['port'])}" if configuration_hash["port"]
+        server_arg = "-S #{Shellwords.escape(configuration_hash[:host])}"
+        server_arg += ":#{Shellwords.escape(configuration_hash[:port])}" if configuration_hash[:port]
         command = [
           "defncopy-ttds",
           server_arg,
-          "-D #{Shellwords.escape(configuration_hash['database'])}",
-          "-U #{Shellwords.escape(configuration_hash['username'])}",
-          "-P #{Shellwords.escape(configuration_hash['password'])}",
+          "-D #{Shellwords.escape(configuration_hash[:database])}",
+          "-U #{Shellwords.escape(configuration_hash[:username])}",
+          "-P #{Shellwords.escape(configuration_hash[:password])}",
           "-o #{Shellwords.escape(filename)}",
         ]
         table_args = connection.tables.map { |t| Shellwords.escape(t) }
@@ -88,11 +88,11 @@ module ActiveRecord
       attr_reader :configuration, :configuration_hash
 
       def default_collation
-        configuration_hash["collation"] || DEFAULT_COLLATION
+        configuration_hash[:collation] || DEFAULT_COLLATION
       end
 
       def establish_master_connection
-        establish_connection configuration_hash.merge("database" => "master")
+        establish_connection configuration_hash.merge(database: "master")
       end
     end
 

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -12,6 +12,7 @@ class SQLServerRakeTest < ActiveRecord::TestCase
   let(:new_database)          { "activerecord_unittest_tasks" }
   let(:default_configuration) { ARTest.test_configuration_hashes["arunit"] }
   let(:configuration)         { default_configuration.merge("database" => new_database) }
+  let(:db_config)             { ActiveRecord::Base.configurations.resolve(configuration) }
 
   before { skip "on azure" if azure_skip }
   before { disconnect! unless azure_skip }
@@ -151,7 +152,7 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
     _(filedata).must_match %r{CREATE TABLE dbo\.users}
     db_tasks.purge(configuration)
     _(connection.tables).wont_include "users"
-    db_tasks.load_schema configuration, :sql, filename
+    db_tasks.load_schema db_config, :sql, filename
     _(connection.tables).must_include "users"
   end
 end


### PR DESCRIPTION
Two changes:
1. `configuration_hash` keys are symbols, not strings.
2. `ActiveRecord::Tasks::DatabaseTasks.load_schema` requires a `ActiveRecord::DatabaseConfigurations::HashConfig` instance