### PR TITLE
Need to set explicitly set JSON attribute as such

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2586,6 +2586,18 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
   end
 end
 
+
+class StoreTest < ActiveRecord::TestCase
+  Admin::User.attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
+end
+
+# Need to `StoreTest#saved changes tracking for accessors with json column`
+# class Admin::User < ActiveRecord::Base
+#   attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
+# end
+
+
+
 # Need to use `install_unregistered_type_fallback` instead of `install_unregistered_type_error` so that message-pack
 # can read and write `ActiveRecord::ConnectionAdapters::SQLServer::Type::Data` objects.
 class ActiveRecordMessagePackTest < ActiveRecord::TestCase

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2586,18 +2586,6 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
   end
 end
 
-
-class StoreTest < ActiveRecord::TestCase
-  Admin::User.attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
-end
-
-# Need to `StoreTest#saved changes tracking for accessors with json column`
-# class Admin::User < ActiveRecord::Base
-#   attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
-# end
-
-
-
 # Need to use `install_unregistered_type_fallback` instead of `install_unregistered_type_error` so that message-pack
 # can read and write `ActiveRecord::ConnectionAdapters::SQLServer::Type::Data` objects.
 class ActiveRecordMessagePackTest < ActiveRecord::TestCase
@@ -2609,6 +2597,11 @@ class ActiveRecordMessagePackTest < ActiveRecord::TestCase
       ActiveSupport::MessagePack::Extensions.install_unregistered_type_fallback(factory)
     end
   end
+end
+
+class StoreTest < ActiveRecord::TestCase
+  # Set the attribute as JSON type for the `StoreTest#saved changes tracking for accessors with json column` test.
+  Admin::User.attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
 end
 
 # TODO: Need to uncoerce the 'SerializedAttributeTest' tests before releasing adapter for Rails 7.1


### PR DESCRIPTION
Since SQL Server does not have a native JSON column type, JSON columns are stored as `nvarchar(max)`. Need to explicitly mark a model's attribute as JSON since it cannot be inferred. 

This PR marks the `admin_users.json_options` column as JSON so that the `StoreTest#saved changes tracking for accessors with json column` test passes following https://github.com/rails/rails/pull/43386