### PR TITLE
Fix the invalid options migration tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2473,3 +2473,17 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_not author.valid?
   end
 end
+
+module ActiveRecord
+  class Migration
+    class InvalidOptionsTest < ActiveRecord::TestCase
+      # Include the additional SQL Server migration options.
+      def invalid_add_column_option_exception_message(key)
+        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":if_exists", ":if_not_exists"]
+        default_keys.concat([":is_identity"]) # SQL Server additional valid keys
+
+        "Unknown key: :#{key}. Valid keys are: #{default_keys.join(", ")}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix the `test/cases/migration/invalid_options_test.rb` tests.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6300135339/job/17102280466?pr=1094
```
ActiveRecord::Migration::InvalidOptionsTest#test_add_reference_with_invalid_options [/usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/invalid_options_test.rb:46]:
--- expected
+++ actual
@@ -1 +1 @@
-"Unknown key: :boring_key. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists"
+"Unknown key: :boring_key. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :is_identity"


bin/rails test /usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/invalid_options_test.rb:39

F

Failure:
ActiveRecord::Migration::InvalidOptionsTest#test_add_column_with_invalid_options [/usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/invalid_options_test.rb:68]:
--- expected
+++ actual
@@ -1 +1 @@
-"Unknown key: :preccision. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists"
+"Unknown key: :preccision. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :is_identity"


bin/rails test /usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/invalid_options_test.rb:63
```