### PR TITLE
Rails 6.1: Skip tests on Windows because of atomic write issue

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -768,11 +768,6 @@ module ActiveRecord
     end
   end
 
-  class DatabaseTasksDumpSchemaCacheTest < ActiveRecord::TestCase
-    # Skip this test with /tmp/my_schema_cache.yml path on Windows.
-    coerce_tests! :test_dump_schema_cache if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
-  end
-
   class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
     # We extend `local_database?` so that common VM IPs can be used.
     coerce_tests! :test_ignores_remote_databases, :test_warning_for_remote_databases
@@ -1524,13 +1519,20 @@ end
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCacheTest < ActiveRecord::TestCase
+      # Tests fail on Windows AppVeyor CI with 'Permission denied' error when renaming file during `File.atomic_write` call.
+      coerce_tests! :test_yaml_dump_and_load, :test_yaml_dump_and_load_with_gzip if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+
       # Ruby 2.5 and 2.6 have issues to marshal Time before 1900. 2012.sql has one column with default value 1753
       coerce_tests! :test_marshal_dump_and_load_with_gzip, :test_marshal_dump_and_load_via_disk
-      def test_marshal_dump_and_load_with_gzip_coerced
-        with_marshable_time_defaults { original_test_marshal_dump_and_load_with_gzip }
-      end
-      def test_marshal_dump_and_load_via_disk_coerced
-        with_marshable_time_defaults { original_test_marshal_dump_and_load_via_disk }
+
+      # Tests fail on Windows AppVeyor CI with 'Permission denied' error when renaming file during `File.atomic_write` call.
+      unless RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+        def test_marshal_dump_and_load_with_gzip_coerced
+          with_marshable_time_defaults { original_test_marshal_dump_and_load_with_gzip }
+        end
+        def test_marshal_dump_and_load_via_disk_coerced
+          with_marshable_time_defaults { original_test_marshal_dump_and_load_via_disk }
+        end
       end
 
       private


### PR DESCRIPTION
Coercing tests on Windows that rely on `SchemaCache#dump_to`. The call in https://github.com/rails/rails/blob/e2781c2d93808031fbc4dbecaa7aac59aa90b4b8/activesupport/lib/active_support/core_ext/file/atomic.rb#L50 to rename the file fails on Windows. This is a Rails/Windows issue. 

**MacOS**
```
> tempfile = Tempfile.new('test.txt')
=> #<File:/var/folders/mp/_9w8583s18z93h_w2s7zxq24ks97j0/T/test.txt20210429-16257-39oo5i>
> File.atomic_write(tempfile.path) { |file| file.write('BLAH') }
=> 4
```

**Windows** 
```
> tempfile = Tempfile.new('test.txt')
=> #<Tempfile:C:/Users/user/AppData/Local/Temp/test.txt20210429-8740-1pwkymo>
> File.atomic_write(tempfile.path) { |file| file.write('BLAH') }
*** Errno::EACCES Exception: Permission denied @ rb_file_s_rename - (C:/Users/user/AppData/Local/Temp/.test.txt20210429-8740-1pwkymo20210429-8740-yjlmty, C:/Users/user/AppData/Local/Temp/test.txt20210429-8740-1pwkymo)
```

An example of exception raised is (https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/38929321#L397):
```
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_marshal_dump_and_load_with_gzip_coerced:
Errno::EACCES: Permission denied @ rb_file_s_rename - (C:/Users/appveyor/AppData/Local/Temp/1/.schema_cache-20210429-3648-11o6yfo.dump.gz20210429-3648-4s5ga8, C:/Users/appveyor/AppData/Local/Temp/1/schema_cache-20210429-3648-11o6yfo.dump.gz)
    rails (8b63ea762239) activesupport/lib/active_support/core_ext/file/atomic.rb:50:in `rename'
    rails (8b63ea762239) activesupport/lib/active_support/core_ext/file/atomic.rb:50:in `block in atomic_write'
    C:/Ruby26-x64/lib/ruby/2.6.0/tempfile.rb:295:in `open'
    rails (8b63ea762239) activesupport/lib/active_support/core_ext/file/atomic.rb:24:in `atomic_write'
    rails (8b63ea762239) activerecord/lib/active_record/connection_adapters/schema_cache.rb:211:in `open'
    rails (8b63ea762239) activerecord/lib/active_record/connection_adapters/schema_cache.rb:158:in `dump_to'
```

Also in this PR, no longer need to coerce the `DatabaseTasksDumpSchemaCacheTest#test_dump_schema_cache` test as it has been updated on the Rails test suite and will now work on Windows.