### PR TITLE
[Rails 7] Typo on coerced test original call

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1824,7 +1824,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
   # Call original test from coerced test. Fixes issue on CI with Rails installed as a gem.
   coerce_tests! :test_verbose_query_logs
   def test_verbose_query_logs_coerced
-    original_test_vebose_query_logs
+    original_test_verbose_query_logs
   end
 
   # Bindings logged slightly differently.


### PR DESCRIPTION
Fixes
````
LogSubscriberTest#test_verbose_query_logs_coerced:
NameError: undefined local variable or method `original_test_vebose_query_logs' for #<LogSubscriberTest:0x00007f7d7b2850c8 @NAME="test_verbose_query_logs_coerced"
````

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4650448486?check_suite_focus=true):
```
7739 runs, 21027 assertions, 95 failures, 63 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4671248057?check_suite_focus=true)
```
7739 runs, 21034 assertions, 95 failures, 62 errors, 43 skips
```