### PR TITLE
[Rails 7] Coerce test using blob

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -591,6 +591,36 @@ class MigrationTest < ActiveRecord::TestCase
   # For some reason our tests set Rails.@_env which breaks test env switching.
   coerce_tests! :test_internal_metadata_stores_environment_when_other_data_exists
   coerce_tests! :test_internal_metadata_stores_environment
+
+  # Same as original but using binary type instead of blob
+  coerce_tests! :test_add_column_with_casted_type_if_not_exists_set_to_true
+  def test_add_column_with_casted_type_if_not_exists_set_to_true_coerced
+    migration_a = Class.new(ActiveRecord::Migration::Current) {
+      def version; 100 end
+      def migrate(x)
+        add_column "people", "last_name", :binary
+      end
+    }.new
+
+    migration_b = Class.new(ActiveRecord::Migration::Current) {
+      def version; 101 end
+      def migrate(x)
+        add_column "people", "last_name", :binary, if_not_exists: true
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    assert_column Person, :last_name, "migration_a should have created the last_name column on people"
+
+    assert_nothing_raised do
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+    end
+  ensure
+    Person.reset_column_information
+    if Person.column_names.include?("last_name")
+      Person.connection.remove_column("people", "last_name")
+    end
+  end
 end
 
 class CoreTest < ActiveRecord::TestCase


### PR DESCRIPTION
SQL Server adapter doesn't support `:blob` data type. One test is using it. The original test has a conditional to use another data type for Postgresql, which doesn't support blob too.

The PR reimplements the test using `:binary` data type.

Fixes
````
# Error:
#   MigrationTest#test_add_column_with_casted_type_if_not_exists_set_to_true:
#   StandardError: An error has occurred, this and all later migrations canceled:
#   TinyTds::Error: Column, parameter, or variable #65: Cannot find data type blob.
```

Before (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4674744906?check_suite_focus=true):
```
7739 runs, 21036 assertions, 94 failures, 60 errors, 43 skips
```

After (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4738774805?check_suite_focus=true):
```
7743 runs, 21048 assertions, 94 failures, 59 errors, 43 skips
```