### PR TITLE
Fix date columns serialization for range values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#935](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/935) Fix schema cache generation
   (**breaking change**)
 - [#936](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/936) Fix deteministic fetch when table has a composite primary key
+- [#938](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/938) Fix date columns serialization for range values
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/type/date.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/date.rb
@@ -10,7 +10,8 @@ module ActiveRecord
           end
 
           def serialize(value)
-            return unless value.present?
+            value = super
+            return value unless value.acts_like?(:date)
 
             date = super(value).to_s(:_sqlserver_dateformat)
             Data.new date, self

--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -299,6 +299,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(obj.date).must_equal Date.civil(0001, 4, 1)
       obj.reload
       _(obj.date).must_equal Date.civil(0001, 4, 1)
+      # Can filter by date range
+      _(obj).must_equal obj.class.where(date: obj.date..Date::Infinity.new).first
       # Can keep and return assigned date.
       assert_obj_set_and_save :date, Date.civil(1972, 04, 14)
       # Can accept and cast time objects.
@@ -333,6 +335,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       obj.reload
       _(obj.datetime).must_equal time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
       _(obj).must_equal obj.class.where(datetime: time).first
+      # Can filter by datetime range
+      _(obj).must_equal obj.class.where(datetime: time..DateTime::Infinity.new).first
       # Will cast to true DB value on attribute write, save and return again.
       time = Time.utc 2010, 04, 01, 12, 34, 56, 234567
       time2 = Time.utc 2010, 04, 01, 12, 34, 56, 233000


### PR DESCRIPTION
Fix a bug where filtered `date` columns couldn't be serialized if value was date range. See #937 for more information.

Fixes #937.