### PR TITLE
Validate table name length when renaming

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -125,7 +125,10 @@ module ActiveRecord
           sp_executesql(sql, "SCHEMA", binds).map { |r| r["name"] }
         end
 
-        def rename_table(table_name, new_name)
+        def rename_table(table_name, new_name, **options)
+          validate_table_length!(new_name) unless options[:_uses_legacy_table_name]
+          schema_cache.clear_data_source_cache!(table_name.to_s)
+          schema_cache.clear_data_source_cache!(new_name.to_s)
           do_execute "EXEC sp_rename '#{table_name}', '#{new_name}'"
           rename_table_indexes(table_name, new_name)
         end


### PR DESCRIPTION
Validate table name length when renaming. Fixes:

```
Failure:
ActiveRecord::Migration::RenameTableTest#test_rename_table_raises_for_long_table_names [/usr/local/bundle/bundler/gems/rails-7f8cdb1dc3ae/activerecord/test/cases/migration/rename_table_test.rb:58]:
ArgumentError expected but nothing was raised.

bin/rails test /usr/local/bundle/bundler/gems/rails-7f8cdb1dc3ae/activerecord/test/cases/migration/rename_table_test.rb:53
```