### PR TITLE
Update calculate monkey-patch

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -8,18 +8,41 @@ module ActiveRecord
     module SQLServer
       module CoreExt
         module Calculations
-          # Same as original except we don't perform PostgreSQL hack that removes ordering.
           def calculate(operation, column_name)
-            return super unless klass.connection.adapter_name == "SQLServer"
+            if klass.connection.sqlserver?
+              _calculate(operation, column_name)
+            else
+              super
+            end
+          end
+
+          private
+
+          # Same as original `calculate` method except we don't perform PostgreSQL hack that removes ordering.
+          def _calculate(operation, column_name)
+            operation = operation.to_s.downcase
+
+            if @none
+              case operation
+              when "count", "sum"
+                result = group_values.any? ? Hash.new : 0
+                return @async ? Promise::Complete.new(result) : result
+              when "average", "minimum", "maximum"
+                result = group_values.any? ? Hash.new : nil
+                return @async ? Promise::Complete.new(result) : result
+              end
+            end
 
             if has_include?(column_name)
               relation = apply_join_dependency
 
-              if operation.to_s.downcase == "count"
+              if operation == "count"
                 unless distinct_value || distinct_select?(column_name || select_for_count)
                   relation.distinct!
-                  relation.select_values = [klass.primary_key || table[Arel.star]]
+                  relation.select_values = [ klass.primary_key || table[Arel.star] ]
                 end
+                # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
+                # relation.order_values = [] if group_values.empty?
               end
 
               relation.calculate(operation, column_name)
@@ -27,8 +50,6 @@ module ActiveRecord
               perform_calculation(operation, column_name)
             end
           end
-
-          private
 
           def build_count_subquery(relation, column_name, distinct)
             return super unless klass.connection.adapter_name == "SQLServer"

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -42,7 +42,9 @@ module ActiveRecord
                   relation.select_values = [ klass.primary_key || table[Arel.star] ]
                 end
                 # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
+                # Start of monkey-patch
                 # relation.order_values = [] if group_values.empty?
+                # End of monkey-patch
               end
 
               relation.calculate(operation, column_name)


### PR DESCRIPTION
Fixes the failing `activerecord/test/cases/null_relation_test.rb` tests. Needed to copy over the changes made to the `ActiveRecord::Calculations.calculate` method that we monkey-patch.

Cleaned up the `construct_relation_for_exists` monky-patch too.