### PR TITLE
Rails 6.1: Read file in binary mode to support the Windows CI

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1270,6 +1270,16 @@ module ActiveRecord
       query = Post.optimizer_hints("OMGHINT").merge(Post.optimizer_hints("OMGHINT")).to_sql
       assert_equal expected, query
     end
+
+    # Original Rails test fails on Windows CI because the dump file was not being binary read.
+    coerce_tests! :test_marshal_load_legacy_relation
+    def test_marshal_load_legacy_relation_coerced
+      path = File.expand_path(
+        "support/marshal_compatibility_fixtures/legacy_relation.dump",
+        ARTest::SQLServer.root_activerecord_test
+      )
+      assert_equal 11, Marshal.load(File.binread(path)).size
+    end
   end
 end
 


### PR DESCRIPTION
Coerced and re-implemented the `ActiveRecord::RelationTest#test_marshal_load_legacy_relation` test as the original Rails test was not reading the dump file in binary mode and so wasn't passing on Windows environments.

The coerce can be removed on Rails 7+ as the test was removed in https://github.com/rails/rails/commit/0e35e670b2aa7e704e4eac999d71be3cb1f914b3#diff-744b39fde5c3433ab31f1fe1721fde897ebde5c0abb5a09e6752a1479ac42668