### PR TITLE
[Rails 6.1] Fix support for different index types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1006](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1006) Fix support for index types
+
 ## v6.1.2.1
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v6.1.2.0...v6.1.2.1)

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -34,17 +34,19 @@ module ActiveRecord
         end
 
         def visit_CreateIndexDefinition(o)
-          if_not_exists = o.if_not_exists
+          index = o.index
 
-          o.if_not_exists = false
+          sql = []
+          sql << "IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = '#{o.index.name}')" if o.if_not_exists
+          sql << "CREATE"
+          sql << "UNIQUE" if index.unique
+          sql << index.type.upcase if index.type
+          sql << "INDEX"
+          sql << "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
+          sql << "(#{quoted_columns(index)})"
+          sql << "WHERE #{index.where}" if index.where
 
-          sql = super
-
-          if if_not_exists
-            sql = "IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = '#{o.index.name}') #{sql}"
-          end
-
-          sql
+          sql.join(" ")
         end
 
         def add_column_options!(sql, options)

--- a/test/cases/active_schema_test_sqlserver.rb
+++ b/test/cases/active_schema_test_sqlserver.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+
+class ActiveSchemaTestSQLServer < ActiveRecord::TestCase
+  before do
+    connection.create_table :schema_test_table, force: true, id: false do |t|
+      t.column :foo, :string, limit: 100
+      t.column :state, :string
+    end
+  end
+
+  after do
+    connection.drop_table :schema_test_table rescue nil
+  end
+
+  it 'default index' do
+    assert_sql('CREATE INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo])') do
+      connection.add_index :schema_test_table, "foo"
+    end
+  end
+
+  it 'unique index' do
+    assert_sql('CREATE UNIQUE INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo])') do
+      connection.add_index :schema_test_table, "foo", unique: true
+    end
+  end
+
+  it 'where condition on index' do
+    assert_sql("CREATE INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo]) WHERE state = 'active'") do
+      connection.add_index :schema_test_table, "foo", where: "state = 'active'"
+    end
+  end
+
+  it 'if index does not exist' do
+    assert_sql("IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = 'index_schema_test_table_on_foo') " \
+               "CREATE INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo])") do
+      connection.add_index :schema_test_table, "foo", if_not_exists: true
+    end
+  end
+
+  describe "index types" do
+    it 'clustered index' do
+      assert_sql('CREATE CLUSTERED INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo])') do
+        connection.add_index :schema_test_table, "foo", type: :clustered
+      end
+    end
+
+    it 'nonclustered index' do
+      assert_sql('CREATE NONCLUSTERED INDEX [index_schema_test_table_on_foo] ON [schema_test_table] ([foo])') do
+        connection.add_index :schema_test_table, "foo", type: :nonclustered
+      end
+    end
+  end
+end


### PR DESCRIPTION
Back-port of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1002 into the `6-1-stable` branch.

Fixes the https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/999 issue that was initially reported for Rails 6.1