### PR TITLE
[Rails 7] Update preloader monkey patch

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
@@ -6,20 +6,12 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module CoreExt
-        module Preloader
-          private
+        module LoaderQuery
+          def load_records_for_keys(keys, &block)
+            return super unless scope.connection.adapter_name == "SQLServer"
 
-          def records_for(ids)
-            return super unless klass.connection.adapter_name == "SQLServer"
-
-            ids.each_slice(in_clause_length).flat_map do |slice|
-              scope.where(association_key_name => slice).load do |record|
-                # Processing only the first owner
-                # because the record is modified but not an owner
-                owner = owners_by_key[convert_key(record[association_key_name])].first
-                association = owner.association(reflection.name)
-                association.set_inverse_instance(record)
-              end.records
+            keys.each_slice(in_clause_length).flat_map do |slice|
+              scope.where(association_key_name => slice).load(&block).records
             end
           end
 
@@ -33,6 +25,6 @@ module ActiveRecord
 end
 
 ActiveSupport.on_load(:active_record) do
-  mod = ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::Preloader
-  ActiveRecord::Associations::Preloader::Association.prepend(mod)
+  mod = ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::LoaderQuery
+  ActiveRecord::Associations::Preloader::Association::LoaderQuery.prepend(mod)
 end

--- a/test/cases/eager_load_too_many_ids_test_sqlserver.rb
+++ b/test/cases/eager_load_too_many_ids_test_sqlserver.rb
@@ -1,0 +1,18 @@
+require "cases/helper_sqlserver"
+require "models/citation"
+require "models/book"
+
+class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
+  fixtures :citations
+
+  def test_batch_preloading_too_many_ids
+    in_clause_length = 10_000
+
+    # We Monkey patch Preloader to work with batches of 10_000 records.
+    # Expect: N Books queries + Citation query
+    expected_query_count = (Citation.count / in_clause_length.to_f).ceil + 1
+    assert_queries(expected_query_count) do
+      Citation.preload(:reference_of).to_a.size
+    end
+  end
+end


### PR DESCRIPTION
Fixes:
```
 Error:
 EagerLoadingTooManyIdsTest#test_preloading_too_many_ids:
 ActiveRecord::StatementInvalid: TinyTds::Error: The query processor ran
 out of internal resources and could not produce a query plan. This is a
 rare event and only expected for extremely complex queries or queries
 that reference a very large number of tables or partitions. Please
 simplify the query. If you believe you have received this message in
 error, contact Customer Support Services for more information.
```

The adapter monkey patch `Preloader::Association` to preload in slices
of 10.000 records (see
[here](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/main/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb).

Rails moved the method the adapter was patching to `Preloader::Association::LoaderQuery` [here](https://github.com/rails/rails/commit/eeef0bb26a23133d51e9031877985a29cd53bd66).

The PR updates the monkey patch. Also adds a test of preload in slices as a way to detect future update needs.

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4715117843?check_suite_focus=true):
```
7740 runs, 21036 assertions, 94 failures, 59 errors, 43 skips
```