### PR TITLE
Queries to find indexes are schema queries

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -44,7 +44,7 @@ module ActiveRecord
             else
               name    = index[:index_name]
               unique  = index[:index_description] =~ /unique/
-              where   = select_value("SELECT [filter_definition] FROM sys.indexes WHERE name = #{quote(name)}")
+              where   = select_value("SELECT [filter_definition] FROM sys.indexes WHERE name = #{quote(name)}", "SCHEMA")
               orders  = {}
               columns = []
 


### PR DESCRIPTION
Queries to find table indexes should be marked as schema queries. This will fix a number of failing tests including:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6300135339/job/17102280466?pr=1094
```
UniquenessValidationWithIndexTest#test_changing_non_unique_attribute [/usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/validations/uniqueness_validation_test.rb:668]:
2 instead of 0 queries were executed.
Queries:
SELECT [filter_definition] FROM sys.indexes WHERE name = N'index_topics_on_author_name_and_title'
SELECT [filter_definition] FROM sys.indexes WHERE name = N'topics_index'.
Expected: 0
  Actual: 2
```