### PR TITLE
Updated CI rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7.5
-          - 3.0.3
-          - 3.1.0
+          - 2.7.7
+          - 3.1.3
+          - 3.2.1
 
     steps:
       - name: Checkout code

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
-ARG TARGET_VERSION=2.6.3
+ARG TARGET_VERSION=3.2.1
 
-FROM railssqlserver/activerecord-sqlserver-adapter:${TARGET_VERSION}
+FROM aidanharan/activerecord-sqlserver-adapter:${TARGET_VERSION}
 
 ENV WORKDIR /activerecord-sqlserver-adapter
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 ARG TARGET_VERSION=3.2.1
 
-FROM aidanharan/activerecord-sqlserver-adapter:${TARGET_VERSION}
+FROM ghcr.io/rails-sqlserver/activerecord-sqlserver-adapter:${TARGET_VERSION}
 
 ENV WORKDIR /activerecord-sqlserver-adapter
 


### PR DESCRIPTION
Updated the CI to use the latest rubies:
- v2.7.7
- v3.1.3
- v3.2.1

Using Github container registry instead of DockerHub for the docker images. See https://github.com/rails-sqlserver/docker-images/pull/4

This fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1034