### PR TITLE
Fix creation of stored procedures that contain insert statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [#1073](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1073) Improve performance of view default function lookup
 
+#### Fixed
+
+- [#1088](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1088) Fix creation of stored procedures that contain insert statements
+
 ## v7.0.3.0
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -406,7 +406,7 @@ module ActiveRecord
         end
 
         def insert_sql?(sql)
-          !(sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)/i).nil?
+          !(sql =~ /\A\s*(INSERT|EXEC sp_executesql N'INSERT)/i).nil?
         end
 
         def identity_columns(table_name)

--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -115,4 +115,22 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
       refute_includes schemas, { "name" => "some schema" }
     end
   end
+
+  describe 'creating stored procedure' do
+    it 'stored procedure contains inserts are created successfully' do
+      sql = <<-SQL
+          CREATE OR ALTER PROCEDURE do_some_task
+          AS
+          IF NOT EXISTS(SELECT * FROM sys.objects WHERE type = 'U' AND name = 'SomeTableName')
+          BEGIN
+            CREATE TABLE SomeTableName (SomeNum int PRIMARY KEY CLUSTERED);
+            INSERT INTO SomeTableName(SomeNum) VALUES(1);
+          END
+        SQL
+
+      assert_nothing_raised { connection.execute(sql) }
+    ensure
+      connection.execute("DROP PROCEDURE IF EXISTS dbo.do_some_task;")
+    end
+  end
 end


### PR DESCRIPTION
When creating a stored procedure that contained an insert statements, the SQL was being incorrectly flagged as a insert statement. We should check the start of the string to find if an SQL statement is an insert, rather than each line of the string. Issue introduced in Rails 7.0 branch by https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/988

Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1087