### PR TITLE
Savepoint queries should be internally executed

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -100,19 +100,6 @@ module ActiveRecord
           execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION", "TRANSACTION"
         end
 
-        include Savepoints
-
-        def create_savepoint(name = current_savepoint_name)
-          execute "SAVE TRANSACTION #{name}", "TRANSACTION"
-        end
-
-        def exec_rollback_to_savepoint(name = current_savepoint_name)
-          execute "ROLLBACK TRANSACTION #{name}", "TRANSACTION"
-        end
-
-        def release_savepoint(name = current_savepoint_name)
-        end
-
         def case_sensitive_comparison(attribute, value)
           column = column_for_attribute(attribute)
 

--- a/lib/active_record/connection_adapters/sqlserver/savepoints.rb
+++ b/lib/active_record/connection_adapters/sqlserver/savepoints.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module Savepoints
+        def current_savepoint_name
+          current_transaction.savepoint_name
+        end
+
+        def create_savepoint(name = current_savepoint_name)
+          internal_execute("SAVE TRANSACTION #{name}", "TRANSACTION")
+        end
+
+        def exec_rollback_to_savepoint(name = current_savepoint_name)
+          internal_execute("ROLLBACK TRANSACTION #{name}", "TRANSACTION")
+        end
+
+        def release_savepoint(_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -17,6 +17,7 @@ require "active_record/connection_adapters/sqlserver/type"
 require "active_record/connection_adapters/sqlserver/database_limits"
 require "active_record/connection_adapters/sqlserver/database_statements"
 require "active_record/connection_adapters/sqlserver/database_tasks"
+require "active_record/connection_adapters/sqlserver/savepoints"
 require "active_record/connection_adapters/sqlserver/transaction"
 require "active_record/connection_adapters/sqlserver/errors"
 require "active_record/connection_adapters/sqlserver/schema_creation"
@@ -40,7 +41,8 @@ module ActiveRecord
               SQLServer::Showplan,
               SQLServer::SchemaStatements,
               SQLServer::DatabaseLimits,
-              SQLServer::DatabaseTasks
+              SQLServer::DatabaseTasks,
+              SQLServer::Savepoints
 
       ADAPTER_NAME = "SQLServer".freeze
 


### PR DESCRIPTION
When executing queries for savepoints, use `internal_execute` instead of `execute`. The method `execute` causes the query cache to be cleared which was breaking the following ActiveRecord tests:

- QueryCacheExpiryTest#test_insert 
- QueryCacheExpiryTest#test_update
- QueryCacheExpiryTest#test_destroy
- QueryCacheExpiryTest#test_cache_is_expired_by_habtm_update