### PR TITLE
Coerce sanitize test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1425,7 +1425,7 @@ class SanitizeTest < ActiveRecord::TestCase
   end
 
   # Use nvarchar string (N'') in assert
-  coerce_tests! test_named_bind_with_literal_colons
+  coerce_tests! :test_named_bind_with_literal_colons
   def test_named_bind_with_literal_colons_coerced
     assert_equal "TO_TIMESTAMP(N'2017/08/02 10:59:00', 'YYYY/MM/DD HH12:MI:SS')", bind("TO_TIMESTAMP(:date, 'YYYY/MM/DD HH12\\:MI\\:SS')", date: "2017/08/02 10:59:00")
     assert_raise(ActiveRecord::PreparedStatementInvalid) { bind "TO_TIMESTAMP(:date, 'YYYY/MM/DD HH12:MI:SS')", date: "2017/08/02 10:59:00" }

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1423,6 +1423,13 @@ class SanitizeTest < ActiveRecord::TestCase
       searchable_post.search_as_scope("20% _reduction_!").to_a
     end
   end
+
+  # Use nvarchar string (N'') in assert
+  coerce_tests! test_named_bind_with_literal_colons
+  def test_named_bind_with_literal_colons_coerced
+    assert_equal "TO_TIMESTAMP(N'2017/08/02 10:59:00', 'YYYY/MM/DD HH12:MI:SS')", bind("TO_TIMESTAMP(:date, 'YYYY/MM/DD HH12\\:MI\\:SS')", date: "2017/08/02 10:59:00")
+    assert_raise(ActiveRecord::PreparedStatementInvalid) { bind "TO_TIMESTAMP(:date, 'YYYY/MM/DD HH12:MI:SS')", date: "2017/08/02 10:59:00" }
+  end
 end
 
 class SchemaDumperTest < ActiveRecord::TestCase


### PR DESCRIPTION
Coerce the `SanitizeTest#test_named_bind_with_literal_colons` test to handle nvarchar string `N''`.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/5877896924/job/15938914187#step:4:408
```
2023-08-16T11:00:18.7978921Z Failure:
2023-08-16T11:00:18.7980364Z SanitizeTest#test_named_bind_with_literal_colons [/usr/local/bundle/bundler/gems/rails-6db58ed7b6b3/activerecord/test/cases/sanitize_test.rb:228]:
2023-08-16T11:00:18.7980914Z --- expected
2023-08-16T11:00:18.7981144Z +++ actual
2023-08-16T11:00:18.7981408Z @@ -1 +1 @@
2023-08-16T11:00:18.7981816Z -"TO_TIMESTAMP('2017/08/02 10:59:00', 'YYYY/MM/DD HH12:MI:SS')"
2023-08-16T11:00:18.7982290Z +"TO_TIMESTAMP(N'2017/08/02 10:59:00', 'YYYY/MM/DD HH12:MI:SS')"
```