### PR TITLE
Rails 6.1: Coerce test as SQL is invalid for MSSQL

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -807,6 +807,9 @@ class FinderTest < ActiveRecord::TestCase
   ensure
     NonPrimaryKey.implicit_order_column = old_implicit_order_column
   end
+
+  # SQL Server is unable to use aliased SELECT in the HAVING clause.
+  coerce_tests! :test_include_on_unloaded_relation_with_having_referencing_aliased_select
 end
 
 module ActiveRecord


### PR DESCRIPTION
Coercing the `FinderTest#test_include_on_unloaded_relation_with_having_referencing_aliased_select` test as SQL Server does not support the SQL.

There is no point re-implementing the coerced test as its purpose is to test the HAVING clause referencing an aliased SELECT.

**SQL Server**
```ruby
Author.select("COUNT(*) as total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(bob)
```

SQL generated:
```sql
SELECT COUNT(*) as total_posts, authors.*
FROM [authors] 
INNER JOIN [posts] ON [posts].[author_id] = [authors].[id] 
GROUP BY [authors].[id] 
HAVING (total_posts > 2)
```

This SQL is invalid in SQL Server and throws the error `Invalid column name 'total_posts'`. There are 2 reasons why the SQL is invalid:
- Cannot use SELECT alias `total_posts` in HAVING clause.
- Cannot SELECT `authors.*` as the columns are not in the GROUP clause.

**PostgreSQL**
PostgreSQL skips this test (https://github.com/rails/rails/blob/d927db7eec984a980e5533dc307164e24c137690/activerecord/test/cases/finder_test.rb#L428) as it does not support the SQL.

```sql
SELECT COUNT(*) as total_posts, authors.* 
FROM "authors" 
INNER JOIN "posts" ON "posts"."author_id" = "authors"."id" 
GROUP BY "authors"."id" 
HAVING (total_posts > 2)
```

Error:
```
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column "total_posts" does not exist
LINE 1: ... = "authors"."id" GROUP BY "authors"."id" HAVING (total_post...
```

**MySQL**
Generates the following SQL which is valid in MySQL.

```sql
SELECT COUNT(*) as total_posts, authors.* 
FROM `authors` 
INNER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` 
GROUP BY `authors`.`id` 
HAVING (total_posts > 2)
```

**SQLite**
Generates the following SQL which is valid in SQLite.

```sql
SELECT COUNT(*) as total_posts, authors.* 
FROM "authors" 
INNER JOIN "posts" ON "posts"."author_id" = "authors"."id" 
GROUP BY "authors"."id" 
HAVING (total_posts > 2)
```