### PR TITLE
Fix materialized transaction queries

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -76,7 +76,7 @@ module ActiveRecord
         end
 
         def begin_db_transaction
-          execute "BEGIN TRANSACTION", "TRANSACTION"
+          internal_execute("BEGIN TRANSACTION", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         def transaction_isolation_levels
@@ -84,20 +84,20 @@ module ActiveRecord
         end
 
         def begin_isolated_db_transaction(isolation)
-          set_transaction_isolation_level transaction_isolation_levels.fetch(isolation)
+          set_transaction_isolation_level(transaction_isolation_levels.fetch(isolation))
           begin_db_transaction
         end
 
         def set_transaction_isolation_level(isolation_level)
-          execute "SET TRANSACTION ISOLATION LEVEL #{isolation_level}", "TRANSACTION"
+          internal_execute("SET TRANSACTION ISOLATION LEVEL #{isolation_level}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
         end
 
         def commit_db_transaction
-          execute "COMMIT TRANSACTION", "TRANSACTION"
+          internal_execute("COMMIT TRANSACTION", "TRANSACTION", allow_retry: false, materialize_transactions: true)
         end
 
         def exec_rollback_db_transaction
-          execute "IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION", "TRANSACTION"
+          internal_execute("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION", "TRANSACTION", allow_retry: false, materialize_transactions: true)
         end
 
         def case_sensitive_comparison(attribute, value)


### PR DESCRIPTION
Use `internal_execute` when sending transaction control SQL.

Fixes test:
- TransactionInstrumentationTest#test_reconnecting_after_materialized_transaction_starts_new_event

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6454350937/job/17519696207

```
Error:
TransactionInstrumentationTest#test_reconnecting_after_materialized_transaction_starts_new_event:
RuntimeError: Wrapped undumpable exception for: ActiveRecord::StatementInvalid: TinyTds::Error: The COMMIT TRANSACTION request has no corresponding BEGIN TRANSACTION.
```
