### PR TITLE
Force Rails < 7.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Interested in older versions? We follow a rational versioning policy that tracks
 
 | Adapter Version | Rails Version | Support                                                                                     |
 |-----------------| ------------- | ------------------------------------------------------------------------------------------- |
-| `7.0.1.0`       | `7.0.x`       | [active](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/main)   |
+| `7.0.2.0`       | < `7.0.5`     | [active](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/main)   |
 | `6.1.2.1`       | `6.1.x`       | [active](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/6-1-stable) |
 | `6.0.3`         | `6.0.x`       | [active](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/6-0-stable) |
 | `5.2.1`         | `5.2.x`       | [ended](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/5-2-stable) |

--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 7.0.0"
+  spec.add_dependency "activerecord", ["<= 7.0.4.3", ">= 7.0.0"]
   spec.add_dependency "tiny_tds"
 end


### PR DESCRIPTION
I think we should do this until https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1056 is fixed.