### PR TITLE
[Rails 7] Add missing keyword `async` to `exec_query` method

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -409,7 +409,7 @@ module ActiveRecord
         # === SQLServer Specific (Selecting) ============================ #
 
         def raw_select(sql, name = "SQL", binds = [], options = {})
-          log(sql, name, binds) { _raw_select(sql, options) }
+          log(sql, name, binds, async: options[:async]) { _raw_select(sql, options) }
         end
 
         def _raw_select(sql, options = {})

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -26,7 +26,7 @@ module ActiveRecord
           end
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false)
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           if preventing_writes? && write_query?(sql)
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
@@ -34,7 +34,7 @@ module ActiveRecord
           materialize_transactions
           mark_transaction_written_if_write(sql)
 
-          sp_executesql(sql, name, binds, prepare: prepare)
+          sp_executesql(sql, name, binds, prepare: prepare, async: async)
         end
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, _sequence_name = nil)


### PR DESCRIPTION
Fix the following error: 
```
ArgumentError: unknown keyword: :async
     activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:29:in `exec_query'
     rails (5850a6592ff1) activerecord/lib/active_record/future_result.rb:127:in `exec_query'
     rails (5850a6592ff1) activerecord/lib/active_record/future_result.rb:133:in `exec_query'
     rails (5850a6592ff1) activerecord/lib/active_record/future_result.rb:119:in `execute_query'
```

Async queries were introduced in [this commit](https://github.com/rails/rails/commit/7fc174aadaefc2c0a8a6b7c8a7599dd9ca04811f).

The PR reduces the CI errors from (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4617260332?check_suite_focus=true):

7743 runs, 13869 assertions, 85 failures, 2636 errors, 39 skips
to (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4621600569?check_suite_focus=true)

7743 runs, 14263 assertions, 84 failures, 2454 errors, 40 skips
