### PR TITLE
Implement MessagePack methods on the Data class

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/data.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/data.rb
@@ -36,6 +36,16 @@ module ActiveRecord
             self.class == other.class && value == other.value
           end
           alias :== :eql?
+
+          def self.from_msgpack_ext(string)
+            type, value = string.chomp!("msgpack_ext").split(',')
+
+            Data.new(value, type.constantize)
+          end
+
+          def to_msgpack_ext
+            [type.class.to_s, value].join(',') + "msgpack_ext"
+          end
         end
       end
     end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2586,6 +2586,19 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
   end
 end
 
+# Need to use `install_unregistered_type_fallback` instead of `install_unregistered_type_error` so that message-pack
+# can read and write `ActiveRecord::ConnectionAdapters::SQLServer::Type::Data` objects.
+class ActiveRecordMessagePackTest < ActiveRecord::TestCase
+  private
+  def serializer
+    @serializer ||= ::MessagePack::Factory.new.tap do |factory|
+      ActiveRecord::MessagePack::Extensions.install(factory)
+      ActiveSupport::MessagePack::Extensions.install(factory)
+      ActiveSupport::MessagePack::Extensions.install_unregistered_type_fallback(factory)
+    end
+  end
+end
+
 # TODO: Need to uncoerce the 'SerializedAttributeTest' tests before releasing adapter for Rails 7.1
 class SerializedAttributeTest < ActiveRecord::TestCase
   coerce_all_tests!


### PR DESCRIPTION
Implement the MessgePack methods on the `ActiveRecord::ConnectionAdapters::SQLServer::Type::Data` class as it doesn't inherit from any of the other class that implement them. 

Fixes test:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6494022569/job/17636125629
```
Error:
ActiveRecordMessagePackTest#test_0002_roundtrips record and cached associations:
ActiveSupport::MessagePack::UnserializableObjectError: Unsupported type ActiveRecord::ConnectionAdapters::SQLServer::Type::Data for object "10-12-2023 09:49:44.575472"
    rails (319256ac4708) activesupport/lib/active_support/message_pack/extensions.rb:233:in `raise_unserializable'
```