### PR TITLE
Allow column name with COLLATE as safe SQL string

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/quoting.rb
+++ b/lib/active_record/connection_adapters/sqlserver/quoting.rb
@@ -100,6 +100,7 @@ module ActiveRecord
               # [database_name].[database_owner].[table_name].[column_name] | function(one or no argument)
               ((?:\w+\.|\[\w+\]\.)?(?:\w+\.|\[\w+\]\.)?(?:\w+\.|\[\w+\]\.)?(?:\w+|\[\w+\]) | \w+\((?:|\g<2>)\))
             )
+            (?:\s+COLLATE\s+\w+)?
             (?:\s+ASC|\s+DESC)?
             (?:\s+NULLS\s+(?:FIRST|LAST))?
           )

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1850,6 +1850,18 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     assert_equal titles_expected, titles
   end
+
+  # Collation name should not be quoted. Hardcoded values for different adapters.
+  coerce_tests! %r{order: allows valid arguments with COLLATE}
+  test "order: allows valid arguments with COLLATE" do
+    collation_name = "Latin1_General_CS_AS_WS"
+
+    ids_expected = Post.order(Arel.sql(%Q'author_id, title COLLATE #{collation_name} DESC')).pluck(:id)
+
+    ids = Post.order(["author_id", %Q'title COLLATE #{collation_name} DESC']).pluck(:id)
+
+    assert_equal ids_expected, ids
+  end
 end
 
 class ReservedWordTest < ActiveRecord::TestCase


### PR DESCRIPTION
Collation name cannot be quoted in SQL Server. Rails test uses hardcoded values per adapter.

See https://github.com/rails/rails/pull/44384