### PR TITLE
Added method to build change column definition

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -221,6 +221,12 @@ module ActiveRecord
           execute "DROP INDEX #{quote_column_name(index_name)} ON #{quote_table_name(table_name)}"
         end
 
+        def build_change_column_definition(table_name, column_name, type, **options) # :nodoc:
+          td = create_table_definition(table_name)
+          cd = td.new_column_definition(column_name, type, **options)
+          ChangeColumnDefinition.new(cd, column_name)
+        end
+
         def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
           column = column_for(table_name, column_name)
           return unless column


### PR DESCRIPTION
Fix the `ActiveRecord::Migration::SchemaDefinitionsTest#test_build_change_column_definition` test.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6457398530/job/17528801352
```
Error:
ActiveRecord::Migration::SchemaDefinitionsTest#test_build_change_column_definition:
NoMethodError: undefined method `build_change_column_definition' for #<ActiveRecord::ConnectionAdapters::SQLServerAdapter version: 7.1.0, azure: false>
    rails (5f296f893892) activerecord/test/cases/migration/schema_definitions_test.rb:86:in `test_build_change_column_definition'
```