### PR TITLE
Fix auto populated ID after insert

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -43,9 +43,9 @@ module ActiveRecord
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, _sequence_name = nil, returning: nil)
           if id_insert_table_name = exec_insert_requires_identity?(sql, pk, binds)
-            with_identity_insert_enabled(id_insert_table_name) { super(sql, name, binds, pk) }
+            with_identity_insert_enabled(id_insert_table_name) { super(sql, name, binds, pk, returning) }
           else
-            super(sql, name, binds, pk)
+            super(sql, name, binds, pk, returning)
           end
         end
 

--- a/lib/active_record/connection_adapters/sqlserver_column.rb
+++ b/lib/active_record/connection_adapters/sqlserver_column.rb
@@ -17,6 +17,7 @@ module ActiveRecord
         def is_identity?
           is_identity
         end
+        alias_method :auto_incremented_by_db?, :is_identity?
 
         def is_primary?
           is_primary


### PR DESCRIPTION
Fix issue with auto-population of ActiveRecord object ID after creation by insert.

Example of fixed test is following from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/5868251547/job/15910651869
```
InheritanceTest#test_class_with_blank_sti_name:
ActiveRecord::RecordNotFound: Couldn't find Company without an ID
    rails (3779b5069dd1) activerecord/lib/active_record/relation/finder_methods.rb:474:in `find_with_ids'
    rails (3779b5069dd1) activerecord/lib/active_record/relation/finder_methods.rb:69:in `find'
    rails (3779b5069dd1) activerecord/lib/active_record/querying.rb:23:in `find'
    rails (3779b5069dd1) activerecord/lib/active_record/core.rb:250:in `find'
    rails (3779b5069dd1) activerecord/test/cases/inheritance_test.rb:50:in `test_class_with_blank_sti_name'
```

Ref:
- https://github.com/rails/rails/commit/c92933265efce7faa77767bf7f6ac0532312fd4e