### PR TITLE
Dump the precision for datetime columns following the new defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Changed
+
+- [#1004](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1004) Dump the precision for datetime columns following the new defaults.
+
 ## v7.0.0.0.rc1
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/6-1-stable...v7.0.0.0.rc1)

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -79,7 +79,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :float_col,       type: "float",        limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :string_col,      type: "string",       limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :text_col,        type: "text",         limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :datetime_col,    type: "datetime",     limit: nil,          precision: 6,    scale: nil, default: nil
+    assert_line :datetime_col,    type: "datetime",     limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :timestamp_col,   type: "datetime",     limit: nil,          precision: nil,  scale: nil, default: nil
     assert_line :time_col,        type: "time",         limit: nil,          precision: 7,    scale: nil, default: nil
     assert_line :date_col,        type: "date",         limit: nil,          precision: nil,  scale: nil, default: nil


### PR DESCRIPTION
The CI is failing following the release of Rails 7.0.2, see https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/runs/5123050136?check_suite_focus=true:

```
SchemaDumperTestSQLServer#test_0002_sst_datatypes_migration [/activerecord-sqlserver-adapter/test/cases/schema_dumper_test_sqlserver.rb:82]:
Precision of 6 not found in:
t.datetime "datetime_col".
Expected: 6
  Actual: nil
```

The test is failing following https://github.com/rails/rails/pull/44358. When dumping a datetime column that uses the default precision of 6, the column will now be dumped with precision `nil` rather than `6`. 