### PR TITLE
[Rails 7] Fix randomly failing Rails relations test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1350,6 +1350,14 @@ module ActiveRecord
       query = Post.optimizer_hints("OMGHINT").merge(Post.optimizer_hints("OMGHINT")).to_sql
       assert_equal expected, query
     end
+
+    # Workaround for randomly failing test. Ordering of results not guaranteed.
+    coerce_tests! :test_select_quotes_when_using_from_clause
+    def test_select_quotes_when_using_from_clause_coerced
+      quoted_join = ActiveRecord::Base.connection.quote_table_name("join")
+      selected = Post.select(:join).from(Post.select("id as #{quoted_join}")).map(&:join)
+      assert_equal Post.pluck(:id).sort, selected.sort
+    end
   end
 end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1352,6 +1352,7 @@ module ActiveRecord
     end
 
     # Workaround for randomly failing test. Ordering of results not guaranteed.
+    # TODO: Remove coerced test when https://github.com/rails/rails/pull/44168 merged.
     coerce_tests! :test_select_quotes_when_using_from_clause
     def test_select_quotes_when_using_from_clause_coerced
       quoted_join = ActiveRecord::Base.connection.quote_table_name("join")


### PR DESCRIPTION
The ordering of results is not guaranteed by SQL Server if not specified. This results in the `ActiveRecord::RelationTest#test_select_quotes_when_using_from_clause` test randomly failing.

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/4805711536?check_suite_focus=true

```
Failure:
ActiveRecord::RelationTest#test_select_quotes_when_using_from_clause [/usr/local/bundle/bundler/gems/rails-595a37d477be/activerecord/test/cases/relation_test.rb:296]:
--- expected
+++ actual
@@ -1 +1 @@
-[3, 1, 2, 4, 5, 6, 7, 9, 11, 8, 10]
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

rails test usr/local/bundle/bundler/gems/rails-595a37d477be/activerecord/test/cases/relation_test.rb:292
```