### PR TITLE
Fix deprecated warning message

### DIFF
--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -43,7 +43,7 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
   end
 
   it 'test deprecation with transaction return when executing procedure' do
-    assert_deprecated do
+    assert_deprecated(ActiveRecord.deprecator) do
       ActiveRecord::Base.transaction do
         connection.execute_procedure("my_getutcdate")
         return


### PR DESCRIPTION
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1067

Fix warning message:

```
DEPRECATION WARNING: assert_deprecated without a deprecator is deprecated (called from block in <class:ExecuteProcedureTestSQLServer> at /vagrant/activerecord-sqlserver-adapter/test/cases/execute_procedure_test_sqlserver.rb:46)
```