### PR TITLE
Fixes for USE clause

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module DatabaseStatements
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :dbcc, :explain, :save, :select, :set, :rollback, :waitfor) # :nodoc:
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :dbcc, :explain, :save, :select, :set, :rollback, :waitfor, :use) # :nodoc:
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:
@@ -217,7 +217,7 @@ module ActiveRecord
           return if sqlserver_azure?
 
           name = SQLServer::Utils.extract_identifiers(database || @connection_parameters[:database]).quoted
-          execute "USE #{name}" unless name.blank?
+          execute("USE #{name}", "SCHEMA") unless name.blank?
         end
 
         def user_options

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -118,10 +118,12 @@ module ActiveRecord
             AND TC.CONSTRAINT_TYPE = N'PRIMARY KEY'
             ORDER BY KCU.ORDINAL_POSITION ASC
           }.gsub(/[[:space:]]/, " ")
+
           binds = []
           nv128 = SQLServer::Type::UnicodeVarchar.new limit: 128
           binds << Relation::QueryAttribute.new("TABLE_NAME", identifier.object, nv128)
           binds << Relation::QueryAttribute.new("TABLE_SCHEMA", identifier.schema, nv128) unless identifier.schema.blank?
+
           sp_executesql(sql, "SCHEMA", binds).map { |r| r["name"] }
         end
 


### PR DESCRIPTION
Fixes for the `USE` clause.

- `USE` queries should not be regarded as write queries. 
- `USE` queries should be marked as schema type queries. 

Changes reduced the number of failing `bundle exec rake test TEST_FILES_AR="test/cases/query_cache_test.rb"` tests.


Before
```
55 runs, 169 assertions, 6 failures, 2 errors, 2 skips
```

After
```
55 runs, 173 assertions, 5 failures, 0 errors, 2 skips
```