### PR TITLE
Fix hook method that allows custom connection configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#1029](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1029) Handle views defined in other databases.
 - [#1033](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1033) Support proc default values in ruby 3.2.
 - [#1020](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1020) Support using adapter as a stand-alone gem.
-
+- [#1039](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1039) Fix hook method that allows custom connection configuration.
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ end
 
 #### Configure Connection
 
-We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes.
+We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just implement the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes.
 
 ```ruby
 module ActiveRecord

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -157,7 +157,7 @@ module ActiveRecord
       def initialize(connection, logger, _connection_options, config)
         super(connection, logger, config)
         @connection_options = config
-        configure_connection
+        perform_connection_configuration
       end
 
       # === Abstract Adapter ========================================== #
@@ -316,14 +316,6 @@ module ActiveRecord
       def reset!
         reset_transaction
         do_execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION"
-      end
-
-      def configure_connection
-        @spid = _raw_select("SELECT @@SPID", fetch: :rows).first.first
-        @version_year = version_year
-
-        initialize_dateformatter
-        use_database
       end
 
       # === Abstract Adapter (Misc Support) =========================== #
@@ -557,7 +549,20 @@ module ActiveRecord
 
       def connect
         @connection = self.class.new_client(@connection_options)
-        configure_connection
+        perform_connection_configuration
+      end
+
+      def perform_connection_configuration
+        configure_connection_defaults
+        configure_connection if self.respond_to?(:configure_connection)
+      end
+
+      def configure_connection_defaults
+        @spid = _raw_select("SELECT @@SPID", fetch: :rows).first.first
+        @version_year = version_year
+
+        initialize_dateformatter
+        use_database
       end
     end
   end


### PR DESCRIPTION
The method `configure_connection` was meant to be a hook method to allow custom connection configuration. However, the method was implemented in the adapter to perform the default connection configuration. I have extracted the default connection configuration to it's own method so that the hook method is available again for custom configuration.

This allows users to implement `configure_connection` without having to re-implement the default configuration or call super to call the adapter's implementation of the method.

This fixes issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/950

Note: The fix will later be backported to the `6-1-stable` branch. 