### PR TITLE
Fix appname resolution when outside Rails context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#943](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/943) Fix appname resolution when outside Rails context
+
 ## v6.1.2.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v6.1.1.0...v6.1.2.0)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -119,9 +119,9 @@ module ActiveRecord
         end
 
         def rails_application_name
-          return nil if Rails.application.nil?
-
           Rails.application.class.name.split("::").first
+        rescue
+          nil # Might not be in a Rails context so we fallback to `nil`.
         end
 
         def config_login_timeout(config)


### PR DESCRIPTION
The adapter can be used outside a Rails context so TinyTDS appname config should
be able to be resolved if a Rails application was not detected.

Fix #942.