### PR TITLE
Added method to build change column default definition

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -221,6 +221,14 @@ module ActiveRecord
           execute "DROP INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}"
         end
 
+        def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
+          column = column_for(table_name, column_name)
+          return unless column
+
+          default = extract_new_default_value(default_or_changes)
+          ChangeColumnDefaultDefinition.new(column, default)
+        end
+
         def foreign_keys(table_name)
           identifier = SQLServer::Utils.extract_identifiers(table_name)
           fk_info = execute_procedure :sp_fkeys, nil, identifier.schema, nil, identifier.object, identifier.schema


### PR DESCRIPTION
Fix for following type of errors.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6380010572/job/17313600140?pr=1102
```
ActiveRecord::Migration::SchemaDefinitionsTest#test_build_change_column_default_definition:
NotImplementedError: build_change_column_default_definition is not implemented
    rails (ccb7be66ac20) activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:723:in `build_change_column_default_definition'
    rails (ccb7be66ac20) activerecord/test/cases/migration/schema_definitions_test.rb:98:in `test_build_change_column_default_definition'
```

Implementation copied from Rails Postgresql adapter.