### PR TITLE
[Rails 7] Coerced field order with strings test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2087,6 +2087,17 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
   end
 
   # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! :test_in_order_of_with_string_column
+  def test_in_order_of_with_string_column_coerced
+    Book.connection.remove_index(:books, column: [:author_id, :name])
+
+    original_test_in_order_of_with_string_column
+  ensure
+    Book.where(author_id: nil, name: nil).delete_all
+    Book.connection.add_index(:books, [:author_id, :name], unique: true)
+  end
+
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
   coerce_tests! :test_in_order_of_with_enums_keys
   def test_in_order_of_with_enums_keys_coerced
     Book.connection.remove_index(:books, column: [:author_id, :name])


### PR DESCRIPTION
Fixes:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/3282242551/jobs/5405374502
```
FieldOrderedValuesTest#test_in_order_of_with_string_column:
ActiveRecord::RecordNotUnique: TinyTds::Error: Cannot insert duplicate key row in object 'dbo.books' with unique index 'index_books_on_author_id_and_name'. The duplicate key value is (<NULL>, <NULL>).
    activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:456:in `each'
    activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:456:in `handle_to_names_and_values_dblib'
    activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:447:in `handle_to_names_and_values'
    activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:426:in `_raw_select'
```

Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.