### PR TITLE
Replace octal values with integers

### DIFF
--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -277,8 +277,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "date"
       _(col.type).must_equal               :date
       _(col.null).must_equal               true
-      _(col.default).must_equal            connection_dblib_73? ? Date.civil(0001, 1, 1) : "0001-01-01"
-      _(obj.date).must_equal               Date.civil(0001, 1, 1)
+      _(col.default).must_equal            connection_dblib_73? ? Date.civil(1, 1, 1) : "0001-01-01"
+      _(obj.date).must_equal               Date.civil(1, 1, 1)
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       _(type).must_be_instance_of Type::Date
@@ -287,22 +287,22 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.scale).must_be_nil
       # Can cast strings. SQL Server format.
       obj.date = "04-01-0001"
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       obj.save!
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       obj.reload
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       # Can cast strings. ISO format.
       obj.date = "0001-04-01"
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       obj.save!
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       obj.reload
-      _(obj.date).must_equal Date.civil(0001, 4, 1)
+      _(obj.date).must_equal Date.civil(1, 4, 1)
       # Can filter by date range
       _(obj).must_equal obj.class.where(date: obj.date..Date::Infinity.new).first
       # Can keep and return assigned date.
-      assert_obj_set_and_save :date, Date.civil(1972, 04, 14)
+      assert_obj_set_and_save :date, Date.civil(1972, 4, 14)
       # Can accept and cast time objects.
       obj.date = Time.utc(2010, 4, 14, 12, 34, 56, 3000)
       _(obj.date).must_equal               Date.civil(2010, 4, 14)
@@ -315,7 +315,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "datetime"
       _(col.type).must_equal               :datetime
       _(col.null).must_equal               true
-      time = Time.utc 1753, 01, 01, 00, 00, 00, 123000
+      time = Time.utc 1753, 1, 1, 0, 0, 0, 123000
       _(col.default).must_equal            time, "Microseconds were <#{col.default.usec}> vs <123000>"
       _(obj.datetime).must_equal           time, "Microseconds were <#{obj.datetime.usec}> vs <123000>"
       _(col.default_function).must_be_nil
@@ -327,7 +327,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       obj.save!
       _(obj).must_equal obj.class.where(datetime: time).first
       # Can save to proper accuracy and return again.
-      time = Time.utc 2010, 04, 01, 12, 34, 56, 3000
+      time = Time.utc 2010, 4, 1, 12, 34, 56, 3000
       obj.datetime = time
       _(obj.datetime).must_equal time, "Microseconds were <#{obj.datetime.usec}> vs <3000>"
       obj.save!
@@ -338,8 +338,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       # Can filter by datetime range
       _(obj).must_equal obj.class.where(datetime: time..DateTime::Infinity.new).first
       # Will cast to true DB value on attribute write, save and return again.
-      time = Time.utc 2010, 04, 01, 12, 34, 56, 234567
-      time2 = Time.utc 2010, 04, 01, 12, 34, 56, 233000
+      time = Time.utc 2010, 4, 1, 12, 34, 56, 234567
+      time2 = Time.utc 2010, 4, 1, 12, 34, 56, 233000
       obj.datetime = time
       _(obj.datetime).must_equal time2, "Microseconds were <#{obj.datetime.usec}> vs <233000>"
       obj.save!
@@ -427,8 +427,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "datetimeoffset(7)"
       _(col.type).must_equal               :datetimeoffset
       _(col.null).must_equal               true
-      _(col.default).must_equal            Time.new(1984, 01, 24, 04, 20, 00, -28800).change(nsec: 123456700), "Nanoseconds <#{col.default.nsec}> vs <123456700>"
-      _(obj.datetimeoffset_7).must_equal   Time.new(1984, 01, 24, 04, 20, 00, -28800).change(nsec: 123456700), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <999999900>"
+      _(col.default).must_equal            Time.new(1984, 1, 24, 4, 20, 0, -28800).change(nsec: 123456700), "Nanoseconds <#{col.default.nsec}> vs <123456700>"
+      _(obj.datetimeoffset_7).must_equal   Time.new(1984, 1, 24, 4, 20, 0, -28800).change(nsec: 123456700), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <999999900>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       _(type).must_be_instance_of Type::DateTimeOffset
@@ -436,12 +436,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Can save 100 nanosecond precisoins and return again.
-      obj.datetimeoffset_7 = Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456755)
-      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      obj.datetimeoffset_7 = Time.new(2010, 4, 1, 12, 34, 56, +18000).change(nsec: 123456755)
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 4, 1, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       obj.save!
-      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 4, 1, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       obj.reload
-      _(obj.datetimeoffset_7).must_equal Time.new(2010, 04, 01, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
+      _(obj.datetimeoffset_7).must_equal Time.new(2010, 4, 1, 12, 34, 56, +18000).change(nsec: 123456800), "Nanoseconds were <#{obj.datetimeoffset_7.nsec}> vs <123456800>"
       # Maintains the timezone
       time = ActiveSupport::TimeZone["America/Los_Angeles"].local 2010, 12, 31, 23, 59, 59, Rational(123456800, 1000)
       obj.datetimeoffset_7 = time
@@ -470,8 +470,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "smalldatetime"
       _(col.type).must_equal               :smalldatetime
       _(col.null).must_equal               true
-      _(col.default).must_equal            Time.utc(1901, 01, 01, 15, 45, 00, 000)
-      _(obj.smalldatetime).must_equal      Time.utc(1901, 01, 01, 15, 45, 00, 000)
+      _(col.default).must_equal            Time.utc(1901, 1, 1, 15, 45, 0, 0)
+      _(obj.smalldatetime).must_equal      Time.utc(1901, 1, 1, 15, 45, 0, 0)
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       _(type).must_be_instance_of Type::SmallDateTime
@@ -479,12 +479,12 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_be_nil
       _(type.scale).must_be_nil
       # Will remove fractional seconds and return again.
-      obj.smalldatetime = Time.utc(2078, 06, 05, 4, 20, 00, 3000)
-      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.smalldatetime.usec}> vs <0>"
+      obj.smalldatetime = Time.utc(2078, 6, 5, 4, 20, 0, 3000)
+      _(obj.smalldatetime).must_equal Time.utc(2078, 6, 5, 4, 20, 0, 0), "Microseconds were <#{obj.smalldatetime.usec}> vs <0>"
       obj.save!
-      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
+      _(obj.smalldatetime).must_equal Time.utc(2078, 6, 5, 4, 20, 0, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
       obj.reload
-      _(obj.smalldatetime).must_equal Time.utc(2078, 06, 05, 4, 20, 00, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
+      _(obj.smalldatetime).must_equal Time.utc(2078, 6, 5, 4, 20, 0, 0), "Microseconds were <#{obj.reload.smalldatetime.usec}> vs <0>"
     end
 
     it "time(7)" do
@@ -493,7 +493,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "time(7)"
       _(col.type).must_equal               :time
       _(col.null).must_equal               true
-      _(col.default).must_equal            Time.utc(1900, 01, 01, 04, 20, 00, Rational(288321500, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <288321500>"
+      _(col.default).must_equal            Time.utc(1900, 1, 1, 4, 20, 0, Rational(288321500, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <288321500>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       _(type).must_be_instance_of Type::Time
@@ -501,22 +501,22 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Time's #usec precision (low micro)
-      obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, 300)
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
+      obj.time_7 = Time.utc(2000, 1, 1, 15, 45, 0, 300)
+      _(obj.time_7).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
+      _(obj.time_7).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
       obj.save!; obj.reload
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
-      _(obj.time_7).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
+      _(obj.time_7).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Microseconds were <#{obj.time_7.usec}> vs <0>"
+      _(obj.time_7).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Nanoseconds were <#{obj.time_7.nsec}> vs <300>"
       # Time's #usec precision (high micro)
-      obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, 234567)
-      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
+      obj.time_7 = Time.utc(2000, 1, 1, 15, 45, 0, 234567)
+      _(obj.time_7).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
       obj.save!; obj.reload
-      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
+      _(obj.time_7).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 234567), "Microseconds were <#{obj.time_7.usec}> vs <234567>"
       # Time's #usec precision (high nano rounded)
-      obj.time_7 = Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321545, 1000))
-      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
+      obj.time_7 = Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321545, 1000))
+      _(obj.time_7).must_equal Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
       obj.save!; obj.reload
-      _(obj.time_7).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
+      _(obj.time_7).must_equal Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_7.nsec}> vs <288321500>"
     end
 
     it "time(2)" do
@@ -533,20 +533,20 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_equal 2
       _(type.scale).must_be_nil
       # Always uses TinyTDS/Windows 2000-01-01 convention too.
-      obj.time_2 = Time.utc(2015, 01, 10, 15, 45, 00, 0)
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0)
+      obj.time_2 = Time.utc(2015, 1, 10, 15, 45, 0, 0)
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 0)
       obj.save!; obj.reload
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0)
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 0)
       # Time's #usec precision (barely in 2 precision equal to 0.03 seconds)
-      obj.time_2 = Time.utc(2000, 01, 01, 15, 45, 00, 30000)
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
+      obj.time_2 = Time.utc(2000, 1, 1, 15, 45, 0, 30000)
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
       obj.save!; obj.reload
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 30000), "Microseconds were <#{obj.time_2.usec}> vs <30000>"
       # Time's #usec precision (below 2 precision)
-      obj.time_2 = Time.utc(2000, 01, 01, 15, 45, 00, 4000)
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
+      obj.time_2 = Time.utc(2000, 1, 1, 15, 45, 0, 4000)
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
       obj.save!; obj.reload
-      _(obj.time_2).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
+      _(obj.time_2).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 0), "Microseconds were <#{obj.time_2.usec}> vs <0>"
     end
 
     it "time using default precision" do
@@ -555,7 +555,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "time(7)"
       _(col.type).must_equal               :time
       _(col.null).must_equal               true
-      _(col.default).must_equal            Time.utc(1900, 01, 01, 15, 03, 42, Rational(62197800, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <62197800>"
+      _(col.default).must_equal            Time.utc(1900, 1, 1, 15, 3, 42, Rational(62197800, 1000)), "Nanoseconds were <#{col.default.nsec}> vs <62197800>"
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       _(type).must_be_instance_of Type::Time
@@ -563,22 +563,22 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(type.precision).must_equal 7
       _(type.scale).must_be_nil
       # Time's #usec precision (low micro)
-      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 300)
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
+      obj.time_default = Time.utc(2000, 1, 1, 15, 45, 0, 300)
+      _(obj.time_default).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
+      _(obj.time_default).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
       obj.save!; obj.reload
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
-      _(obj.time_default).must_equal             Time.utc(2000, 01, 01, 15, 45, 00, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
+      _(obj.time_default).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Microseconds were <#{obj.time_default.usec}> vs <0>"
+      _(obj.time_default).must_equal             Time.utc(2000, 1, 1, 15, 45, 0, 300), "Nanoseconds were <#{obj.time_default.nsec}> vs <300>"
       # Time's #usec precision (high micro)
-      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, 234567)
-      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      obj.time_default = Time.utc(2000, 1, 1, 15, 45, 0, 234567)
+      _(obj.time_default).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
       obj.save!; obj.reload
-      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
+      _(obj.time_default).must_equal Time.utc(2000, 1, 1, 15, 45, 0, 234567), "Microseconds were <#{obj.time_default.usec}> vs <234567>"
       # Time's #usec precision (high nano rounded)
-      obj.time_default = Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321545, 1000))
-      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
+      obj.time_default = Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321545, 1000))
+      _(obj.time_default).must_equal Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
       obj.save!; obj.reload
-      _(obj.time_default).must_equal Time.utc(2000, 01, 01, 15, 45, 00, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
+      _(obj.time_default).must_equal Time.utc(2000, 1, 1, 15, 45, 0, Rational(288321500, 1000)), "Nanoseconds were <#{obj.time_default.nsec}> vs <288321500>"
     end
 
     # Character Strings


### PR DESCRIPTION
Replace the octal values in the `ColumnTestSQLServer` tests with integers. Mixing octal and integer values together in the tests can lead to confusion.