### PR TITLE
Rails 6.1: Refactored to use new_client connection pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 #### Changed
 
-- ...
+- [#917](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/917) Refactored to use new_client connection pattern
 
 #### Added
 

--- a/lib/active_record/sqlserver_base.rb
+++ b/lib/active_record/sqlserver_base.rb
@@ -4,21 +4,15 @@ module ActiveRecord
   module ConnectionHandling
     def sqlserver_connection(config) #:nodoc:
       config = config.symbolize_keys
-      config.reverse_merge! mode: :dblib
-      mode = config[:mode].to_s.downcase.underscore.to_sym
-      case mode
-      when :dblib
-        require "tiny_tds"
-      else
-        raise ArgumentError, "Unknown connection mode in #{config.inspect}."
-      end
-      ConnectionAdapters::SQLServerAdapter.new(nil, nil, config.merge(mode: mode))
-    rescue TinyTds::Error => e
-      if e.message.match(/database .* does not exist/i)
-        raise ActiveRecord::NoDatabaseError
-      else
-        raise
-      end
+      config.reverse_merge!(mode: :dblib)
+      config[:mode] = config[:mode].to_s.downcase.underscore.to_sym
+
+      ConnectionAdapters::SQLServerAdapter.new(
+        ConnectionAdapters::SQLServerAdapter.new_client(config),
+        logger,
+        nil,
+        config
+        )
     end
   end
 end


### PR DESCRIPTION
Refactored the connection code to use `.new_client` as suggested in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903#discussion_r617639344 This PR follows the same general patterns as used by the MySQL and PostgreSQL adapters.

References:
- MySQL: https://github.com/rails/rails/blob/0184a019353fa862c37ae61308e62e4e702c347f/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L23
- PostgreSQL: https://github.com/rails/rails/blob/0184a019353fa862c37ae61308e62e4e702c347f/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L37
