### PR TITLE
Updated license to remove copyright

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2022
+Copyright (c) Ken Collins
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Many many people have contributed. If you do not see your name here and it shoul
 
 You can see an up-to-date list of contributors here: http://github.com/rails-sqlserver/activerecord-sqlserver-adapter/contributors
 
+
 ## License
 
-Copyright © 2008-2022. It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](MIT-LICENSE) file.
+ActiveRecord SQL Server Adapter is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Updated the license to remove copyright. It now uses the same license as Ruby on Rails (see https://github.com/rails/rails/blob/5694f1ec0305e1946f6505257c596d4d6be9c4e4/README.md#L97).

This is in response to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1063

@metaskills Could you review as copyright probably resides with you?