### PR TITLE
Fix CI tests for Rails 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5.9, 2.6.7, 2.7.3, 3.0.1]
+        ruby:
+          - 2.7.5
+          - 3.0.3
 
     steps:
       - name: Checkout code

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "bcrypt"
-gem "pg",      ">= 0.18.0"
+gem "pg", "~> 1.3"
 gem "sqlite3", "~> 1.4"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "minitest", ">= 5.15.0", "< 5.16"
 
 if ENV["RAILS_SOURCE"]
   gemspec path: ENV["RAILS_SOURCE"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,10 @@ build: off
 matrix:
   fast_finish: true
   allow_failures:
-    - ruby_version: "25"
-    - ruby_version: "26"
-    - ruby_version: "27"
     - ruby_version: "27-x64"
+    - ruby_version: "27"
+    - ruby_version: "30"
+    - ruby_version: "30-x64"
 services:
   - mssql2014
 
@@ -38,9 +38,7 @@ environment:
   CI_AZURE_PASS:
     secure: cSQp8sk4urJYvq0utpsK+r7J+snJ2wpcdp8RdXJfB+w=
   matrix:
-    - ruby_version: "25-x64"
-    - ruby_version: "25"
-    - ruby_version: "26-x64"
-    - ruby_version: "26"
     - ruby_version: "27-x64"
     - ruby_version: "27"
+    - ruby_version: "30"
+    - ruby_version: "30-x64"


### PR DESCRIPTION
Fix CI tests on the Rails 6.0 branch.

Most of the changes have been backported from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1037

Note: The Rails 6.0 tests do not support Ruby 3.1.