### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5.9, 2.6.7, 2.7.3, 3.0.1]
+        ruby:
+          - 2.7.5
+          - 3.0.3
+          - 3.1.0
 
     steps:
       - name: Checkout code

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1414,7 +1414,8 @@ class YamlSerializationTest < ActiveRecord::TestCase
   coerce_tests! :test_types_of_virtual_columns_are_not_changed_on_round_trip
   def test_types_of_virtual_columns_are_not_changed_on_round_trip_coerced
     author = Author.select("authors.*, 5 as posts_count").first
-    dumped = YAML.load(YAML.dump(author))
+    dumped_author = YAML.dump(author)
+    dumped = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(dumped_author) : YAML.load(dumped_author)
     assert_equal 5, author.posts_count
     assert_equal 5, dumped.posts_count
   end

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -176,7 +176,8 @@ class SQLServerRakeSchemaCacheDumpLoadTest < SQLServerRakeTest
   it "dumps schema cache with SQL Server metadata" do
     quietly { db_tasks.dump_schema_cache connection, filename }
 
-    schema_cache = YAML.load(File.read(filename))
+    filedata = File.read(filename)
+    schema_cache = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(filedata) : YAML.load(filedata)
 
     col_id, col_name = connection.schema_cache.columns("users")
 


### PR DESCRIPTION
Backport CI testing changes from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/997 into the `6-1-stable` branch.

Update CI matrix to support the following rubies:

- 2.7.5
- 3.0.3
- 3.1.0