### PR TITLE
[Rails 7] Remove Time#to_s(:_sqlserver_time) is deprecated warning

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/time.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/time.rb
@@ -11,7 +11,7 @@ module ActiveRecord
             value = super
             return value unless value.acts_like?(:time)
 
-            time = "#{value.to_s(:_sqlserver_time)}.#{quote_fractional(value)}"
+            time = "#{value.to_formatted_s(:_sqlserver_time)}.#{quote_fractional(value)}"
 
             Data.new time, self
           end


### PR DESCRIPTION
```
DEPRECATION WARNING: Time#to_s(:_sqlserver_time) is deprecated. Please
use Time#to_formatted_s(:_sqlserver_time) instead. (called from
serialize at
/activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/type/time.rb:14)
/usr/local/lib/ruby/2.7.0/delegate.rb:83:in `method_missing'
  /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/type/time.rb:14:in
`serialize'
  /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/type/time.rb:24:in
`type_cast_for_schema'
```