### PR TITLE
[Rails 7] Added support for quoted_time

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/data.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/data.rb
@@ -7,6 +7,8 @@ module ActiveRecord
         class Data
           attr_reader :value, :type
 
+          delegate :sub, to: :value
+
           def initialize(value, type)
             @value, @type = value, type
           end


### PR DESCRIPTION
Fixes for the Rails 7 CI `quoted_time` errors.

```
NoMethodError: undefined method `sub' for "01-01-2000 07:17:04.0":ActiveRecord::ConnectionAdapters::SQLServer::Type::Data
Did you mean?  stub
     rails (5850a6592ff1) activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:141:in `quoted_time'
     rails (5850a6592ff1) activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:22:in `quote'
     activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/quoting.rb:121:in `quote'
```

The PR reduces the CI errors from (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4617260332?check_suite_focus=true):
```
7743 runs, 11683 assertions, 77 failures, 3396 errors, 39 skips
```
to (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4619098779?check_suite_focus=true)
```
7743 runs, 20985 assertions, 101 failures, 83 errors, 43 skips
```