### PR TITLE
[Rails 6.1 CI] Use PostgreSQL 1.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "bcrypt"
-gem "pg",      ">= 0.18.0"
+
+gem "pg", "1.2.3"
+
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 


### PR DESCRIPTION
The Rails 6.1 Windows CI is failing because the PostgreSQL v1.3.1 gem cannot be installed on the Windows CI image. See https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/42526232/job/uqyayud4m8mssojy

The Windows CI last passed when PostgreSQL v1.2.3 gem was used. See https://ci.appveyor.com/project/wpolicarpo/activerecord-sqlserver-adapter/builds/41990100/job/f776f13o08f7pyo1

This PR will force the CI to use v1.2.3 of the `pg` gem. This will allow the Linux CI and Windows CI tests to pass. 

Note: This issue does not affect `main` since no Windows CI builds currently pass on `main`. It may affect `6-0-stable` and so might need to be back-ported there.