### PR TITLE
Rails 6.1: Check if TinyTDS connection failed when using raw_connection_run/execute_procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,6 @@
 
 #### Added
 
-- ...
+- [#918](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/918) Check if TinyTDS connection failed when using raw_connection_run/execute_procedure
 
 Please check [6-0-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/6-0-stable/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
Whenever we call `@connection.execute` we should check if the return value is `false`, which indicates that the connection has failed. Previously we were only checking the return value in `raw_connection_do` but I see no reason why we should not also check it in `raw_connection_run` and `execute_procedure`. 

This issue was brought up by @mgrunberg in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/903#discussion_r620646305

References:
- TinyTDS returning `false` if connection fails: https://github.com/rails-sqlserver/tiny_tds/blob/77341a31dbed0299ae6160ec75f00089f95880c7/ext/tiny_tds/client.c#L256