### PR TITLE
Fix tests to handle companies status column

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -450,7 +450,7 @@ class CalculationsTest < ActiveRecord::TestCase
       FROM companies
       INNER JOIN accounts ON companies.id = accounts.firm_id
       WHERE companies.id = ?
-      GROUP BY companies.id, companies.type, companies.firm_id, companies.firm_name, companies.name, companies.client_of, companies.rating, companies.account_id, companies.description
+      GROUP BY companies.id, companies.type, companies.firm_id, companies.firm_name, companies.name, companies.client_of, companies.rating, companies.account_id, companies.description, companies.status
       ORDER BY companies.id
       OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY
     SQL
@@ -476,7 +476,7 @@ class CalculationsTest < ActiveRecord::TestCase
              .select("companies.*", "AVG(CAST(accounts.credit_limit AS DECIMAL)) AS avg_credit_limit")
              .where(id: rails_core)
              .joins(:account)
-             .group(:id, :type, :firm_id, :firm_name, :name, :client_of, :rating, :account_id, :description)
+             .group(:id, :type, :firm_id, :firm_name, :name, :client_of, :rating, :account_id, :description, :status)
              .take!
 
     # all the DependentFirm attributes should be present


### PR DESCRIPTION
Fix the following tests to accommodate the `companies.status` column that was added to the tests in Rails 7.0.5.

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/5122100848/jobs/9210694895?pr=1057

```
CalculationsTest#test_select_avg_with_joins_and_group_by_as_virtual_attribute_with_ar_coerced:
ActiveRecord::StatementInvalid: TinyTds::Error: Column 'companies.status' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.

CalculationsTest#test_select_avg_with_joins_and_group_by_as_virtual_attribute_with_sql_coerced:
ActiveRecord::StatementInvalid: TinyTds::Error: Column 'companies.status' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.
```