### PR TITLE
Remove monkey-patch

### DIFF
--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -64,39 +64,6 @@ module Arel
         super
       end
 
-      def visit_Arel_Nodes_HomogeneousIn(o, collector)
-        collector.preparable = false
-
-        collector << quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
-
-        if o.type == :in
-          collector << " IN ("
-        else
-          collector << " NOT IN ("
-        end
-
-        values = o.casted_values
-
-        if values.empty?
-          collector << @connection.quote(nil)
-        elsif @connection.prepared_statements
-          # Monkey-patch start. Add query attribute bindings rather than just values.
-          column_name = o.column_name
-          column_type = o.attribute.relation.type_for_attribute(o.column_name)
-          # Use cast_type on encrypted attributes. Don't encrypt them again
-          column_type = column_type.cast_type if column_type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
-          attrs = values.map { |value| ActiveRecord::Relation::QueryAttribute.new(column_name, value, column_type) }
-
-          collector.add_binds(attrs, &bind_block)
-          # Monkey-patch end.
-        else
-          collector.add_binds(values, &bind_block)
-        end
-
-        collector << ")"
-        collector
-      end
-
       def visit_Arel_Nodes_SelectStatement(o, collector)
         @select_statement = o
         distinct_One_As_One_Is_So_Not_Fetch o


### PR DESCRIPTION
Fix the following errors in Rails 7.1 tests:

```
NoMethodError: undefined method `table_name' for #<Arel::Nodes::HomogeneousIn...
```

Example: https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/5749938359/job/15585717869?pr=1066#step:4:567