### PR TITLE
Unique attribute of IndexDefinition should be a boolean

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -39,11 +39,11 @@ module ActiveRecord
           data.reduce([]) do |indexes, index|
             index = index.with_indifferent_access
 
-            if index[:index_description] =~ /primary key/
+            if index[:index_description].match?(/primary key/)
               indexes
             else
               name    = index[:index_name]
-              unique  = index[:index_description] =~ /unique/
+              unique  = index[:index_description].match?(/unique/)
               where   = select_value("SELECT [filter_definition] FROM sys.indexes WHERE name = #{quote(name)}", "SCHEMA")
               orders  = {}
               columns = []


### PR DESCRIPTION
The `unique` attribute of `IndexDefinition` should be a boolean.

Fixes `ActiveRecord::Migration::ReferencesStatementsTest#test_creates_named_unique_index` test.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6328689792/job/17187421431
```
ActiveRecord::Migration::ReferencesStatementsTest#test_creates_named_unique_index [/usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/references_statements_test.rb:82]:
Expected false to be truthy.

bin/rails test /usr/local/bundle/bundler/gems/rails-6797c7382e37/activerecord/test/cases/migration/references_statements_test.rb:80
```