### PR TITLE
Fix foreign key tests

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -224,17 +224,25 @@ module ActiveRecord
         def foreign_keys(table_name)
           identifier = SQLServer::Utils.extract_identifiers(table_name)
           fk_info = execute_procedure :sp_fkeys, nil, identifier.schema, nil, identifier.object, identifier.schema
-          fk_info.map do |row|
-            from_table = identifier.object
-            to_table = row["PKTABLE_NAME"]
+
+          grouped_fk = fk_info.group_by { |row| row["FK_NAME"] }.values.each { |group| group.sort_by! { |row| row["KEY_SEQ"] } }
+          grouped_fk.map do |group|
+            row = group.first
             options = {
               name: row["FK_NAME"],
-              column: row["FKCOLUMN_NAME"],
-              primary_key: row["PKCOLUMN_NAME"],
               on_update: extract_foreign_key_action("update", row["FK_NAME"]),
               on_delete: extract_foreign_key_action("delete", row["FK_NAME"])
             }
-            ForeignKeyDefinition.new from_table, to_table, options
+
+            if group.one?
+              options[:column] = row["FKCOLUMN_NAME"]
+              options[:primary_key] = row["PKCOLUMN_NAME"]
+            else
+              options[:column] = group.map { |row| row["FKCOLUMN_NAME"] }
+              options[:primary_key] = group.map { |row| row["PKCOLUMN_NAME"] }
+            end
+
+            ForeignKeyDefinition.new(identifier.object, row["PKTABLE_NAME"], options)
           end
         end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2489,3 +2489,25 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
     end
   end
 end
+
+module ActiveRecord
+  class Migration
+    class ForeignKeyTest
+      # SQL Server does not support 'restrict' for 'on_update' or 'on_delete'.
+      coerce_tests! :test_add_on_delete_restrict_foreign_key
+
+      # Match different error message.
+      coerce_tests! :test_add_foreign_key_with_if_not_exists_not_set
+      def test_add_foreign_key_with_if_not_exists_not_set_coerced
+        @connection.add_foreign_key :astronauts, :rockets
+        assert_equal 1, @connection.foreign_keys("astronauts").size
+
+        error = assert_raises do
+          @connection.add_foreign_key :astronauts, :rockets
+        end
+
+        assert_match(/There is already an object named \'.*\' in the database/, error.message)
+      end
+    end
+  end
+end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2492,7 +2492,7 @@ end
 
 module ActiveRecord
   class Migration
-    class ForeignKeyTest
+    class ForeignKeyTest < ActiveRecord::TestCase
       # SQL Server does not support 'restrict' for 'on_update' or 'on_delete'.
       coerce_tests! :test_add_on_delete_restrict_foreign_key
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1096,7 +1096,7 @@ end
 module ActiveRecord
   class Migration
     class ForeignKeyTest < ActiveRecord::TestCase
-      # We do not support :restrict.
+      # SQL Server does not support 'restrict' for 'on_update' or 'on_delete'.
       coerce_tests! :test_add_on_delete_restrict_foreign_key
       def test_add_on_delete_restrict_foreign_key_coerced
         assert_raises ArgumentError do
@@ -2485,28 +2485,6 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
         assert_encrypted_attribute article, :title, "Article #{index} (#{thread_label})"
         article.decrypt
         assert_not_encrypted_attribute article, :title, "Article #{index} (#{thread_label})"
-      end
-    end
-  end
-end
-
-module ActiveRecord
-  class Migration
-    class ForeignKeyTest < ActiveRecord::TestCase
-      # SQL Server does not support 'restrict' for 'on_update' or 'on_delete'.
-      coerce_tests! :test_add_on_delete_restrict_foreign_key
-
-      # Match different error message.
-      coerce_tests! :test_add_foreign_key_with_if_not_exists_not_set
-      def test_add_foreign_key_with_if_not_exists_not_set_coerced
-        @connection.add_foreign_key :astronauts, :rockets
-        assert_equal 1, @connection.foreign_keys("astronauts").size
-
-        error = assert_raises do
-          @connection.add_foreign_key :astronauts, :rockets
-        end
-
-        assert_match(/There is already an object named \'.*\' in the database/, error.message)
       end
     end
   end


### PR DESCRIPTION
Fixed schema statements so that the Rails `activerecord/test/cases/migration/foreign_key_test.rb` tests pass. Included adding support for composite foreign keys.