### PR TITLE
[Rails 7] Add missing release version to migration

### DIFF
--- a/test/migrations/transaction_table/1_table_will_never_be_created.rb
+++ b/test/migrations/transaction_table/1_table_will_never_be_created.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TableWillNeverBeCreated < ActiveRecord::Migration
+class TableWillNeverBeCreated < ActiveRecord::Migration[5.2]
   def self.up
     create_table(:sqlserver_trans_table1) {}
     create_table(:sqlserver_trans_table2) { raise("HELL") }


### PR DESCRIPTION
Fixes:
```
Failure:
MigrationTestSQLServer::For transactions#test_0001_not create a tables if error in migrations [/activerecord-sqlserver-adapter/test/cases/migration_test_sqlserver.rb:25]:
Expected /this and all later migrations canceled/ to match "Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Active Record release the migration was written for:\n\n  class TableWillNeverBeCreated < ActiveRecord::Migration[7.0]".
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4650448486?check_suite_focus=true):
```
7739 runs, 21027 assertions, 95 failures, 63 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4671594128?check_suite_focus=true)
```
7739 runs, 21035 assertions, 94 failures, 63 errors, 43 skips
```