### PR TITLE
[Rails 7] Better handle sql queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Changed
 
 - [#983](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/983) Optimize remove_columns to use a single SQL statement
+- [#984](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/984) Better handle SQL queries with invalid encoding
 
 #### Added
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -9,6 +9,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def execute(sql, name = nil)

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -91,6 +91,18 @@ module ActiveRecord
       Subscriber.send(:load_schema!)
       original_test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
     end
+
+    coerce_tests! :test_doesnt_error_when_a_select_query_has_encoding_errors
+    def test_doesnt_error_when_a_select_query_has_encoding_errors_coerced
+      ActiveRecord::Base.while_preventing_writes do
+        # TinyTDS fail on encoding errors.
+        # But at least we can assert it fails in the client and not before when trying to
+        # match the query.
+        assert_raises ActiveRecord::StatementInvalid do
+          @connection.select_all("SELECT '\xC8'")
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Following the same strategy as rails/rails@8cf09b7.

```
If the SQL encoding somehow is invalid, `Regexp#match?` raises
`ArgumentError`.

Best we can do is to copy the string and try to match the regexp in "binary" mode.
```

After this change ActiveRecord::StatementInvalid is raised. Quoting [Rails Postgresql
test](rails/rails@8cf09b7#diff-39aac151bf5772be2c6c4fec49bf5cdf5a21ca816fe181ef01466ecd941bef9bR56)
```
At least we can assert it fails in the client and not before when trying
to match the query.
```

This PR fixes
```
Error:
 ActiveRecord::AdapterPreventWritesTest#test_doesnt_error_when_a_select_query_has_encoding_errors:
 ArgumentError: invalid byte sequence in UTF-8
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4702621559?check_suite_focus=true):
```
7739 runs, 21053 assertions, 94 failures, 59 errors, 43 skips
```