### PR TITLE
Freeze the SQL sent to instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [#1021](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1021) Freeze the SQL sent to instrumentation.
+
 ## v7.0.0.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v7.0.0.0.rc1...v7.0.0.0)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -360,7 +360,7 @@ module ActiveRecord
             sql = "EXEC sp_executesql #{quote(sql)}"
             sql += ", #{types}, #{params}" unless params.empty?
           end
-          sql
+          sql.freeze
         end
 
         def raw_connection_do(sql)


### PR DESCRIPTION
This PR fixes the failing `QueryCacheTest#test_query_cache_does_not_allow_sql_key_mutation` test.

```
QueryCacheTest#test_query_cache_does_not_allow_sql_key_mutation [/usr/local/bundle/bundler/gems/rails-926d00643fb7/activerecord/test/cases/query_cache_test.rb:493]:
FrozenError expected but nothing was raised.
```

The issue is that the SQL sent to instrumentation is expected to be frozen. In other adapters, the SQL string used for the query cache and instrumentation are the same frozen string. The freezing of the SQL is done by https://github.com/rails/rails/blob/487282cb40b013b9f2a86e1dbd5affa38955fab1/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L39

In the SQL Server adapter we wrap the SQL using `EXEC sp_executesql`. 

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/a798480f5b01c0252da8dfde5947b5687e12b563/lib/active_record/connection_adapters/sqlserver/database_statements.rb#L360

It is this unfrozen SQL that is sent to instrumentation. The `QueryCacheTest#test_query_cache_does_not_allow_sql_key_mutation` test is expecting the SQL sent to instrumentation to be frozen.