### PR TITLE
Fix application name sent to TinyTDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 #### Fixed
 
 - [#940](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/940) Primary key violation should result in RecordNotUnique error
-- [#941](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/941) Fix application name sent to TinyTDS
 
 #### Changed
 
-- ...
+- [#941](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/941) No longer support configuring the application name by overriding the 'configure_application_name' method.
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 - [#940](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/940) Primary key violation should result in RecordNotUnique error
+- [#941](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/941) Fix application name sent to TinyTDS
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -82,26 +82,32 @@ end
 ```
 
 
-#### Configure Connection & App Name
+#### Configure Connection
 
-We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes. Also, TinyTDS supports an application name when it logs into SQL Server. This can be used to identify the connection in SQL Server's activity monitor. By default it will use the `appname` from your database.yml file or a lowercased version of your Rails::Application name. It is now possible to define a `configure_application_name` method that can give you per instance details. Below shows how you might use this to get the process id and thread id of the current connection.
+We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes.
 
 ```ruby
 module ActiveRecord
   module ConnectionAdapters
     class SQLServerAdapter < AbstractAdapter
-
       def configure_connection
         raw_connection_do "SET TEXTSIZE #{64.megabytes}"
       end
-
-      def configure_application_name
-        "myapp_#{$$}_#{Thread.current.object_id}".to(29)
-      end
-
     end
   end
 end
+```
+
+#### Configure Application Name
+
+TinyTDS supports an application name when it logs into SQL Server. This can be used to identify the connection in SQL Server's activity monitor. By default it will use the `appname` from your database.yml file or your Rails::Application name.
+
+Below shows how you might use the database.yml file to use the process ID in your application name.
+
+```yaml
+development:
+  adapter: sqlserver
+  appname: <%= myapp_#{Process.pid} %>
 ```
 
 #### Executing Stored Procedures

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -105,7 +105,23 @@ module ActiveRecord
         end
 
         def config_appname(config)
-          config[:appname] || configure_application_name || Rails.application.class.name.split("::").first rescue nil
+          if self.instance_methods.include?(:configure_application_name)
+            ActiveSupport::Deprecation.warn <<~MSG.squish
+            Configuring the application name used by TinyTDS by overriding the
+            `ActiveRecord::ConnectionAdapters::SQLServerAdapter#configure_application_name`
+            instance method is no longer supported. The application name should configured
+            using the `appname` setting in the `database.yml` file instead. Consult the
+            README for further information."
+            MSG
+          end
+
+          config[:appname] || rails_application_name
+        end
+
+        def rails_application_name
+          return nil if Rails.application.nil?
+
+          Rails.application.class.name.split("::").first
         end
 
         def config_login_timeout(config)
@@ -119,8 +135,6 @@ module ActiveRecord
         def config_encoding(config)
           config[:encoding].present? ? config[:encoding] : nil
         end
-
-        def configure_application_name; end
       end
 
       def initialize(connection, logger, _connection_options, config)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -119,6 +119,8 @@ module ActiveRecord
         def config_encoding(config)
           config[:encoding].present? ? config[:encoding] : nil
         end
+
+        def configure_application_name; end
       end
 
       def initialize(connection, logger, _connection_options, config)
@@ -482,8 +484,6 @@ module ActiveRecord
           errors << TinyTds::Error if defined?(TinyTds::Error)
         end
       end
-
-      def configure_application_name; end
 
       def initialize_dateformatter
         @database_dateformat = user_options_dateformat


### PR DESCRIPTION
Fixes the application name so that the Rails application name can be used for the database connection created by TinyTDS. 

During the refactoring in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/917 the method `configure_application_name` should have been moved from an instance to a class method. This resulted in the application name never getting set to the Rails application name as the call to `configure_application_name` would throw a `NameError` exception, which resulted in the application name being set to `nil`. The TinyTds client would ignore the `nil` and use 'TinyTds' as the application name instead (https://github.com/rails-sqlserver/tiny_tds/blob/e3e79a030271891b11b6e7676382fe31f389b099/lib/tiny_tds/client.rb#L50).