### PR TITLE
[Rails 7] Raise error asking for non-existing table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#983](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/983) Optimize remove_columns to use a single SQL statement
 - [#984](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/984) Better handle SQL queries with invalid encoding
+- [#988](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/988) Raise `ActiveRecord::StatementInvalid` when `columns` is called with a non-existing table (***breaking change***)
 
 #### Added
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -439,14 +439,10 @@ module ActiveRecord
           end
 
           # Since Rails 7, it's expected that all adapter raise error when table doesn't exists.
-          # It's hard to modify the existing query to detect non-existing tables.
-          # Checking existance with an extra query up-front seems bad from performance perspecive.
-          # Asumming that most of the times this method is called with an existing table, we only do a second query
-          # when there are no columns. This way handle the unlikely edge case of asking for columns of an empty table
+          # I'm not aware of the possibility of tables without columns on SQL Server (postgres have those).
+          # Raise error if the method return an empty array
           columns.tap do |result|
-            if result.empty? && !data_source_exists?(table_name)
-              raise ActiveRecord::StatementInvalid, "Table '#{table_name}' doesn't exist"
-            end
+            raise ActiveRecord::StatementInvalid, "Table '#{table_name}' doesn't exist" if result.empty?
           end
         end
 


### PR DESCRIPTION
mysql, sqlite3 and postgresql have consistent behaviour regarding non-existing table columns (see [this commit](https://github.com/rails/rails/commit/e323e68a750c8dbc3b7ef156c99c3924c38a84c0)).

SQL server was returning an empty array.

This is a breaking change but apps can recover by adding a rescue block.
Make more sense to behave like all other adapters.

Fixes:
```
Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_columns_for_non_existent_table [/home/matias/.rvm/gems/ruby-2.7.4/bundler/gems/rails-5850a6592ff1/activerecord/test/cases/connection_adapters/schema_cache_test.rb:139]:
ActiveRecord::StatementInvalid expected but nothing was raised.

Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_columns_hash_for_non_existent_table [/home/matias/.rvm/gems/ruby-2.7.4/bundler/gems/rails-5850a6592ff1/activerecord/test/cases/connection_adapters/schema_cache_test.rb:149]:
ActiveRecord::StatementInvalid expected but nothing was raised.
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4735046133?check_suite_focus=true):
```
7743 runs, 21049 assertions, 92 failures, 60 errors, 43 skips
```