### PR TITLE
Rails 6.1: Fix randomly failing prevent writes test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -52,23 +52,40 @@ module ActiveRecord
       Subscriber.send(:load_schema!)
       original_test_errors_when_an_insert_query_is_called_while_preventing_writes
     end
+
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
+    coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes_coerced
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
+    end
+
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
+    coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes_coerced
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
+    end
   end
 end
 
 module ActiveRecord
   class AdapterPreventWritesLegacyTest < ActiveRecord::TestCase
-    # We do some read queries. Remove assert_no_queries
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
     coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes
     def test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes_coerced
-      @connection_handler.while_preventing_writes do
-        @connection.transaction do
-          assert_raises(ActiveRecord::ReadOnlyError) do
-            @connection.insert("/* some comment */ INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
-          end
-        end
-      end
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes
     end
 
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
+    coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
+    def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes_coerced
+      Subscriber.send(:load_schema!)
+      original_test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
+    end
+
+    # Fix randomly failing test. The loading of the model's schema was affecting the test.
     coerce_tests! :test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
     def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes_coerced
       Subscriber.send(:load_schema!)


### PR DESCRIPTION
Fix some randomly failing tests. The tests fail because the table schema is sometimes queried for if the schema is not already loaded. The tests rely on the number of queries being performed and so the schema loading queries throw off the tests.

Example of `ActiveRecord::AdapterPreventWritesLegacyTest#test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes` failing:
https://pipelines.actions.githubusercontent.com/OGQvFf2eDbGUprKdJ5qsq3TsAFLfKWDWAJCyTHn8ess0fbvp0X/_apis/pipelines/1/runs/172/signedlogcontent/6?urlExpires=2021-04-22T14%3A43%3A54.2983268Z&urlSigningMethod=HMACV1&urlSignature=1puWUyN%2Fxlx7jqGDOQjHpgDOQG9SfPBtfCS4J4WdB6I%3D

Example of `ActiveRecord::AdapterPreventWritesTest#test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes` failing:
https://pipelines.actions.githubusercontent.com/OGQvFf2eDbGUprKdJ5qsq3TsAFLfKWDWAJCyTHn8ess0fbvp0X/_apis/pipelines/1/runs/174/signedlogcontent/5?urlExpires=2021-04-22T15%3A18%3A22.8253096Z&urlSigningMethod=HMACV1&urlSignature=FY2PmomDAdBmXJ4EdcuTaVrhq7foyh%2BM38MrnA9zXa8%3D
