### PR TITLE
[Rails 7] Support find_by an encrypted attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@
 #### Added
 
 - [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Support `ActiveRecord::QueryLogs`
+- [#981](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/981) Support `find_by` an encrypted attribute
 
 Please check [6-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/6-1-stable/CHANGELOG.md) for previous changes.

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -83,6 +83,8 @@ module Arel
           # Monkey-patch start. Add query attribute bindings rather than just values.
           column_name = o.column_name
           column_type = o.attribute.relation.type_for_attribute(o.column_name)
+          # Use cast_type on encrypted attributes. Don't encrypt them again
+          column_type = column_type.cast_type if column_type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
           attrs = values.map { |value| ActiveRecord::Relation::QueryAttribute.new(column_name, value, column_type) }
 
           collector.add_binds(attrs, &bind_block)


### PR DESCRIPTION
Due to our Arel monkey patch for [IN with prepared statements](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/main/lib/arel/visitors/sqlserver.rb#L82), encrypted attributes values were encrypted twice.

Take the following example

```
ActiveRecord::Encryption.config.support_unencrypted_data = true
EncryptedBook.find_by(name: "Dune")
```

Before:
```
EXEC sp_executesql N'SELECT [encrypted_books].* FROM [encrypted_books]
WHERE [encrypted_books].[name] IN (@0, @1) ORDER BY [encrypted_books].[id] ASC
OFFSET 0 ROWS FETCH NEXT @2 ROWS ONLY', N'@0 nvarchar(max), @1 nvarchar(max), @2 int',
@0 =
N'{"p":"BbyqDSWICbMEBTtrN4iv0paan00brX1ly6wT92lFrgOQZomP5jBjhPlalbTvucTFX249bJHp7j6usa7SBpAuQFzN+sZFa3dMnlTcaei5","h":{"iv":"2esXR4qnvSteG+o7","at":"pXZzi+SpMNxpAvA8eQYVqA=="}}',
@1 =
N'{"p":"DIohhw==","h":{"iv":"wEPaDcJP3VNIxaiz","at":"X7+2xvvcu1k1if6Dy28Esw=="}}',
@2 = 1  [["name", nil], ["name", nil], ["LIMIT", nil]]
```

After:
```
EXEC sp_executesql N'SELECT [encrypted_books].* FROM [encrypted_books]
WHERE [encrypted_books].[name] IN (@0, @1) ORDER BY [encrypted_books].[id] ASC
OFFSET 0 ROWS FETCH NEXT @2 ROWS ONLY', N'@0 nvarchar(max), @1nvarchar(max), @2 int',
@0 =
N'{"p":"DIohhw==","h":{"iv":"wEPaDcJP3VNIxaiz","at":"X7+2xvvcu1k1if6Dy28Esw=="}}',
@1 = N'Dune',
@2 = 1  [["name", nil], ["name", nil], ["LIMIT", nil]]
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4680952614?check_suite_focus=true):
```
7739 runs, 21038 assertions, 90 failures, 60 errors, 43 skips
```