### PR TITLE
Use IN sql instead of OR sql for query constraints

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
@@ -8,10 +8,22 @@ module ActiveRecord
       module CoreExt
         module LoaderQuery
           def load_records_for_keys(keys, &block)
-            return super unless scope.connection.adapter_name == "SQLServer"
+            return super unless scope.connection.sqlserver?
 
-            keys.each_slice(in_clause_length).flat_map do |slice|
-              scope.where(association_key_name => slice).load(&block).records
+            if association_key_name.is_a?(Array)
+              query_constraints = Hash.new { |hsh, key| hsh[key] = Set.new }
+
+              keys.each_with_object(query_constraints) do |values_set, constraints|
+                association_key_name.zip(values_set).each do |key_name, value|
+                  constraints[key_name] << value
+                end
+              end
+
+              scope.where(query_constraints).load(&block)
+            else
+              keys.each_slice(in_clause_length).flat_map do |slice|
+                scope.where(association_key_name => slice).load(&block).records
+              end
             end
           end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -956,25 +956,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal 3, authors(:david).posts_with_comments.where("LEN(comments.body) > 15").references(:comments).count
   end
 
-  # Use TOP (1) in scope vs limit 1.
+  # The raw SQL in the scope uses `limit 1`.
   coerce_tests! %r{including association based on sql condition and no database column}
-
-  # Table name not regex escaped in original test. Remove coerced test when https://github.com/rails/rails/pull/49345 merged.
-  coerce_tests! %r{preloading belongs_to association SQL}
-  test "preloading belongs_to association SQL coerced" do
-    blog_ids = [sharded_blogs(:sharded_blog_one).id, sharded_blogs(:sharded_blog_two).id]
-    posts = Sharded::BlogPost.where(blog_id: blog_ids).includes(:comments)
-
-    sql = capture_sql do
-      comments_collection = posts.map(&:comments)
-      assert_equal 3, comments_collection.size
-    end.last
-
-    c = Sharded::BlogPost.connection
-    quoted_blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
-    quoted_blog_post_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_post_id"))
-    assert_match(/WHERE #{quoted_blog_id} IN \(.+\) AND #{quoted_blog_post_id} IN \(.+\)/, sql)
-  end
 end
 
 require "models/topic"


### PR DESCRIPTION
Fix the SQL to use IN sql instead of OR sql for query constraints. This fixes test `preloading belongs_to association SQL` in `activerecord/test/cases/associations/eager_test.rb`. 

Changes required after https://github.com/rails/rails/pull/48947