### PR TITLE
[Rails 7] Fix original method call

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1769,7 +1769,7 @@ class EnumTest < ActiveRecord::TestCase
   test "serializable? with large number label coerced" do
     Book.connection.remove_index(:books, column: [:author_id, :name])
 
-    send(:'original_serializable? with large number label')
+    send(:'original_serializable\? with large number label')
   ensure
     Book.where(author_id: nil, name: nil).delete_all
     Book.connection.add_index(:books, [:author_id, :name], unique: true)


### PR DESCRIPTION
Error introduced in #978

Fixes:
````
EnumTest#test_0093_serializable? with large number label coerced:
NoMethodError: undefined method `original_serializable? with large number label ...
Did you mean?  original_serializable\? with large number label
````

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4675689174?check_suite_focus=true)
```
7739 runs, 21044 assertions, 94 failures, 59 errors, 43 skips
```