### PR TITLE
Fix CI tests for Rails 6.1.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5.9, 2.6.7, 2.7.3, 3.0.1]
+        ruby:
+          - 2.7.5
+          - 3.0.3
+          - 3.1.0
 
     steps:
       - name: Checkout code

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,11 @@ gemspec
 
 gem "bcrypt"
 
-gem "pg", "1.2.3"
+gem "pg", "~> 1.3"
 
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "minitest", ">= 5.15.0", "< 5.16"
 
 if ENV["RAILS_SOURCE"]
   gemspec path: ENV["RAILS_SOURCE"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ build: off
 matrix:
   fast_finish: true
   allow_failures:
-    - ruby_version: "25"
-    - ruby_version: "26"
     - ruby_version: "27"
     - ruby_version: "27-x64"
+    - ruby_version: "30"
+    - ruby_version: "30-x64"
 services:
   - mssql2014
 
@@ -38,9 +38,7 @@ environment:
   CI_AZURE_PASS:
     secure: cSQp8sk4urJYvq0utpsK+r7J+snJ2wpcdp8RdXJfB+w=
   matrix:
-    - ruby_version: "25-x64"
-    - ruby_version: "25"
-    - ruby_version: "26-x64"
-    - ruby_version: "26"
     - ruby_version: "27-x64"
     - ruby_version: "27"
+    - ruby_version: "30-x64"
+    - ruby_version: "30"

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -176,7 +176,8 @@ class SQLServerRakeSchemaCacheDumpLoadTest < SQLServerRakeTest
   it "dumps schema cache with SQL Server metadata" do
     quietly { db_tasks.dump_schema_cache connection, filename }
 
-    schema_cache = YAML.load(File.read(filename))
+    filedata = File.read(filename)
+    schema_cache = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(filedata) : YAML.load(filedata)
 
     col_id, col_name = connection.schema_cache.columns("users")
 


### PR DESCRIPTION
Fix CI tests for Rails 6.1.7.2

Also, updated the CI Ruby matrix to match https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/997

