### PR TITLE
Apply monkey patches for SQL Server connections only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+#### Fixed
+
+- [#933](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/933) Conditionally apply SQL Server monkey patches to ActiveRecord so that it is safe to use this gem alongside other database adapters (e.g. PostgreSQL) in a multi-database Rails app
+
+#### Changed
+
+- ...
+
+#### Added
+
+- ...
+
 ## v6.1.0.0
 
 - No changes

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
@@ -10,6 +10,8 @@ module ActiveRecord
           private
 
           def attributes_for_update(attribute_names)
+            return super unless self.class.connection.adapter_name == "SQLServer"
+
             super.reject do |name|
               column = self.class.columns_hash[name]
               column && column.respond_to?(:is_identity?) && column.is_identity?

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -10,6 +10,8 @@ module ActiveRecord
         module Calculations
           # Same as original except we don't perform PostgreSQL hack that removes ordering.
           def calculate(operation, column_name)
+            return super unless klass.connection.adapter_name == "SQLServer"
+
             if has_include?(column_name)
               relation = apply_join_dependency
 
@@ -29,6 +31,8 @@ module ActiveRecord
           private
 
           def build_count_subquery(relation, column_name, distinct)
+            return super unless klass.connection.adapter_name == "SQLServer"
+
             super(relation.unscope(:order), column_name, distinct)
           end
         end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -9,6 +9,8 @@ module ActiveRecord
           SQLSERVER_STATEMENT_REGEXP = /N'(.+)', N'(.+)', (.+)/
 
           def exec_explain(queries)
+            return super unless connection.adapter_name == "SQLServer"
+
             unprepared_queries = queries.map do |(sql, binds)|
               [unprepare_sqlserver_statement(sql, binds), binds]
             end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
@@ -12,6 +12,8 @@ module ActiveRecord
 
           # Same as original except we order by values in distinct select if present.
           def construct_relation_for_exists(conditions)
+            return super unless klass.connection.adapter_name == "SQLServer"
+
             conditions = sanitize_forbidden_attributes(conditions)
 
             if distinct_value && offset_value

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
@@ -10,6 +10,8 @@ module ActiveRecord
           private
 
           def records_for(ids)
+            return super unless klass.connection.adapter_name == "SQLServer"
+
             ids.each_slice(in_clause_length).flat_map do |slice|
               scope.where(association_key_name => slice).load do |record|
                 # Processing only the first owner


### PR DESCRIPTION
Recent versions of Rails support multiple database connections within the same app. It is possible for these connections to use different adapters. For example, one adapter may use SQL Server, and another uses PostgreSQL.

This gem applies some monkey patches to ActiveRecord for SQL Server compatibility. These patches could break other adapters, though, in a multiple-database scenario.

This PR modifies the patches so that they are applied only if the connection is SQL Server. If not, the original ActiveRecord implementation (`super`) is used instead.

Fixes #929

@aidanharan @wpolicarpo what do you think of this approach? Any suggestions on how to test?