### PR TITLE
[Rails 7] Transform queries to add comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,6 @@
 
 #### Added
 
-- [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Add support to `ActiveRecord::QueryLogs`
+- [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Support `ActiveRecord::QueryLogs`
 
 Please check [6-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/6-1-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@
 
 #### Changed
 
-- [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Add support to `ActiveRecord::QueryLogs`
 ...
 
 #### Added
 
-...
+- [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Add support to `ActiveRecord::QueryLogs`
 
 Please check [6-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/6-1-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Changed
 
+- [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Add support to `ActiveRecord::QueryLogs`
 ...
 
 #### Added

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -12,6 +12,7 @@ module ActiveRecord
         end
 
         def execute(sql, name = nil)
+          sql = transform_query(sql)
           if preventing_writes? && write_query?(sql)
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
@@ -27,6 +28,7 @@ module ActiveRecord
         end
 
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+          sql = transform_query(sql)
           if preventing_writes? && write_query?(sql)
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1965,7 +1965,7 @@ end
 require "models/dashboard"
 class QueryLogsTest < ActiveRecord::TestCase
   # Same as original coerced test except our SQL ends with binding.
-  # TODO: Remove coerce after Rails 7.0.1 (see https://github.com/rails/rails/pull/44053)
+  # TODO: Remove coerce after Rails 7.1.0 (see https://github.com/rails/rails/pull/44053)
   coerce_tests! :test_custom_basic_tags, :test_custom_proc_tags, :test_multiple_custom_tags, :test_custom_proc_context_tags
   def test_custom_basic_tags_coerced
     ActiveRecord::QueryLogs.tags = [ :application, { custom_string: "test content" } ]

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1965,6 +1965,7 @@ end
 require "models/dashboard"
 class QueryLogsTest < ActiveRecord::TestCase
   # Same as original coerced test except our SQL ends with binding.
+  # TODO: Remove coerce after Rails 7.0.1 (see https://github.com/rails/rails/pull/44053)
   coerce_tests! :test_custom_basic_tags, :test_custom_proc_tags, :test_multiple_custom_tags, :test_custom_proc_context_tags
   def test_custom_basic_tags_coerced
     ActiveRecord::QueryLogs.tags = [ :application, { custom_string: "test content" } ]


### PR DESCRIPTION
Add support to `ActiveRecord::QueryLogs`

`ActiveRecord::QueryLogs` was introduced [here](https://github.com/rails/rails/commit/2408615154d039264810edbe628f4fc06d8cdc45). Then Rails decided to delegate query transformation responsibility to
each adapter [here](https://github.com/rails/rails/commit/12cc24a733190693c9e703c3edbd024a445d52db)

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4675651408?check_suite_focus=true)
```
7739 runs, 21031 assertions, 83 failures, 60 errors, 43 skips
```