### PR TITLE
Include Calculations module instead of prepending

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -43,5 +43,5 @@ end
 
 ActiveSupport.on_load(:active_record) do
   mod = ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Calculations
-  ActiveRecord::Relation.prepend(mod)
+  ActiveRecord::Relation.include(mod)
 end


### PR DESCRIPTION
Another gem (groupdate: https://github.com/ankane/groupdate by @ankane) also patches the `ActiveRecord::Relation#calculate` method and breaks when used with this library. Prepending this `Calculations` module prevents any other libraries from patching this method, and it looks like an `include` will have the same desired effect to patch existing out-of-the-box ActiveRecord code. I'm not sure if this is prepended to ensure nothing else is patching `#calculate`, and how important that may be.

I see the reasoning for patching `#calculate` by this library is helpfully defined in the patched method:
`# Same as original except we don't perform PostgreSQL hack that removes ordering.`

Comparing to the original activerecord `#calculate` implementation, the following lines are removed for `count` operations:
```ruby
# PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
relation.order_values = [] if group_values.empty?
```

In my somewhat obscure edge case scenario where both of these gems are used (along with postgres and sqlserver), I need to choose which gem is going to win the monkey patching war for `#calculate`. Changing this from `prepend` to `include` allows me to make this choice by the sequence the gems are loaded in. The downside of this change is it could allow another gem to patch `#calculate` away from the intended version in this library (but hopefully that is not much of a threat, and maybe a feature, as it is in my case).
