### PR TITLE
Rails 6.1: Fixed the namespace of the BasePreventWritesLegacyTest class

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1760,18 +1760,20 @@ class BasePreventWritesTest < ActiveRecord::TestCase
       end
     end
   end
-end
 
-class BasePreventWritesLegacyTest < ActiveRecord::TestCase
-  # SQL Server does not have query for release_savepoint
-  coerce_tests! %r{an empty transaction does not raise if preventing writes}
-  test "an empty transaction does not raise if preventing writes coerced" do
-    ActiveRecord::Base.connection_handler.while_preventing_writes do
-      assert_queries(1, ignore_none: true) do
-        Bird.transaction do
-          ActiveRecord::Base.connection.materialize_transactions
+  class BasePreventWritesLegacyTest < ActiveRecord::TestCase
+    # SQL Server does not have query for release_savepoint
+    coerce_tests! %r{an empty transaction does not raise if preventing writes}
+    test "an empty transaction does not raise if preventing writes coerced" do
+      ActiveRecord::Base.connection_handler.while_preventing_writes do
+        assert_queries(1, ignore_none: true) do
+          Bird.transaction do
+            ActiveRecord::Base.connection.materialize_transactions
+          end
         end
       end
     end
   end
 end
+
+


### PR DESCRIPTION
Noticed that the `BasePreventWritesTest::BasePreventWritesLegacyTest#test_0006_an empty transaction does not raise if preventing writes` test is still failing (see https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2409001850) even though it was being coerced in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/901

The issue is that the coerce is for the `BasePreventWritesLegacyTest` class not the `BasePreventWritesTest::BasePreventWritesLegacyTest` class (https://github.com/rails/rails/blob/738ca3595fb88580a84072b31ce8a999af4762d6/activerecord/test/cases/base_prevent_writes_test.rb#L98).

This PR just moves the class into the correct namespace.