### PR TITLE
Support proc default values in ruby 3.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Fixed
 
 - [#1029](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1029) Handle views defined in other databases.
+- [#1033](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1033) Support proc default values in ruby 3.2.
+
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
         def quote_default_expression(value, column)
           cast_type = lookup_cast_type(column.sql_type)
-          if cast_type.type == :uuid && value =~ /\(\)/
+          if cast_type.type == :uuid && value.is_a?(String) && value.include?('()')
             value
           else
             super

--- a/test/cases/uuid_test_sqlserver.rb
+++ b/test/cases/uuid_test_sqlserver.rb
@@ -43,4 +43,12 @@ class SQLServerUuidTest < ActiveRecord::TestCase
     obj = with_use_output_inserted_disabled { SSTestUuid.create!(name: "😢") }
     _(obj.id).must_be :nil?
   end
+
+  it "can add column with proc as default" do
+    table_name = SSTestUuid.table_name
+    connection.add_column table_name, :thingy, :uuid, null: false, default: -> { "NEWSEQUENTIALID()" }
+    SSTestUuid.reset_column_information
+    column = SSTestUuid.columns_hash["thingy"]
+    _(column.default_function).must_equal "newsequentialid()"
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1032
```
NoMethodError: undefined method `=~' for #<Proc:..
```

As [the issue](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1032) explains `=~` [was removed](https://bugs.ruby-lang.org/issues/15231) from Proc.

`Proc` are handled by [this line of code](https://github.com/rails/rails/blob/v7.0.4.2/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L96)

The solution is to add a check and call `~=` only when `value` is a `String`.

I took the oportunity to follow rubocop performance suggestions
```
Performance/StringInclude: Use String#include? instead of a regex match
with literal-only pattern.
```
Got the idea from postgresql adapter
(https://github.com/rails/rails/commit/5726b1d1d7665c33830ad114f45258ecf772b7b6#diff-d8e4ab5c8c59df4fc1bc85457af0d07b88bd842a287233617a97ad2436fcb842R120)