### PR TITLE
[Rails 7] Optimize remove columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Changed
 
-...
+- [#983](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/983) Optimize remove_columns to use a single SQL statement
 
 #### Added
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -507,6 +507,13 @@ module ActiveRecord
           }.gsub(/[ \t\r\n]+/, " ").strip
         end
 
+        def remove_columns_for_alter(table_name, *column_names, **options)
+          first, *rest = column_names
+
+          # return an array like this [DROP COLUMN col_1, col_2, col_3]. Abstract adapter joins fragments with ", "
+          [remove_column_for_alter(table_name, first)] + rest.map { |column_name| quote_column_name(column_name) }
+        end
+
         def remove_check_constraints(table_name, column_name)
           constraints = select_values "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE where TABLE_NAME = '#{quote_string(table_name)}' and COLUMN_NAME = '#{quote_string(column_name)}'", "SCHEMA"
           constraints.each do |constraint|


### PR DESCRIPTION
Rails introduced an optimization to remove_columns [here](https://github.com/rails/rails/commit/bff3523242d3fcdc7a069ff86863e08d01537674) to use a single SQL statement.

The produced SQL is

```sql
ALTER TABLE [my_table] DROP COLUMN [col_one], DROP COLUMN [col_two]
```

but SQL Server requires

```sql
ALTER TABLE [my_table] DROP COLUMN [col_one], [col_two]
```

This PR fixes: 
```
Error:
 ActiveRecord::Migration::ColumnsTest#test_remove_columns_single_statement:
 ActiveRecord::StatementInvalid: TinyTds::Error: Incorrect syntax near the keyword 'DROP'.
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4702425973?check_suite_focus=true):
```
7739 runs, 21034 assertions, 94 failures, 59 errors, 43 skips
```