### PR TITLE
[Rails 6.1] Support different index types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#999](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/999) Fixed support for index types
+
 ## v6.1.2.1
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v6.1.2.0...v6.1.2.1)

--- a/test/cases/active_schema_test_sqlserver.rb
+++ b/test/cases/active_schema_test_sqlserver.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+
+class ActiveSchemaTestSQLServer < ActiveRecord::TestCase
+  describe "index types" do
+    before do
+      connection.create_table :index_types, force: true, id: false do |t|
+        t.column :foo, :string, limit: 100
+      end
+    end
+
+    after do
+      connection.drop_table :index_types rescue nil
+    end
+
+    it 'default index' do
+      assert_sql('CREATE INDEX [index_index_types_on_foo] ON [index_types] ([foo])') do
+        connection.add_index :index_types, "foo"
+      end
+    end
+
+    it 'clustered index' do
+      assert_sql('CREATE clustered INDEX [index_index_types_on_foo] ON [index_types] ([foo])') do
+        connection.add_index :index_types, "foo", type: :clustered
+      end
+    end
+
+    it 'nonclustered index' do
+      assert_sql('CREATE nonclustered INDEX [index_index_types_on_foo] ON [index_types] ([foo])') do
+        connection.add_index :index_types, "foo", type: :nonclustered
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes clustered index issue identified in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/999

Now `connection.add_index "testings", "last_name", type: :clustered` will successfully generate the SQL to create the clustered index.

The issue was introduced between Rails 6.0 and 6.1 by https://github.com/rails/rails/pull/39203