### PR TITLE
[Rails 7] Reimplement test that build queries with group by and then call `all`

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1090,6 +1090,24 @@ class UpdateAllTest < ActiveRecord::TestCase
     _(david.reload.name).must_equal "David"
     _(mary.reload.name).must_equal "Test"
   end
+
+  # SQL Server doesn't support queries like SELECT table.* FROM table GROUP BY table.id.
+  # These kind of query is generated to get the affeted records.
+  # Same as original but moving conflicting queries into subqueries
+  coerce_tests! :test_update_all_with_group_by
+  def test_update_all_with_group_by_coerced
+    minimum_comments_count = 2
+
+    Post.most_commented(minimum_comments_count).update_all(title: "ig")
+    posts = Post.where(id: Post.most_commented(minimum_comments_count)).all.to_a
+
+    assert_operator posts.length, :>, 0
+    assert posts.all? { |post| post.comments.length >= minimum_comments_count }
+    assert posts.all? { |post| "ig" == post.title }
+
+    post = Post.where(id: Post.joins(:comments).group("posts.id").having("count(comments.id) < #{minimum_comments_count}")).first
+    assert_not_equal "ig", post.title
+  end
 end
 
 require "models/topic"
@@ -2091,5 +2109,25 @@ class InsertAllTest < ActiveRecord::TestCase
 
     result = Book.insert_all! [{ name: "Rework", author_id: 1 }], returning: Arel.sql("UPPER(INSERTED.name) as name")
     assert_equal %w[ REWORK ], result.pluck("name")
+  end
+end
+
+class DeleteAllTest < ActiveRecord::TestCase
+  # SQL Server does not support SELECT table.* FROM table GROUP BY table.id.
+  # This test is using these kind of query to get the amount of records that should be deleted.
+  # Same as original moving conflicting queries into subqueries.
+  coerce_tests! :test_delete_all_with_group_by_and_having
+  def test_delete_all_with_group_by_and_having_coerced
+    minimum_comments_count = 2
+    posts_to_be_deleted = Post.where(id: Post.most_commented(minimum_comments_count)).all.to_a
+    assert_operator posts_to_be_deleted.length, :>, 0
+
+    assert_difference("Post.count", -posts_to_be_deleted.length) do
+      Post.most_commented(minimum_comments_count).delete_all
+    end
+
+    posts_to_be_deleted.each do |deleted_post|
+      assert_raise(ActiveRecord::RecordNotFound) { deleted_post.reload }
+    end
   end
 end


### PR DESCRIPTION
Rails introduced the ability to call delete_all and update_all on scopes
that use having and group by doing a subquery. See [here](https://github.com/rails/rails/commit/989d53ba3b3b43d3b1a179a146be9244e1c2537e)
and [here](https://github.com/rails/rails/commit/4acb6660e265fd40b38e301fbd15909574d6a59e)

To test this they build scopes like
`Post.group('posts.id').joins(:comments).having('count('comments.id') >
2').all`. SQL Server adapter doesn't support these. Results in
```
ActiveRecord::StatementInvalid: TinyTds::Error: Column 'posts.author_id'
is invalid in the select list because it is not contained in either an
aggregate function or the GROUP BY clause.
```

Coerce and reimplement the test to use subqueries.


Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4732617519?check_suite_focus=true):
```
7743 runs, 21058 assertions, 94 failures, 58 errors, 43 skips
```