### PR TITLE
Use Github container registry instead of Docker Hub

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   sqlserver:
-    image: metaskills/mssql-server-linux-rails
+    image: ghcr.io/rails-sqlserver/mssql-server-linux-rails
   ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=sqlserver


### PR DESCRIPTION
Use Github container registry for the CI rather than combination of Github and Docker Hub.