### PR TITLE
Fix for adding timestamps to table

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -256,6 +256,13 @@ module ActiveRecord
           end
         end
 
+        # In SQL Server only the first column added should have the `ADD` keyword.
+        def add_timestamps(table_name, **options)
+          fragments = add_timestamps_for_alter(table_name, **options)
+          fragments[1..].each { |fragment| fragment.sub!('ADD ', '') }
+          execute "ALTER TABLE #{quote_table_name(table_name)} #{fragments.join(', ')}"
+        end
+
         def columns_for_distinct(columns, orders)
           order_columns = orders.reject(&:blank?).map { |s|
                             s = s.to_sql unless s.is_a?(String)

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -513,7 +513,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   # Leave it up to users to format selects/functions so HAVING works correctly.
   coerce_tests! :test_having_with_strong_parameters
-  
+
   # SELECT columns must be in the GROUP clause. Since since `ids` only selects the primary key you cannot perform this query in SQL Server.
   coerce_tests! :test_ids_with_includes_and_non_primary_key_order
 end


### PR DESCRIPTION
In SQL Server only the first column added should have the `ADD` keyword.

Incorrect SQL:
```sql
ALTER TABLE [my_table] ADD [created_at] datetime2(6) NOT NULL, ADD [updated_at] datetime2(6) NOT NULL
```

Correct SQL:
```sql
ALTER TABLE [my_table] ADD [created_at] datetime2(6) NOT NULL, [updated_at] datetime2(6) NOT NULL
```

Fixes test:
```
ActiveRecord::Migration::ColumnsTest#test_add_timestamps_single_statement:
ActiveRecord::StatementInvalid: TinyTds::Error: Incorrect syntax near the keyword 'ADD'.
    activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:28:in `do'
    ...
bin/rails test /usr/local/bundle/bundler/gems/rails-7b670848e136/activerecord/test/cases/migration/columns_test.rb:399
```