### PR TITLE
[Rails 7] Coerce test to match sql server table quoting

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2056,3 +2056,22 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 end
+
+class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
+  # TODO: Remove coerce after Rails 7.1.0 (see https://github.com/rails/rails/pull/44051)
+  coerce_tests! :test_disable_joins_through_with_enum_type
+  def test_disable_joins_through_with_enum_type_coerced
+    joins = capture_sql { @member.club }
+    no_joins = capture_sql { @member.club_without_joins }
+
+    assert_equal 1, joins.size
+    assert_equal 2, no_joins.size
+
+    assert_match(/INNER JOIN/, joins.first)
+    no_joins.each do |nj|
+      assert_no_match(/INNER JOIN/, nj)
+    end
+
+    assert_match(/\[memberships\]\.\[type\]/, no_joins.first)
+  end
+end


### PR DESCRIPTION
Fixes
````
HasOneThroughDisableJoinsAssociationsTest#test_disable_joins_through_with_enum_type [/usr/local/bundle/bundler/gems/rails-5850a6592ff1/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb:82]:
Expected /"memberships"."type"/ to match "EXEC sp_executesql N'SELECT [memberships].[club_id] FROM [memberships] WHERE [memberships].[member_id] = @0 AND [memberships].[type] = @1', N'@0 int, @1 int', @0 = 1, @1 = 1".
````

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4675665721?check_suite_focus=true)
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```