### PR TITLE
Fix Rails application name and SQL Server check 

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/abstract_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/abstract_adapter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module CoreExt
+        module AbstractAdapter
+          def sqlserver?
+            false
+          end
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  mod = ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::AbstractAdapter
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(mod)
+end

--- a/lib/active_record/connection_adapters/sqlserver/transaction.rb
+++ b/lib/active_record/connection_adapters/sqlserver/transaction.rb
@@ -5,14 +5,12 @@ require "active_record/connection_adapters/abstract/transaction"
 module ActiveRecord
   module ConnectionAdapters
     module SQLServerTransaction
+      delegate :sqlserver?, to: :connection, prefix: true
+
       private
 
-      def sqlserver?
-        connection.respond_to?(:sqlserver?) && connection.sqlserver?
-      end
-
       def current_isolation_level
-        return unless sqlserver?
+        return unless connection_sqlserver?
 
         level = connection.user_options_isolation_level
         # When READ_COMMITTED_SNAPSHOT is set to ON,
@@ -50,7 +48,7 @@ module ActiveRecord
       private
 
       def reset_starting_isolation_level
-        if sqlserver? && starting_isolation_level
+        if connection_sqlserver? && starting_isolation_level
           connection.set_transaction_isolation_level(starting_isolation_level)
         end
       end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -12,6 +12,7 @@ require "active_record/connection_adapters/sqlserver/core_ext/explain_subscriber
 require "active_record/connection_adapters/sqlserver/core_ext/attribute_methods"
 require "active_record/connection_adapters/sqlserver/core_ext/finder_methods"
 require "active_record/connection_adapters/sqlserver/core_ext/preloader"
+require "active_record/connection_adapters/sqlserver/core_ext/abstract_adapter"
 require "active_record/connection_adapters/sqlserver/version"
 require "active_record/connection_adapters/sqlserver/type"
 require "active_record/connection_adapters/sqlserver/database_limits"
@@ -100,7 +101,7 @@ module ActiveRecord
         super
 
         @config[:tds_version] = "7.3" unless @config[:tds_version]
-        @config[:appname] = rails_application_name unless @config[:appname]
+        @config[:appname] = self.class.rails_application_name unless @config[:appname]
         @config[:login_timeout] = @config[:login_timeout].present? ? @config[:login_timeout].to_i : nil
         @config[:timeout] = @config[:timeout].present? ? @config[:timeout].to_i / 1000 : nil
         @config[:encoding] = @config[:encoding].present? ? @config[:encoding] : nil


### PR DESCRIPTION
Hi,

I've been trying to use the `main` version of the adapter on our project and can't make it running yet.
Here are 2 issues I've found so far.

1. Small bug

`rails_application_name` is called on the instance level instead of class

2. Issue with `sqlserver?` declaration

```
3.2.0 :001 > User.where(id: 1).exists?
/Users/alexandreovertus/.rvm/gems/ruby-3.2.0/bundler/gems/activerecord-sqlserver-adapter-d1a3b1dd1977/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb:14:in `construct_relation_for_exists’: undefined method `sqlserver?' for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x0000000117eaf020 @transaction_manager=#<ActiveRecord::ConnectionAdapters::TransactionManager:0x00000001162e0100 @stack=[], @connection=#
```

`sqlserver?` is unknown from the other adapter. As I understand the goal of defining a method to easily detect which adapter is currently used rather than relying on the name, its not known by the abstracted layer. Ideally the abstract layer would define a method dynamically based on the name of the adapter, in the meantime we can explicitly add a method on the abstract module to make it shared.

Let me know if it makes sense as if its easier to share those notes or make a useable PR to contribute.

Thanks for your support and help with this library 🎉 
