### PR TITLE
Rails 6.1: Coerce schema cache test to handle Time marshal in ruby 2.5 and 2.6

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1474,7 +1474,35 @@ end
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCacheTest < ActiveRecord::TestCase
+      # Ruby 2.5 and 2.6 have issues to marshal Time before 1900. 2012.sql has one column with default value 1753
+      coerce_tests! :test_marshal_dump_and_load_with_gzip, :test_marshal_dump_and_load_via_disk
+      def test_marshal_dump_and_load_with_gzip_coerced
+        with_marshable_time_defaults { original_test_marshal_dump_and_load_with_gzip }
+      end
+      def test_marshal_dump_and_load_via_disk_coerced
+        with_marshable_time_defaults { original_test_marshal_dump_and_load_via_disk }
+      end
+
       private
+
+      def with_marshable_time_defaults
+        # Detect problems
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7")
+          column = @connection.columns(:sst_datatypes).find { |c| c.name == "datetime" }
+          current_default = column.default if column.default.is_a?(Time) && column.default.year < 1900
+        end
+
+        # Correct problems
+        if current_default.present?
+          @connection.change_column_default(:sst_datatypes, :datetime, current_default.dup.change(year: 1900))
+        end
+
+        # Run original test
+        yield
+      ensure
+        # Revert changes
+        @connection.change_column_default(:sst_datatypes, :datetime, current_default) if current_default.present?
+      end
 
       # We need to give the full path for this to work.
       def schema_dump_path
@@ -1876,5 +1904,3 @@ class BasePreventWritesTest < ActiveRecord::TestCase
     end
   end
 end
-
-


### PR DESCRIPTION
This PR fixes: 
```
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_via_disk:
ArgumentError: year too big to marshal: 1753 UTC
```
```
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_with_gzip:
ArgumentError: year too big to marshal: 1753 UTC
```
Those errors only exists in [ruby 2.5](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2411021223?check_suite_focus=true#step:4:187) and [2.6](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/2411021223?check_suite_focus=true#step:4:187) runs

**Context**

Rails 6.1 adds support for marshal as a schema cache serialization strategy (https://github.com/rails/rails/commit/9a356fcd4223c1b6bbd83445cc95c402ce49844a)

Ruby 2.5 and Ruby 2.6 have a bug that prevents them to marshal Time instances before 1900 (see https://bugs.ruby-lang.org/issues/15160). The issue is not present on 2.7. Found the link looking at https://github.com/rails/rails/issues/41075.

`sst_datatypes` table has a datetime column with default `1753-01-01T00:00:00.123`. The table is created here https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/main/test/schema/datatypes/2012.sql#L27.

**Possible solutions**

1) update 2012.sql and change default to something else.

That file has been around for a while. I can't tell why `1753-01-01T00:00:00.123` was picked. For example, I can't tell if it's covering some specific scenario.

2) coerce the test

change the default value just for the failing test and rubies.

3) cast default value to something different than `Time`

Haven't thought/investigate this path but felt that would lead to issues.

I choose the second option



