### PR TITLE
Fix hook method that allows custom connection configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 - [#1006](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1006) Fix support for index types
+- [#x](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/x) Fix hook method that allows custom connection configuration.
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ end
 
 #### Configure Connection
 
-We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just override the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes.
+We currently conform to an unpublished and non-standard AbstractAdapter interface to configure connections made to the database. To do so, just implement the `configure_connection` method in an initializer like so. In this case below we are setting the `TEXTSIZE` to 64 megabytes.
 
 ```ruby
 module ActiveRecord

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -140,7 +140,7 @@ module ActiveRecord
       def initialize(connection, logger, _connection_options, config)
         super(connection, logger, config)
         @connection_options = config
-        configure_connection
+        perform_connection_configuration
       end
 
       # === Abstract Adapter ========================================== #
@@ -299,14 +299,6 @@ module ActiveRecord
       def reset!
         reset_transaction
         do_execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION"
-      end
-
-      def configure_connection
-        @spid = _raw_select("SELECT @@SPID", fetch: :rows).first.first
-        @version_year = version_year
-
-        initialize_dateformatter
-        use_database
       end
 
       # === Abstract Adapter (Misc Support) =========================== #
@@ -530,7 +522,20 @@ module ActiveRecord
 
       def connect
         @connection = self.class.new_client(@connection_options)
-        configure_connection
+        perform_connection_configuration
+      end
+
+      def perform_connection_configuration
+        configure_connection_defaults
+        configure_connection if self.respond_to?(:configure_connection)
+      end
+
+      def configure_connection_defaults
+        @spid = _raw_select("SELECT @@SPID", fetch: :rows).first.first
+        @version_year = version_year
+
+        initialize_dateformatter
+        use_database
       end
     end
   end


### PR DESCRIPTION
The method configure_connection was meant to be a hook method to allow custom connection configuration. However, the method was implemented in the adapter to perform the default connection configuration. I have extracted the default connection configuration to it's own method so that the hook method is available again for custom configuration.

This allows users to implement configure_connection without having to re-implement the default configuration or call super to call the adapter's implementation of the method.

This fixes issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/950

Note: Backported from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1039