### PR TITLE
Primary key violation should result in RecordNotUnique error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+#### Unreleased
+
+#### Fixed
+
+- [#940](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/940) Primary key violation should result in RecordNotUnique error
+
+#### Changed
+
+- ...
+
+#### Added
+
+- ...
+
 ## v6.1.1.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v6.1.0.0...v6.1.1.0)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -444,7 +444,7 @@ module ActiveRecord
         case message
         when /(SQL Server client is not connected)|(failed to execute statement)/i
           ConnectionNotEstablished.new(message)
-        when /(cannot insert duplicate key .* with unique index) | (violation of unique key constraint)/i
+        when /(cannot insert duplicate key .* with unique index) | (violation of (unique|primary) key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds)
         when /(conflicted with the foreign key constraint) | (The DELETE statement conflicted with the REFERENCE constraint)/i
           InvalidForeignKey.new(message, sql: sql, binds: binds)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -120,6 +120,14 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
            "expected database #{db_config.database} to exist"
   end
 
+  it "test primary key violation" do
+    Post.create!(id: 0, title: 'Setup', body: 'Create post with primary key of zero')
+
+    assert_raise ActiveRecord::RecordNotUnique do
+      Post.create!(id: 0, title: 'Test', body: 'Try to create another post with primary key of zero')
+    end
+  end
+
   describe "with different language" do
     before do
       @default_language = connection.user_options_language


### PR DESCRIPTION
Creating a record that violates a primary key constraint should throw an `ActiveRecord::RecordNotUnique` error rather than the generic `ActiveRecord::StatementInvalid` error.

The issue was caused by how the adapter was translating MSSQL errors into ActiveRecord errors. We were handling unique key violations but not primary key violations.

Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/939