### PR TITLE
[Rails 7] exclude encryption performance from builds

### DIFF
--- a/test/support/rake_helpers.rb
+++ b/test/support/rake_helpers.rb
@@ -25,7 +25,9 @@ end
 
 def ar_cases
   @ar_cases ||= begin
-    Dir.glob("#{ARTest::SQLServer.root_activerecord}/test/cases/**/*_test.rb").reject { |x| x =~ /\/adapters\// }.sort
+    Dir.glob("#{ARTest::SQLServer.root_activerecord}/test/cases/**/*_test.rb").reject {
+      |x| x.include?("/adapters/") || x.include?("/encryption/performance")
+    }.sort
   end
 end
 


### PR DESCRIPTION
Encryption performance is a flaky test (failing in [this run](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4803186154?check_suite_focus=true#step:4:304) but the [next one](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4803192585?check_suite_focus=true) is not failing)

Rails is not running encryption performance test on builds.

Commit https://github.com/rails/rails/commit/1fff866dd1239ff861574ed186e76bdbb166cff1) claims they were meant to be excluded from builds.
The commit also includes the same flaky test failure we have now.

Update `ar_cases` to exclude encryption performance tests