### PR TITLE
[Rails 7] Coerce encrypted with limit test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2155,3 +2155,15 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal %w[ REWORK ], result.pluck("name")
   end
 end
+
+class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::EncryptionTestCase
+  # TODO: Remove coerce after Rails 7.1.0 (see https://github.com/rails/rails/pull/44052)
+  # Same as original but SQL Server string is varchar(4000), not varchar(255) as other adapters. Produce invalid strings with 4001 characters
+  coerce_tests! %r{validate column sizes}
+  test "validate column sizes coerced" do
+    assert EncryptedAuthor.new(name: "jorge").valid?
+    assert_not EncryptedAuthor.new(name: "a" * 4001).valid?
+    author = EncryptedAuthor.create(name: "a" * 4001)
+    assert_not author.valid?
+  end
+end


### PR DESCRIPTION
Fixes:
````
Failure:
ActiveRecord::Encryption::EncryptableRecordTest#test_0032_validate column sizes [/usr/local/bundle/bundler/gems/rails-5850a6592ff1/activerecord/test/cases/encryption/encryptable_record_test.rb:254]:
Expected true to be nil or false

rails test usr/local/bundle/bundler/gems/rails-5850a6592ff1/activerecord/test/cases/encryption/encryptable_record_test.rb:252
````

SQL Server string column limit is 4000. Other adapters use 255. Reimplement test to produce an invalid string considering SQL Server limit