### PR TITLE
Set precision 6 by default for timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [#1052](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1052) Ignore casing of VALUES clause when inserting records using SQL
 - [#1053](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1053) Fix insertion of records to non-default schema table using raw SQL
 
+#### Changed
+
+- [#1057](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1057) Set precision 6 by default for timestamps.
+
 ## v7.0.2.0
 
 [Full changelog](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/compare/v7.0.1.0...v7.0.2.0)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -346,7 +346,7 @@ module ActiveRecord
             datetime2: { name: "datetime2" },
             datetimeoffset: { name: "datetimeoffset" },
             smalldatetime: { name: "smalldatetime" },
-            timestamp: { name: "datetime" },
+            timestamp: { name: "datetime2(6)" },
             time: { name: "time" },
             char: { name: "char" },
             varchar: { name: "varchar", limit: 8000 },

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -101,11 +101,16 @@ module ActiveRecord
 
         def new_column_definition(name, type, **options)
           case type
-          when :datetime
-            type = :datetime2 if options[:precision]
+          when :datetime, :timestamp
+            # If no precision then default it to 6.
+            options[:precision] = 6 unless options.key?(:precision)
+
+            # If there is precision then column must be of type 'datetime2'.
+            type = :datetime2 unless options[:precision].nil?
           when :primary_key
             options[:is_identity] = true
           end
+
           super
         end
       end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -543,7 +543,7 @@ module ActiveRecord
         assert_equal "hello", five.default
       end
 
-      # Rails adds precision 6 by default, sql server uses datetime2 for datetimes with precision
+      # Use precision 6 by default for datetime/timestamp columns. SQL Server uses `datetime2` for date-times with precision.
       coerce_tests! :test_add_column_with_postgresql_datetime_type
       def test_add_column_with_postgresql_datetime_type_coerced
         connection.create_table :testings do |t|
@@ -556,7 +556,7 @@ module ActiveRecord
         assert_equal "datetime2(6)", column.sql_type
       end
 
-      # timestamp is datetime with default limit
+      # Use precision 6 by default for datetime/timestamp columns. SQL Server uses `datetime2` for date-times with precision.
       coerce_tests! :test_change_column_with_timestamp_type
       def test_change_column_with_timestamp_type_coerced
         connection.create_table :testings do |t|
@@ -568,7 +568,20 @@ module ActiveRecord
         column = connection.columns(:testings).find { |c| c.name == "foo" }
 
         assert_equal :datetime, column.type
-        assert_equal "datetime", column.sql_type
+        assert_equal "datetime2(6)", column.sql_type
+      end
+
+      # Use precision 6 by default for datetime/timestamp columns. SQL Server uses `datetime2` for date-times with precision.
+      coerce_tests! :test_add_column_with_timestamp_type
+      def test_add_column_with_timestamp_type_coerced
+        connection.create_table :testings do |t|
+          t.column :foo, :timestamp
+        end
+
+        column = connection.columns(:testings).find { |c| c.name == "foo" }
+
+        assert_equal :datetime, column.type
+        assert_equal "datetime2(6)", column.sql_type
       end
     end
   end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -10,50 +10,51 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
   it "sst_datatypes" do
     generate_schema_for_table "sst_datatypes"
-    assert_line :bigint,            type: "bigint",        limit: nil,   precision: nil,   scale: nil,  default: 42
-    assert_line :int,               type: "integer",       limit: nil,   precision: nil,   scale: nil,  default: 42
-    assert_line :smallint,          type: "integer",       limit: 2,     precision: nil,   scale: nil,  default: 42
-    assert_line :tinyint,           type: "integer",       limit: 1,     precision: nil,   scale: nil,  default: 42
-    assert_line :bit,               type: "boolean",       limit: nil,   precision: nil,   scale: nil,  default: true
-    assert_line :decimal_9_2,       type: "decimal",       limit: nil,   precision: 9,     scale: 2,    default: 12345.01
-    assert_line :numeric_18_0,      type: "decimal",       limit: nil,   precision: 18,    scale: nil,  default: 191
-    assert_line :numeric_36_2,      type: "decimal",       limit: nil,   precision: 36,    scale: 2,    default: 12345678901234567890.01
-    assert_line :money,             type: "money",         limit: nil,   precision: 19,    scale: 4,    default: 4.2
-    assert_line :smallmoney,        type: "smallmoney",    limit: nil,   precision: 10,    scale: 4,    default: 4.2
+
+    assert_line :bigint,            type: "bigint",                                                     default: 42
+    assert_line :int,               type: "integer",                                                    default: 42
+    assert_line :smallint,          type: "integer",       limit: 2,                                    default: 42
+    assert_line :tinyint,           type: "integer",       limit: 1,                                    default: 42
+    assert_line :bit,               type: "boolean",                                                    default: true
+    assert_line :decimal_9_2,       type: "decimal",                     precision: 9,     scale: 2,    default: 12345.01
+    assert_line :numeric_18_0,      type: "decimal",                     precision: 18,                 default: 191
+    assert_line :numeric_36_2,      type: "decimal",                     precision: 36,    scale: 2,    default: 12345678901234567890.01
+    assert_line :money,             type: "money",                       precision: 19,    scale: 4,    default: 4.2
+    assert_line :smallmoney,        type: "smallmoney",                  precision: 10,    scale: 4,    default: 4.2
     # Approximate Numerics
-    assert_line :float,             type: "float",         limit: nil,   precision: nil,   scale: nil,  default: 123.00000001
-    assert_line :real,              type: "real",          limit: nil,   precision: nil,   scale: nil,  default: 123.45
+    assert_line :float,             type: "float",                                                      default: 123.00000001
+    assert_line :real,              type: "real",                                                       default: 123.45
     # Date and Time
-    assert_line :date,              type: "date",          limit: nil,   precision: nil,   scale: nil,  default: "01-01-0001"
-    assert_line :datetime,          type: "datetime",      limit: nil,   precision: nil,   scale: nil,  default: "01-01-1753 00:00:00.123"
+    assert_line :date,              type: "date",                                                       default: "01-01-0001"
+    assert_line :datetime,          type: "datetime",                    precision: nil,                default: "01-01-1753 00:00:00.123"
     if connection_dblib_73?
-      assert_line :datetime2_7,     type: "datetime",      limit: nil,   precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"
-      assert_line :datetime2_3,     type: "datetime",      limit: nil,   precision: 3,     scale: nil,  default: nil
-      assert_line :datetime2_1,     type: "datetime",      limit: nil,   precision: 1,     scale: nil,  default: nil
+      assert_line :datetime2_7,     type: "datetime",                    precision: 7,                  default: "12-31-9999 23:59:59.9999999"
+      assert_line :datetime2_3,     type: "datetime",                    precision: 3
+      assert_line :datetime2_1,     type: "datetime",                    precision: 1
     end
-    assert_line :smalldatetime,     type: "smalldatetime", limit: nil,   precision: nil,   scale: nil,  default: "01-01-1901 15:45:00.0"
+    assert_line :smalldatetime,     type: "smalldatetime",                                              default: "01-01-1901 15:45:00.0"
     if connection_dblib_73?
-      assert_line :time_7,          type: "time",          limit: nil,   precision: 7,     scale: nil,  default: "04:20:00.2883215"
-      assert_line :time_2,          type: "time",          limit: nil,   precision: 2,     scale: nil,  default: nil
-      assert_line :time_default,    type: "time",          limit: nil,   precision: 7,     scale: nil,  default: "15:03:42.0621978"
+      assert_line :time_7,          type: "time",                        precision: 7,                  default: "04:20:00.2883215"
+      assert_line :time_2,          type: "time",                        precision: 2
+      assert_line :time_default,    type: "time",                        precision: 7,                  default: "15:03:42.0621978"
     end
     # Character Strings
-    assert_line :char_10,           type: "char",          limit: 10,    precision: nil,   scale: nil,  default: "1234567890",           collation: nil
-    assert_line :varchar_50,        type: "varchar",       limit: 50,    precision: nil,   scale: nil,  default: "test varchar_50",      collation: nil
-    assert_line :varchar_max,       type: "varchar_max",   limit: nil,   precision: nil,   scale: nil,  default: "test varchar_max",     collation: nil
-    assert_line :text,              type: "text_basic",    limit: nil,   precision: nil,   scale: nil,  default: "test text",            collation: nil
+    assert_line :char_10,           type: "char",          limit: 10,                                   default: "1234567890"
+    assert_line :varchar_50,        type: "varchar",       limit: 50,                                   default: "test varchar_50"
+    assert_line :varchar_max,       type: "varchar_max",                                                default: "test varchar_max"
+    assert_line :text,              type: "text_basic",                                                 default: "test text"
     # Unicode Character Strings
-    assert_line :nchar_10,          type: "nchar",         limit: 10,    precision: nil,   scale: nil,  default: "12345678åå",           collation: nil
-    assert_line :nvarchar_50,       type: "string",        limit: 50,    precision: nil,   scale: nil,  default: "test nvarchar_50 åå",  collation: nil
-    assert_line :nvarchar_max,      type: "text",          limit: nil,   precision: nil,   scale: nil,  default: "test nvarchar_max åå", collation: nil
-    assert_line :ntext,             type: "ntext",         limit: nil,   precision: nil,   scale: nil,  default: "test ntext åå",        collation: nil
+    assert_line :nchar_10,          type: "nchar",         limit: 10,                                   default: "12345678åå"
+    assert_line :nvarchar_50,       type: "string",        limit: 50,                                   default: "test nvarchar_50 åå"
+    assert_line :nvarchar_max,      type: "text",                                                       default: "test nvarchar_max åå"
+    assert_line :ntext,             type: "ntext",                                                      default: "test ntext åå"
     # Binary Strings
-    assert_line :binary_49,         type: "binary_basic",  limit: 49,    precision: nil,   scale: nil,  default: nil
-    assert_line :varbinary_49,      type: "varbinary",     limit: 49,    precision: nil,   scale: nil,  default: nil
-    assert_line :varbinary_max,     type: "binary",        limit: nil,   precision: nil,   scale: nil,  default: nil
+    assert_line :binary_49,         type: "binary_basic",  limit: 49
+    assert_line :varbinary_49,      type: "varbinary",     limit: 49
+    assert_line :varbinary_max,     type: "binary"
     # Other Data Types
-    assert_line :uniqueidentifier,  type: "uuid",          limit: nil,   precision: nil,   scale: nil,  default: -> { "newid()" }
-    assert_line :timestamp,         type: "ss_timestamp",  limit: nil,   precision: nil,   scale: nil,  default: nil
+    assert_line :uniqueidentifier,  type: "uuid",                                                       default: -> { "newid()" }
+    assert_line :timestamp,         type: "ss_timestamp"
   end
 
   it "sst_datatypes_migration" do
@@ -75,19 +76,20 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     _(columns["date_col"].sql_type).must_equal                   "date"
     _(columns["binary_col"].sql_type).must_equal                 "varbinary(max)"
 
-    assert_line :integer_col,                type: "integer",  limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :bigint_col,                 type: "bigint",   limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :boolean_col,                type: "boolean",  limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :decimal_col,                type: "decimal",  limit: nil, precision: 18,  scale: nil, default: nil
-    assert_line :float_col,                  type: "float",    limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :string_col,                 type: "string",   limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :text_col,                   type: "text",     limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :datetime_nil_precision_col, type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :datetime_col,               type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :timestamp_col,              type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :time_col,                   type: "time",     limit: nil, precision: 7,   scale: nil, default: nil
-    assert_line :date_col,                   type: "date",     limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :binary_col,                 type: "binary",   limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :integer_col,                type: "integer"
+    assert_line :bigint_col,                 type: "bigint"
+    assert_line :boolean_col,                type: "boolean"
+    assert_line :decimal_col,                type: "decimal",              precision: 18
+    assert_line :float_col,                  type: "float"
+    assert_line :string_col,                 type: "string"
+    assert_line :text_col,                   type: "text"
+    assert_line :datetime_nil_precision_col, type: "datetime",             precision: nil
+    assert_line :datetime_col,               type: "datetime"
+    assert_line :datetime_col,               type: "datetime"
+    assert_line :timestamp_col,              type: "datetime"
+    assert_line :time_col,                   type: "time",                 precision: 7
+    assert_line :date_col,                   type: "date"
+    assert_line :binary_col,                 type: "binary"
 
     # Our type methods.
     _(columns["real_col"].sql_type).must_equal          "real"
@@ -107,31 +109,31 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     _(columns["sstimestamp_col"].sql_type).must_equal   "timestamp"
     _(columns["json_col"].sql_type).must_equal          "nvarchar(max)"
 
-    assert_line :real_col,          type: "real",           limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :money_col,         type: "money",          limit: nil, precision: 19,  scale: 4,   default: nil
-    assert_line :smalldatetime_col, type: "smalldatetime",  limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :datetime2_col,     type: "datetime",       limit: nil, precision: 7,   scale: nil, default: nil
-    assert_line :datetimeoffset,    type: "datetimeoffset", limit: nil, precision: 7,   scale: nil, default: nil
-    assert_line :smallmoney_col,    type: "smallmoney",     limit: nil, precision: 10,  scale: 4,   default: nil
-    assert_line :char_col,          type: "char",           limit: 1,   precision: nil, scale: nil, default: nil
-    assert_line :varchar_col,       type: "varchar",        limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :text_basic_col,    type: "text_basic",     limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :nchar_col,         type: "nchar",          limit: 1,   precision: nil, scale: nil, default: nil
-    assert_line :ntext_col,         type: "ntext",          limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :binary_basic_col,  type: "binary_basic",   limit: 1,   precision: nil, scale: nil, default: nil
-    assert_line :varbinary_col,     type: "varbinary",      limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :uuid_col,          type: "uuid",           limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :sstimestamp_col,   type: "ss_timestamp",   limit: nil, precision: nil, scale: nil, default: nil
-    assert_line :json_col,          type: "text",           limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :real_col,          type: "real"
+    assert_line :money_col,         type: "money",                      precision: 19,  scale: 4
+    assert_line :smalldatetime_col, type: "smalldatetime"
+    assert_line :datetime2_col,     type: "datetime",                   precision: 7
+    assert_line :datetimeoffset,    type: "datetimeoffset",             precision: 7
+    assert_line :smallmoney_col,    type: "smallmoney",                 precision: 10,  scale: 4
+    assert_line :char_col,          type: "char",           limit: 1
+    assert_line :varchar_col,       type: "varchar"
+    assert_line :text_basic_col,    type: "text_basic"
+    assert_line :nchar_col,         type: "nchar",          limit: 1
+    assert_line :ntext_col,         type: "ntext"
+    assert_line :binary_basic_col,  type: "binary_basic",   limit: 1
+    assert_line :varbinary_col,     type: "varbinary"
+    assert_line :uuid_col,          type: "uuid"
+    assert_line :sstimestamp_col,   type: "ss_timestamp",                                           null: false
+    assert_line :json_col,          type: "text"
   end
 
   it "dump column collation" do
     generate_schema_for_table('sst_string_collation')
 
-    assert_line :string_without_collation, type: "string",  limit: nil, default: nil, collation: nil
-    assert_line :string_default_collation, type: "varchar", limit: nil, default: nil, collation: nil
-    assert_line :string_with_collation,    type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
-    assert_line :varchar_with_collation,   type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
+    assert_line :string_without_collation, type: "string"
+    assert_line :string_default_collation, type: "varchar"
+    assert_line :string_with_collation,    type: "varchar",                           collation: "SQL_Latin1_General_CP1_CS_AS"
+    assert_line :varchar_with_collation,   type: "varchar",                           collation: "SQL_Latin1_General_CP1_CS_AS"
   end
 
   # Special Cases
@@ -146,8 +148,9 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
   it "no id with model driven primary key" do
     output = generate_schema_for_table "sst_no_pk_data"
+
     _(output).must_match %r{create_table "sst_no_pk_data".*id:\sfalse.*do}
-    assert_line :name, type: "string", limit: nil, default: nil, collation: nil
+    assert_line :name, type: "string"
   end
 
   it "dumps field with unique key constraints only once" do
@@ -160,6 +163,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
   def generate_schema_for_table(*table_names)
     require "stringio"
+
     stream = StringIO.new
     ActiveRecord::SchemaDumper.ignore_tables = all_tables - table_names
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
@@ -179,15 +183,19 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     @schema_lines[column_name.to_s]
   end
 
-  def assert_line(column_name, options = {})
+  def assert_line(column_name, expected_options = {})
     line = line(column_name)
     assert line, "Could not find line with column name: #{column_name.inspect} in schema:\n#{schema}"
 
-    [:type, :limit, :precision, :scale, :collation, :default].each do |key|
-      next unless options.key?(key)
+    # Check that the expected and actual option keys.
+    expected_options_keys = expected_options.keys
+    expected_options_keys.delete(:type)
+    _(expected_options_keys.sort).must_equal (line.options.keys.sort), "For column '#{column_name}' expected schema options and actual schema options do not match."
 
+    # Check the expected and actual option values.
+    expected_options.each do |key, expected|
       actual   = key == :type ? line.send(:type_method) : line.send(key)
-      expected = options[key]
+
       message  = "#{key.to_s.titleize} of #{expected.inspect} not found in:\n#{line}"
 
       if expected.nil?
@@ -213,7 +221,13 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
                 :options
 
     def self.option(method_name)
-      define_method(method_name) { options.present? ? options[method_name.to_sym] : nil }
+      define_method(method_name) do
+        if options.key?(method_name.to_sym)
+          options[method_name.to_sym]
+        else
+          throw "Schema line does include the '#{method_name}' option!"
+        end
+      end
     end
 
     def initialize(line)
@@ -226,6 +240,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     option :scale
     option :default
     option :collation
+    option :null
 
     def to_s
       line.squish
@@ -240,6 +255,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     def parse_line
       _all, type_method, col_name, options = @line.match(LINE_PARSER).to_a
       options = parse_options(options)
+
       [type_method, col_name, options]
     end
 
@@ -249,8 +265,6 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
       else
         {}
       end
-    rescue SyntaxError
-      {}
     end
   end
 end

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -10,122 +10,128 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
   it "sst_datatypes" do
     generate_schema_for_table "sst_datatypes"
-    assert_line :bigint,            type: "bigint",       limit: nil,           precision: nil,   scale: nil,  default: 42
-    assert_line :int,               type: "integer",      limit: nil,           precision: nil,   scale: nil,  default: 42
-    assert_line :smallint,          type: "integer",      limit: 2,             precision: nil,   scale: nil,  default: 42
-    assert_line :tinyint,           type: "integer",      limit: 1,             precision: nil,   scale: nil,  default: 42
-    assert_line :bit,               type: "boolean",      limit: nil,           precision: nil,   scale: nil,  default: true
-    assert_line :decimal_9_2,       type: "decimal",      limit: nil,           precision: 9,     scale: 2,    default: 12345.01
-    assert_line :numeric_18_0,      type: "decimal",      limit: nil,           precision: 18,    scale: nil,  default: 191
-    assert_line :numeric_36_2,      type: "decimal",      limit: nil,           precision: 36,    scale: 2,    default: 12345678901234567890.01
-    assert_line :money,             type: "money",        limit: nil,           precision: 19,    scale: 4,    default: 4.2
-    assert_line :smallmoney,        type: "smallmoney",   limit: nil,           precision: 10,    scale: 4,    default: 4.2
+    assert_line :bigint,            type: "bigint",        limit: nil,   precision: nil,   scale: nil,  default: 42
+    assert_line :int,               type: "integer",       limit: nil,   precision: nil,   scale: nil,  default: 42
+    assert_line :smallint,          type: "integer",       limit: 2,     precision: nil,   scale: nil,  default: 42
+    assert_line :tinyint,           type: "integer",       limit: 1,     precision: nil,   scale: nil,  default: 42
+    assert_line :bit,               type: "boolean",       limit: nil,   precision: nil,   scale: nil,  default: true
+    assert_line :decimal_9_2,       type: "decimal",       limit: nil,   precision: 9,     scale: 2,    default: 12345.01
+    assert_line :numeric_18_0,      type: "decimal",       limit: nil,   precision: 18,    scale: nil,  default: 191
+    assert_line :numeric_36_2,      type: "decimal",       limit: nil,   precision: 36,    scale: 2,    default: 12345678901234567890.01
+    assert_line :money,             type: "money",         limit: nil,   precision: 19,    scale: 4,    default: 4.2
+    assert_line :smallmoney,        type: "smallmoney",    limit: nil,   precision: 10,    scale: 4,    default: 4.2
     # Approximate Numerics
-    assert_line :float,             type: "float",        limit: nil,           precision: nil,   scale: nil,  default: 123.00000001
-    assert_line :real,              type: "real",         limit: nil,           precision: nil,   scale: nil,  default: 123.45
+    assert_line :float,             type: "float",         limit: nil,   precision: nil,   scale: nil,  default: 123.00000001
+    assert_line :real,              type: "real",          limit: nil,   precision: nil,   scale: nil,  default: 123.45
     # Date and Time
-    assert_line :date,              type: "date",         limit: nil,           precision: nil,   scale: nil,  default: "01-01-0001"
-    assert_line :datetime,          type: "datetime",     limit: nil,           precision: nil,   scale: nil,  default: "01-01-1753 00:00:00.123"
+    assert_line :date,              type: "date",          limit: nil,   precision: nil,   scale: nil,  default: "01-01-0001"
+    assert_line :datetime,          type: "datetime",      limit: nil,   precision: nil,   scale: nil,  default: "01-01-1753 00:00:00.123"
     if connection_dblib_73?
-      assert_line :datetime2_7,       type: "datetime",     limit: nil,           precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"
-      assert_line :datetime2_3,       type: "datetime",     limit: nil,           precision: 3,     scale: nil,  default: nil
-      assert_line :datetime2_1,       type: "datetime",     limit: nil,           precision: 1,     scale: nil,  default: nil
+      assert_line :datetime2_7,     type: "datetime",      limit: nil,   precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"
+      assert_line :datetime2_3,     type: "datetime",      limit: nil,   precision: 3,     scale: nil,  default: nil
+      assert_line :datetime2_1,     type: "datetime",      limit: nil,   precision: 1,     scale: nil,  default: nil
     end
-    assert_line :smalldatetime, type: "smalldatetime", limit: nil, precision: nil, scale: nil, default: "01-01-1901 15:45:00.0"
+    assert_line :smalldatetime,     type: "smalldatetime", limit: nil,   precision: nil,   scale: nil,  default: "01-01-1901 15:45:00.0"
     if connection_dblib_73?
-      assert_line :time_7,            type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "04:20:00.2883215"
-      assert_line :time_2,            type: "time",         limit: nil,           precision: 2,     scale: nil,  default: nil
-      assert_line :time_default,      type: "time",         limit: nil,           precision: 7,     scale: nil,  default: "15:03:42.0621978"
+      assert_line :time_7,          type: "time",          limit: nil,   precision: 7,     scale: nil,  default: "04:20:00.2883215"
+      assert_line :time_2,          type: "time",          limit: nil,   precision: 2,     scale: nil,  default: nil
+      assert_line :time_default,    type: "time",          limit: nil,   precision: 7,     scale: nil,  default: "15:03:42.0621978"
     end
     # Character Strings
-    assert_line :char_10,           type: "char",         limit: 10,            precision: nil,   scale: nil,  default: "1234567890",           collation: nil
-    assert_line :varchar_50,        type: "varchar",      limit: 50,            precision: nil,   scale: nil,  default: "test varchar_50",      collation: nil
-    assert_line :varchar_max,       type: "varchar_max",  limit: nil,           precision: nil,   scale: nil,  default: "test varchar_max",     collation: nil
-    assert_line :text,              type: "text_basic",   limit: nil,           precision: nil,   scale: nil,  default: "test text",            collation: nil
+    assert_line :char_10,           type: "char",          limit: 10,    precision: nil,   scale: nil,  default: "1234567890",           collation: nil
+    assert_line :varchar_50,        type: "varchar",       limit: 50,    precision: nil,   scale: nil,  default: "test varchar_50",      collation: nil
+    assert_line :varchar_max,       type: "varchar_max",   limit: nil,   precision: nil,   scale: nil,  default: "test varchar_max",     collation: nil
+    assert_line :text,              type: "text_basic",    limit: nil,   precision: nil,   scale: nil,  default: "test text",            collation: nil
     # Unicode Character Strings
-    assert_line :nchar_10,          type: "nchar",        limit: 10,            precision: nil,   scale: nil,  default: "12345678åå",           collation: nil
-    assert_line :nvarchar_50,       type: "string",       limit: 50,            precision: nil,   scale: nil,  default: "test nvarchar_50 åå",  collation: nil
-    assert_line :nvarchar_max,      type: "text",         limit: nil,           precision: nil,   scale: nil,  default: "test nvarchar_max åå", collation: nil
-    assert_line :ntext,             type: "ntext",        limit: nil,           precision: nil,   scale: nil,  default: "test ntext åå",        collation: nil
+    assert_line :nchar_10,          type: "nchar",         limit: 10,    precision: nil,   scale: nil,  default: "12345678åå",           collation: nil
+    assert_line :nvarchar_50,       type: "string",        limit: 50,    precision: nil,   scale: nil,  default: "test nvarchar_50 åå",  collation: nil
+    assert_line :nvarchar_max,      type: "text",          limit: nil,   precision: nil,   scale: nil,  default: "test nvarchar_max åå", collation: nil
+    assert_line :ntext,             type: "ntext",         limit: nil,   precision: nil,   scale: nil,  default: "test ntext åå",        collation: nil
     # Binary Strings
-    assert_line :binary_49,         type: "binary_basic", limit: 49,            precision: nil,   scale: nil,  default: nil
-    assert_line :varbinary_49,      type: "varbinary",    limit: 49,            precision: nil,   scale: nil,  default: nil
-    assert_line :varbinary_max,     type: "binary",       limit: nil,           precision: nil,   scale: nil,  default: nil
+    assert_line :binary_49,         type: "binary_basic",  limit: 49,    precision: nil,   scale: nil,  default: nil
+    assert_line :varbinary_49,      type: "varbinary",     limit: 49,    precision: nil,   scale: nil,  default: nil
+    assert_line :varbinary_max,     type: "binary",        limit: nil,   precision: nil,   scale: nil,  default: nil
     # Other Data Types
-    assert_line :uniqueidentifier,  type: "uuid",         limit: nil,           precision: nil,   scale: nil,  default: -> { "newid()" }
-    assert_line :timestamp,         type: "ss_timestamp", limit: nil,           precision: nil,   scale: nil,  default: nil
+    assert_line :uniqueidentifier,  type: "uuid",          limit: nil,   precision: nil,   scale: nil,  default: -> { "newid()" }
+    assert_line :timestamp,         type: "ss_timestamp",  limit: nil,   precision: nil,   scale: nil,  default: nil
   end
 
   it "sst_datatypes_migration" do
     columns = SSTestDatatypeMigration.columns_hash
     generate_schema_for_table "sst_datatypes_migration"
+
     # Simple Rails conventions
-    _(columns["integer_col"].sql_type).must_equal      "int(4)"
-    _(columns["bigint_col"].sql_type).must_equal       "bigint(8)"
-    _(columns["boolean_col"].sql_type).must_equal      "bit"
-    _(columns["decimal_col"].sql_type).must_equal      "decimal(18,0)"
-    _(columns["float_col"].sql_type).must_equal        "float"
-    _(columns["string_col"].sql_type).must_equal       "nvarchar(4000)"
-    _(columns["text_col"].sql_type).must_equal         "nvarchar(max)"
-    _(columns["datetime_col"].sql_type).must_equal     "datetime2(6)"
-    _(columns["timestamp_col"].sql_type).must_equal    "datetime"
-    _(columns["time_col"].sql_type).must_equal         "time(7)"
-    _(columns["date_col"].sql_type).must_equal         "date"
-    _(columns["binary_col"].sql_type).must_equal       "varbinary(max)"
-    assert_line :integer_col,     type: "integer",      limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :bigint_col,      type: "bigint",       limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :boolean_col,     type: "boolean",      limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :decimal_col,     type: "decimal",      limit: nil,          precision: 18,   scale: nil, default: nil
-    assert_line :float_col,       type: "float",        limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :string_col,      type: "string",       limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :text_col,        type: "text",         limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :datetime_col,    type: "datetime",     limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :timestamp_col,   type: "datetime",     limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :time_col,        type: "time",         limit: nil,          precision: 7,    scale: nil, default: nil
-    assert_line :date_col,        type: "date",         limit: nil,          precision: nil,  scale: nil, default: nil
-    assert_line :binary_col,      type: "binary",       limit: nil,          precision: nil,  scale: nil, default: nil
+    _(columns["integer_col"].sql_type).must_equal                "int(4)"
+    _(columns["bigint_col"].sql_type).must_equal                 "bigint(8)"
+    _(columns["boolean_col"].sql_type).must_equal                "bit"
+    _(columns["decimal_col"].sql_type).must_equal                "decimal(18,0)"
+    _(columns["float_col"].sql_type).must_equal                  "float"
+    _(columns["string_col"].sql_type).must_equal                 "nvarchar(4000)"
+    _(columns["text_col"].sql_type).must_equal                   "nvarchar(max)"
+    _(columns["datetime_nil_precision_col"].sql_type).must_equal "datetime"
+    _(columns["datetime_col"].sql_type).must_equal               "datetime2(6)"
+    _(columns["timestamp_col"].sql_type).must_equal              "datetime2(6)"
+    _(columns["time_col"].sql_type).must_equal                   "time(7)"
+    _(columns["date_col"].sql_type).must_equal                   "date"
+    _(columns["binary_col"].sql_type).must_equal                 "varbinary(max)"
+
+    assert_line :integer_col,                type: "integer",  limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :bigint_col,                 type: "bigint",   limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :boolean_col,                type: "boolean",  limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :decimal_col,                type: "decimal",  limit: nil, precision: 18,  scale: nil, default: nil
+    assert_line :float_col,                  type: "float",    limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :string_col,                 type: "string",   limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :text_col,                   type: "text",     limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :datetime_nil_precision_col, type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :datetime_col,               type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :timestamp_col,              type: "datetime", limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :time_col,                   type: "time",     limit: nil, precision: 7,   scale: nil, default: nil
+    assert_line :date_col,                   type: "date",     limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :binary_col,                 type: "binary",   limit: nil, precision: nil, scale: nil, default: nil
+
     # Our type methods.
-    _(columns["real_col"].sql_type).must_equal         "real"
-    _(columns["money_col"].sql_type).must_equal        "money"
+    _(columns["real_col"].sql_type).must_equal          "real"
+    _(columns["money_col"].sql_type).must_equal         "money"
     _(columns["smalldatetime_col"].sql_type).must_equal "smalldatetime"
-    _(columns["datetime2_col"].sql_type).must_equal    "datetime2(7)"
-    _(columns["datetimeoffset"].sql_type).must_equal   "datetimeoffset(7)"
-    _(columns["smallmoney_col"].sql_type).must_equal   "smallmoney"
-    _(columns["char_col"].sql_type).must_equal         "char(1)"
-    _(columns["varchar_col"].sql_type).must_equal      "varchar(8000)"
-    _(columns["text_basic_col"].sql_type).must_equal   "text"
-    _(columns["nchar_col"].sql_type).must_equal        "nchar(1)"
-    _(columns["ntext_col"].sql_type).must_equal        "ntext"
-    _(columns["binary_basic_col"].sql_type).must_equal "binary(1)"
-    _(columns["varbinary_col"].sql_type).must_equal    "varbinary(8000)"
-    _(columns["uuid_col"].sql_type).must_equal         "uniqueidentifier"
-    _(columns["sstimestamp_col"].sql_type).must_equal  "timestamp"
-    _(columns["json_col"].sql_type).must_equal         "nvarchar(max)"
-    assert_line :real_col,          type: "real",           limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :money_col,         type: "money",          limit: nil,           precision: 19,    scale: 4,    default: nil
-    assert_line :smalldatetime_col, type: "smalldatetime",  limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :datetime2_col,     type: "datetime",       limit: nil,           precision: 7,     scale: nil,  default: nil
-    assert_line :datetimeoffset,    type: "datetimeoffset", limit: nil,           precision: 7,     scale: nil,  default: nil
-    assert_line :smallmoney_col,    type: "smallmoney",     limit: nil,           precision: 10,    scale: 4,    default: nil
-    assert_line :char_col,          type: "char",           limit: 1,             precision: nil,   scale: nil,  default: nil
-    assert_line :varchar_col,       type: "varchar",        limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :text_basic_col,    type: "text_basic",     limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :nchar_col,         type: "nchar",          limit: 1,             precision: nil,   scale: nil,  default: nil
-    assert_line :ntext_col,         type: "ntext",          limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :binary_basic_col,  type: "binary_basic",   limit: 1,             precision: nil,   scale: nil,  default: nil
-    assert_line :varbinary_col,     type: "varbinary",      limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :uuid_col,          type: "uuid",           limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :sstimestamp_col,   type: "ss_timestamp",   limit: nil,           precision: nil,   scale: nil,  default: nil
-    assert_line :json_col,          type: "text",           limit: nil,           precision: nil,   scale: nil,  default: nil
+    _(columns["datetime2_col"].sql_type).must_equal     "datetime2(7)"
+    _(columns["datetimeoffset"].sql_type).must_equal    "datetimeoffset(7)"
+    _(columns["smallmoney_col"].sql_type).must_equal    "smallmoney"
+    _(columns["char_col"].sql_type).must_equal          "char(1)"
+    _(columns["varchar_col"].sql_type).must_equal       "varchar(8000)"
+    _(columns["text_basic_col"].sql_type).must_equal    "text"
+    _(columns["nchar_col"].sql_type).must_equal         "nchar(1)"
+    _(columns["ntext_col"].sql_type).must_equal         "ntext"
+    _(columns["binary_basic_col"].sql_type).must_equal  "binary(1)"
+    _(columns["varbinary_col"].sql_type).must_equal     "varbinary(8000)"
+    _(columns["uuid_col"].sql_type).must_equal          "uniqueidentifier"
+    _(columns["sstimestamp_col"].sql_type).must_equal   "timestamp"
+    _(columns["json_col"].sql_type).must_equal          "nvarchar(max)"
+
+    assert_line :real_col,          type: "real",           limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :money_col,         type: "money",          limit: nil, precision: 19,  scale: 4,   default: nil
+    assert_line :smalldatetime_col, type: "smalldatetime",  limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :datetime2_col,     type: "datetime",       limit: nil, precision: 7,   scale: nil, default: nil
+    assert_line :datetimeoffset,    type: "datetimeoffset", limit: nil, precision: 7,   scale: nil, default: nil
+    assert_line :smallmoney_col,    type: "smallmoney",     limit: nil, precision: 10,  scale: 4,   default: nil
+    assert_line :char_col,          type: "char",           limit: 1,   precision: nil, scale: nil, default: nil
+    assert_line :varchar_col,       type: "varchar",        limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :text_basic_col,    type: "text_basic",     limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :nchar_col,         type: "nchar",          limit: 1,   precision: nil, scale: nil, default: nil
+    assert_line :ntext_col,         type: "ntext",          limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :binary_basic_col,  type: "binary_basic",   limit: 1,   precision: nil, scale: nil, default: nil
+    assert_line :varbinary_col,     type: "varbinary",      limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :uuid_col,          type: "uuid",           limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :sstimestamp_col,   type: "ss_timestamp",   limit: nil, precision: nil, scale: nil, default: nil
+    assert_line :json_col,          type: "text",           limit: nil, precision: nil, scale: nil, default: nil
   end
 
   it "dump column collation" do
     generate_schema_for_table('sst_string_collation')
 
-    assert_line :string_without_collation, type: "string", limit: nil, default: nil, collation: nil
+    assert_line :string_without_collation, type: "string",  limit: nil, default: nil, collation: nil
     assert_line :string_default_collation, type: "varchar", limit: nil, default: nil, collation: nil
-    assert_line :string_with_collation, type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
-    assert_line :varchar_with_collation, type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
+    assert_line :string_with_collation,    type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
+    assert_line :varchar_with_collation,   type: "varchar", limit: nil, default: nil, collation: "SQL_Latin1_General_CP1_CS_AS"
   end
 
   # Special Cases

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -14,8 +14,9 @@ ActiveRecord::Schema.define do
     t.float     :float_col
     t.string    :string_col
     t.text      :text_col
-    t.datetime  :datetime_col
-    t.timestamp :timestamp_col
+    t.datetime  :datetime_nil_precision_col, precision: nil
+    t.datetime  :datetime_col  # Precision defaults to 6
+    t.timestamp :timestamp_col # Precision defaults to 6
     t.time      :time_col
     t.date      :date_col
     t.binary    :binary_col


### PR DESCRIPTION
`Timestamp` columns should use precision 6 by default. This change was included in Rails 7.0.5 by https://github.com/rails/rails/pull/46110

The previous change to default `datetime` columns to use precision 6 was implemented in the adapter by https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/990

This fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1056