### PR TITLE
Rails 6.1: Legacy binds are not supported

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -28,6 +28,10 @@ end
 require "models/event"
 module ActiveRecord
   class AdapterTest < ActiveRecord::TestCase
+    # Legacy binds are not supported.
+    coerce_tests! :test_select_all_insert_update_delete_with_casted_binds
+    coerce_tests! :test_select_all_insert_update_delete_with_legacy_binds
+
     # As far as I can tell, SQL Server does not support null bytes in strings.
     coerce_tests! :test_update_prepared_statement
 


### PR DESCRIPTION
The legacy binding tests, which we used to coerced, were renamed in the Rails test suite in https://github.com/rails/rails/commit/92360e9ea3674c153adf2fa4c2cdcb6d9afd730b

Legacy binds are not supported by the SQL Server adapter and since Rails are deprecating them there will be no need to support them in future.

Instead of renaming the coerced tests we removed the coercions in the following PRs:
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/887
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/895

This PR just coerces the tests with their new names.