### PR TITLE
Initialise the schema cache when checking the database version

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -243,7 +243,7 @@ module ActiveRecord
       end
 
       def reconnect
-        @raw_connection.close rescue nil
+        @raw_connection&.close rescue nil
         @raw_connection = nil
         @spid = nil
         @collation = nil
@@ -254,7 +254,7 @@ module ActiveRecord
       def disconnect!
         super
 
-        @raw_connection.close rescue nil
+        @raw_connection&.close rescue nil
         @raw_connection = nil
         @spid = nil
         @collation = nil
@@ -336,6 +336,12 @@ module ActiveRecord
 
       def get_database_version # :nodoc:
         version_year
+      end
+
+      def check_version # :nodoc:
+        if schema_cache.database_version < 2012
+          raise "Your version of SQL Server (#{database_version}) is too old. SQL Server Active Record supports 2012 or higher."
+        end
       end
 
       class << self


### PR DESCRIPTION
If you do not check the database version then the schema cache is not initialized. 

Fixes test `ActiveRecord::ConnectionAdapters::SchemaCacheTest.test_when_lazily_load_schema_cache_is_set_cache_is_lazily_populated_when_est_connection`.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6496031218/job/17642131292
```
Error:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_when_lazily_load_schema_cache_is_set_cache_is_lazily_populated_when_est_connection:
NoMethodError: undefined method `size' for nil:NilClass
    rails (319256ac4708) activerecord/test/cases/connection_adapters/schema_cache_test.rb:392:in `test_when_lazily_load_schema_cache_is_set_cache_is_lazily_populated_when_est_connection'
```