### PR TITLE
 Fix for inserting records into non-dbo schema table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [#1049](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1049) Fix for inserting records into non-dbo schema table.
+
 ## v7.0.1.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v7.0.0.0...v7.0.1.0)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -397,14 +397,12 @@ module ActiveRecord
         end
 
         def query_requires_identity_insert?(sql)
-          if insert_sql?(sql)
-            table_name = get_table_name(sql)
-            id_column = identity_columns(table_name).first
-            # id_column && sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)[^(]+\([^)]*\b(#{id_column.name})\b,?[^)]*\)/i ? quote_table_name(table_name) : false
-            id_column && sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)[^(]+\([^)]*\b(#{id_column.name})\b,?[^)]*\)/i ? table_name : false
-          else
-            false
-          end
+          return false unless insert_sql?(sql)
+
+          raw_table_name = get_raw_table_name(sql)
+          id_column = identity_columns(raw_table_name).first
+
+          id_column && sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)[^(]+\([^)]*\b(#{id_column.name})\b,?[^)]*\)/i ? SQLServer::Utils.extract_identifiers(raw_table_name).object : false
         end
 
         def insert_sql?(sql)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -197,7 +197,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       @identity_insert_sql_unordered_sp = "EXEC sp_executesql N'INSERT INTO [funny_jokes] ([name],[id]) VALUES (@0, @1)', N'@0 nvarchar(255), @1  int', @0 = N'Knock knock', @1 = 420"
     end
 
-    it "return quoted table_name to #query_requires_identity_insert? when INSERT sql contains id column" do
+    it "return unquoted table_name to #query_requires_identity_insert? when INSERT sql contains id column" do
       assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql)
       assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unquoted)
       assert_equal "funny_jokes", connection.send(:query_requires_identity_insert?, @identity_insert_sql_unordered)

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -21,6 +21,7 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
 
     it "have only one identity column" do
       columns = connection.columns("test.sst_schema_identity")
+
       assert_equal 2, columns.size
       assert_equal 1, columns.select { |c| c.is_identity? }.size
     end
@@ -29,6 +30,7 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       test_columns = connection.columns("test.sst_schema_columns")
       dbo_columns = connection.columns("dbo.sst_schema_columns")
       columns = connection.columns("sst_schema_columns") # This returns table from dbo schema
+
       assert_equal 7, test_columns.size
       assert_equal 2, dbo_columns.size
       assert_equal 2, columns.size
@@ -39,10 +41,15 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
 
     it "return correct varchar and nvarchar column limit length when table is in non dbo schema" do
       columns = connection.columns("test.sst_schema_columns")
+
       assert_equal 255, columns.find { |c| c.name == "name" }.limit
       assert_equal 1000, columns.find { |c| c.name == "description" }.limit
       assert_equal 255, columns.find { |c| c.name == "n_name" }.limit
       assert_equal 1000, columns.find { |c| c.name == "n_description" }.limit
+    end
+
+    it "creates new record" do
+      Alien.create!(name: 'Trisolarans')
     end
   end
 end

--- a/test/models/sqlserver/alien.rb
+++ b/test/models/sqlserver/alien.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Alien < ActiveRecord::Base
+  self.table_name = "test.aliens"
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -312,4 +312,11 @@ ActiveRecord::Schema.define do
       CONSTRAINT PK_sst_composite_with_identity PRIMARY KEY (pk_col_one, pk_col_two)
     );
   COMPOSITE_WITH_IDENTITY
+
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'aliens' and TABLE_SCHEMA = 'test') DROP TABLE test.aliens"
+  execute <<-TABLE_IN_OTHER_SCHEMA_USED_BY_MODEL
+    CREATE TABLE test.aliens(
+      name varchar(255)
+    )
+  TABLE_IN_OTHER_SCHEMA_USED_BY_MODEL
 end


### PR DESCRIPTION
Fix issue with inserting records into non-dbo schema as reported in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1043
