### PR TITLE
[Rails 7] Update test fo Model.reorder(nil).first usage

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1180,16 +1180,11 @@ class RelationTest < ActiveRecord::TestCase
   # We have implicit ordering, via FETCH.
   coerce_tests! :test_reorder_with_first
   def test_reorder_with_first_coerced
+    post = nil
     sql_log = capture_sql do
-      message = <<~MSG.squish
-        `.reorder(nil)` with `.first` / `.first!` no longer
-        takes non-deterministic result in Rails 6.2.
-        To continue taking non-deterministic result, use `.take` / `.take!` instead.
-      MSG
-      assert_deprecated(message) do
-        assert Post.order(:title).reorder(nil).first
-      end
+      post = Post.order(:title).reorder(nil).first
     end
+    assert_equal posts(:welcome), post
     assert sql_log.none? { |sql| /order by [posts].[title]/i.match?(sql) }, "ORDER BY title was used in the query: #{sql_log}"
     assert sql_log.all?  { |sql| /order by \[posts\]\.\[id\]/i.match?(sql) }, "default ORDER BY ID was not used in the query: #{sql_log}"
   end


### PR DESCRIPTION
Fixes: 
```
RelationTest#test_reorder_with_first_coerced [/activerecord-sqlserver-adapter/test/cases/coerced_tests.rb:1189]:
Expected a deprecation warning within the block but received none
```

Original test changed [here](https://github.com/rails/rails/commit/773eeec6ab2397894fb66b7dca2b84bd0d182d7e)

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4675670619?check_suite_focus=true)
```
7739 runs, 21039 assertions, 93 failures, 60 errors, 43 skips
```