### PR TITLE
[Rails 7] Support string returning clause for AR#insert_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@
 
 - [#972](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) Support `ActiveRecord::QueryLogs`
 - [#981](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/981) Support `find_by` an encrypted attribute
+- [#985](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/985) Support string returning clause for `ActiveRecord#insert_all`
 
 Please check [6-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/6-1-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -149,7 +149,12 @@ module ActiveRecord
           sql = +"INSERT #{insert.into}"
 
           if returning = insert.send(:insert_all).returning
-            sql << " OUTPUT " << returning.map { |column| "INSERTED.#{quote_column_name(column)}" }.join(", ")
+            returning_sql = if returning.is_a?(String)
+              returning
+            else
+              returning.map { |column| "INSERTED.#{quote_column_name(column)}" }.join(", ")
+            end
+            sql << " OUTPUT #{returning_sql}"
           end
 
           sql << " #{insert.values_list}"

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2082,3 +2082,14 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
     assert_match(/\[memberships\]\.\[type\]/, no_joins.first)
   end
 end
+
+class InsertAllTest < ActiveRecord::TestCase
+  coerce_tests! :test_insert_all_returns_requested_sql_fields
+  # Same as original but using INSERTED.name as UPPER argument
+  def test_insert_all_returns_requested_sql_fields_coerced
+    skip unless supports_insert_returning?
+
+    result = Book.insert_all! [{ name: "Rework", author_id: 1 }], returning: Arel.sql("UPPER(INSERTED.name) as name")
+    assert_equal %w[ REWORK ], result.pluck("name")
+  end
+end


### PR DESCRIPTION
[Rails added](https://github.com/rails/rails/commit/c7613dde539a8ffb710e432d131ccc7891520066) support to string returning clause for `insert_all`.

This PR port that behaviour.

We are not manipulating the string in any way, which means that clients need to use `INSERTED.column_name`

This PR fixes
```
Error:
 InsertAllTest#test_insert_all_returns_requested_sql_fields:
 NoMethodError: undefined method `map' for "UPPER(name) as name":Arel::Nodes::SqlLiteral
 Did you mean?  tap
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4702975837?check_suite_focus=true):
```
7739 runs, 21033 assertions, 94 failures, 59 errors, 43 skips
```