### PR TITLE
Add dbconsole support to adapter

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -59,6 +59,23 @@ module ActiveRecord
       self.exclude_output_inserted_table_names = Concurrent::Map.new { false }
 
       class << self
+        def dbconsole(config, options = {})
+          sqlserver_config = config.configuration_hash
+          args = []
+
+          args += ["-d", "#{config.database}"] if config.database
+          args += ["-U", "#{sqlserver_config[:username]}"] if sqlserver_config[:username]
+          args += ["-P", "#{sqlserver_config[:password]}"] if sqlserver_config[:password]
+
+          if sqlserver_config[:host]
+            host_arg = +"tcp:#{sqlserver_config[:host]}"
+            host_arg << ",#{sqlserver_config[:port]}" if sqlserver_config[:port]
+            args += ["-S", host_arg]
+          end
+
+          find_cmd_and_exec("sqlcmd", *args)
+        end
+
         def new_client(config)
           case config[:mode]
           when :dblib

--- a/lib/active_record/sqlserver_base.rb
+++ b/lib/active_record/sqlserver_base.rb
@@ -2,13 +2,17 @@
 
 module ActiveRecord
   module ConnectionHandling
+    def sqlserver_connection_class
+      ConnectionAdapters::SQLServerAdapter
+    end
+
     def sqlserver_connection(config) #:nodoc:
       config = config.symbolize_keys
       config.reverse_merge!(mode: :dblib)
       config[:mode] = config[:mode].to_s.downcase.underscore.to_sym
 
-      ConnectionAdapters::SQLServerAdapter.new(
-        ConnectionAdapters::SQLServerAdapter.new_client(config),
+      sqlserver_connection_class.new(
+        sqlserver_connection_class.new_client(config),
         logger,
         nil,
         config

--- a/test/cases/dbconsole.rb
+++ b/test/cases/dbconsole.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DbConsole < ActiveRecord::TestCase
+  subject { ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter }
+
+  it "uses sqlplus to connect to database" do
+    subject.expects(:find_cmd_and_exec).with("sqlcmd", "-d", "db", "-U", "user", "-P", "secret", "-S", "tcp:localhost,1433")
+
+    config = make_db_config(adapter: "sqlserver", database: "db", username: "user", password: "secret", host: "localhost", port: 1433)
+
+    subject.dbconsole(config)
+  end
+
+  private
+
+  def make_db_config(config)
+    ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", config)
+  end
+end


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/46093

Adds dbconsole method to be used when invoking bin/rails dbconsole.

Moves dbconsole logic related to SQL Server in Rails to the adapter. This connection code and corresponding test was in the dbconsole command in railties.

cc @paarthmadan