### PR TITLE
Translate exceptions

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -309,6 +309,7 @@ module ActiveRecord
           log(sql, name) { raw_connection_do(sql) }
         end
 
+        # TODO: Adapter should be refactored to use `with_raw_connection` to translate exceptions.
         def sp_executesql(sql, name, binds, options = {})
           options[:ar_result] = true if options[:fetch] != :rows
           unless without_prepared_statement?(binds)
@@ -316,6 +317,9 @@ module ActiveRecord
             sql = sp_executesql_sql(sql, types, params, name)
           end
           raw_select sql, name, binds, options
+        rescue => original_exception
+          translated_exception = translate_exception_class(original_exception, sql, binds)
+          raise translated_exception
         end
 
         def sp_executesql_types_and_parameters(binds)


### PR DESCRIPTION
Translation of exceptions has changed in Rails since https://github.com/rails/rails/commit/da52b0d954a356421ccc064df3b1285f2ba10eb5

PR translates exceptions if they happen during `sp_executesql`.

This fixes the following error from https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/5877896924/job/15938914187
```
2023-08-16T11:00:18.3284577Z UniquenessValidationTest#test_validate_uniqueness_with_limit_and_utf8_coerced [/activerecord-sqlserver-adapter/test/cases/coerced_tests.rb:21]:
2023-08-16T11:00:18.3285619Z [ActiveRecord::ValueTooLong] exception expected, not
2023-08-16T11:00:18.3286456Z Class: <TinyTds::Error>
2023-08-16T11:00:18.3287205Z Message: <"String or binary data would be truncated.">
2023-08-16T11:00:18.3287740Z ---Backtrace---
2023-08-16T11:00:18.3290244Z activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:459:in `each'
```

Ref: https://github.com/rails/rails/commit/da52b0d954a356421ccc064df3b1285f2ba10eb5