### PR TITLE
[Rails 7] Remove sql and bindings params from NoDatabaseError initialization

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -467,7 +467,7 @@ module ActiveRecord
         when /has been chosen as the deadlock victim/i
           DeadlockVictim.new(message, sql: sql, binds: binds)
         when /database .* does not exist/i
-          NoDatabaseError.new(message, sql: sql, binds: binds)
+          NoDatabaseError.new(message)
         when /data would be truncated/
           ValueTooLong.new(message, sql: sql, binds: binds)
         when /connection timed out/


### PR DESCRIPTION
Fixes:

```
SQLServerRakeDropTest#test_0002_prints error message when database does
not exist:
ArgumentError: unknown keywords: :sql, :binds
```

`NoDatabaseError` extends `InvalidStatement` which supports `:sql` and `:binds` keywords but [this commit](https://github.com/rails/rails/commit/b28711ffa015217e2c24c87152a2f37d8aca1c83) declares initialize method without them.

The PR reduces the CI errors from (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4617260332?check_suite_focus=true):

7743 runs, 13869 assertions, 85 failures, 2636 errors, 39 skips
to (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4621836570?check_suite_focus=true)

7743 runs, 11418 assertions, 76 failures, 3405 errors, 40 skips
