### PR TITLE
Ignore casing of VALUES clause when inserting records using SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1052](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1052) Ignore casing of VALUES clause when inserting records using SQL
+
 ## v7.0.2.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v7.0.1.0...v7.0.2.0)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -278,11 +278,11 @@ module ActiveRecord
                     id_sql_type = exclude_output_inserted.is_a?(TrueClass) ? "bigint" : exclude_output_inserted
                     <<~SQL.squish
                       DECLARE @ssaIdInsertTable table (#{quoted_pk} #{id_sql_type});
-                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @ssaIdInsertTable"}
+                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/i), " OUTPUT INSERTED.#{quoted_pk} INTO @ssaIdInsertTable"}
                       SELECT CAST(#{quoted_pk} AS #{id_sql_type}) FROM @ssaIdInsertTable
                     SQL
                   else
-                    sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"
+                    sql.dup.insert sql.index(/ (DEFAULT )?VALUES/i), " OUTPUT INSERTED.#{quoted_pk}"
                   end
                 else
                   "#{sql}; SELECT CAST(SCOPE_IDENTITY() AS bigint) AS Ident"
@@ -392,7 +392,7 @@ module ActiveRecord
           self.class.exclude_output_inserted_table_names[table_name]
         end
 
-        def exec_insert_requires_identity?(sql, pk, binds)
+        def exec_insert_requires_identity?(sql, _pk, _binds)
           query_requires_identity_insert?(sql)
         end
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -535,13 +535,13 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   describe "exec_insert" do
     it 'values clause should be case-insensitive' do
-      first_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) VALUES(1, 'Title', 'Body'), (2, 'Title', 'Body')")
-      second_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) values(13, 'Body', 'Body'), (14, 'Body', 'Body')")
+      assert_difference("Post.count", 4) do
+        first_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) VALUES(100, 'Title', 'Body'), (102, 'Title', 'Body')")
+        second_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) values(113, 'Body', 'Body'), (114, 'Body', 'Body')")
 
-      assert_equal Post.count, 4
-
-      assert_equal first_insert.rows.map(&:first), [1, 2]
-      assert_equal second_insert.rows.map(&:first), [13, 14]
+        assert_equal first_insert.rows.map(&:first), [100, 102]
+        assert_equal second_insert.rows.map(&:first), [113, 114]
+      end
     end
   end
 end

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -532,4 +532,16 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       end
     end
   end
+
+  describe "exec_insert" do
+    it 'values clause should be case-insensitive' do
+      first_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) VALUES(1, 'Title', 'Body'), (2, 'Title', 'Body')")
+      second_insert = connection.exec_insert("INSERT INTO [posts] ([id],[title],[body]) values(13, 'Body', 'Body'), (14, 'Body', 'Body')")
+
+      assert_equal Post.count, 4
+
+      assert_equal first_insert.rows.map(&:first), [1, 2]
+      assert_equal second_insert.rows.map(&:first), [13, 14]
+    end
+  end
 end


### PR DESCRIPTION
When inserting records using `exec_insert` the casing of the `VALUES` clause is irrelevant. Updated the regex to be case-insensitive.