### PR TITLE
Require reporting module containing silence_warnings

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain_subscriber.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain_subscriber.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/kernel/reporting"
+
 ActiveSupport.on_load(:active_record) do
   silence_warnings do
     # Already defined in Rails


### PR DESCRIPTION
The module containing `silence_warnings` needs to be required before use. This fixes an issue when you require the 'activerecord-sqlserver-adapter' gem on it's own.

Fixes issue [!1016](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1016)

The issue was introduced between Rails v7.0.2 and v7.0.3. 