### PR TITLE
Change default test password

### DIFF
--- a/test/config.yml
+++ b/test/config.yml
@@ -6,7 +6,7 @@ default_connection_info: &default_connection_info
   port: <%= ENV['ACTIVERECORD_UNITTEST_PORT'] %>
   database: activerecord_unittest
   username: <%= ENV['ACTIVERECORD_UNITTEST_USER'] || 'rails' %>
-  password: <%= ENV['ACTIVERECORD_UNITTEST_PASS'] || '' %>
+  password: <%= ENV['ACTIVERECORD_UNITTEST_PASS'] || 'password' %>
   collation: <%= ENV['ACTIVERECORD_UNITTEST_COLLATION'] || nil %>
   encoding: utf8
 


### PR DESCRIPTION
Changed default test password to `password` rather than blank. Azure Data Studio does not allow for blank password and so easier to change the password rather than having to work around it.