### PR TITLE
Removed legacy connection handling

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -467,12 +467,15 @@ module ActiveRecord
 
         # TODO: Remove
         def dblib_execute(sql)
-          @raw_connection.execute(sql).tap do |result|
-            # TinyTDS returns false instead of raising an exception if connection fails.
-            # Getting around this by raising an exception ourselves while this PR
-            # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
-            raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
-          end
+          throw NotImplementedError
+
+
+          # @raw_connection.execute(sql).tap do |result|
+          #   # TinyTDS returns false instead of raising an exception if connection fails.
+          #   # Getting around this by raising an exception ourselves while this PR
+          #   # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
+          #   raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
+          # end
         end
 
         def ensure_established_connection!

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -381,12 +381,12 @@ module ActiveRecord
         end
 
 
-        def raw_connection_do(sql)
-          result = ensure_established_connection! { dblib_execute(sql) }
-          result.do
-        ensure
-          @update_sql = false
-        end
+        # def raw_connection_do(sql)
+        #   result = ensure_established_connection! { dblib_execute(sql) }
+        #   result.do
+        # ensure
+        #   @update_sql = false
+        # end
 
         # === SQLServer Specific (Identity Inserts) ===================== #
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -312,20 +312,23 @@ module ActiveRecord
 
         # === SQLServer Specific (Executing) ============================ #
 
-        # TODO: Adapter should be refactored to use `with_raw_connection` to translate exceptions.
-        def sp_executesql(sql, name, binds, options = {})
-          options[:ar_result] = true if options[:fetch] != :rows
-
-          unless without_prepared_statement?(binds)
-            types, params = sp_executesql_types_and_parameters(binds)
-            sql = sp_executesql_sql(sql, types, params, name)
-          end
-
-          raw_select sql, name, binds, options
-        rescue => original_exception
-          translated_exception = translate_exception_class(original_exception, sql, binds)
-          raise translated_exception
-        end
+        # # TODO: Adapter should be refactored to use `with_raw_connection` to translate exceptions.
+        # def sp_executesql(sql, name, binds)
+        #
+        #   internal_exec_query(sql, name, binds)
+        #
+        # #   options[:ar_result] = true if options[:fetch] != :rows
+        # #
+        # #   unless without_prepared_statement?(binds)
+        # #     types, params = sp_executesql_types_and_parameters(binds)
+        # #     sql = sp_executesql_sql(sql, types, params, name)
+        # #   end
+        # #
+        # #   raw_select sql, name, binds, options
+        # # rescue => original_exception
+        # #   translated_exception = translate_exception_class(original_exception, sql, binds)
+        # #   raise translated_exception
+        # end
 
         def sp_executesql_types_and_parameters(binds)
           types, params = [], []
@@ -377,6 +380,7 @@ module ActiveRecord
           sql.freeze
         end
 
+
         def raw_connection_do(sql)
           result = ensure_established_connection! { dblib_execute(sql) }
           result.do
@@ -422,20 +426,25 @@ module ActiveRecord
 
         # === SQLServer Specific (Selecting) ============================ #
 
-        def raw_select(sql, name = "SQL", binds = [], options = {})
-          log(sql, name, binds, async: options[:async]) { _raw_select(sql, options) }
-        end
+        # TODO: Need to remove?
+        # def raw_select(sql, name = "SQL", binds = [], options = {})
+        #   log(sql, name, binds, async: options[:async]) { _raw_select(sql, options) }
+        # end
 
-        def _raw_select(sql, options = {})
-          handle = raw_connection_run(sql)
+        # TODO: Rename to `raw_select`?
+        def _raw_select(sql, conn, options = {})
+          # handle = raw_connection_run(sql, conn)
+
+          handle = _execute(sql, conn)
+
           handle_to_names_and_values(handle, options)
         ensure
           finish_statement_handle(handle)
         end
 
-        def raw_connection_run(sql)
-          ensure_established_connection! { dblib_execute(sql) }
-        end
+        # def raw_connection_run(sql, connection)
+        #   dblib_execute(sql, connection)
+        # end
 
         def handle_to_names_and_values(handle, options = {})
           query_options = {}.tap do |qo|
@@ -453,7 +462,7 @@ module ActiveRecord
           handle
         end
 
-        # TODO: Rename
+        # TODO: Rename to `raw_execute`?
         def _execute(sql, conn, perform_do: false)
           result = conn.execute(sql).tap do |_result|
             # TinyTDS returns false instead of raising an exception if connection fails.
@@ -465,18 +474,18 @@ module ActiveRecord
           perform_do ? result.do : result
         end
 
-        # TODO: Remove
-        def dblib_execute(sql)
-          throw NotImplementedError
-
-
-          # @raw_connection.execute(sql).tap do |result|
-          #   # TinyTDS returns false instead of raising an exception if connection fails.
-          #   # Getting around this by raising an exception ourselves while this PR
-          #   # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
-          #   raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
-          # end
-        end
+        # # TODO: Remove
+        # def dblib_execute(sql, connection)
+        #   # throw NotImplementedError
+        #
+        #
+        #   connection.execute(sql).tap do |result|
+        #     # TinyTDS returns false instead of raising an exception if connection fails.
+        #     # Getting around this by raising an exception ourselves while this PR
+        #     # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
+        #     raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
+        #   end
+        # end
 
         def ensure_established_connection!
           raise TinyTds::Error, 'SQL Server client is not connected' unless @raw_connection

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -434,12 +434,6 @@ module ActiveRecord
 
           perform_do ? result.do : result
         end
-
-        def ensure_established_connection!
-          raise TinyTds::Error, 'SQL Server client is not connected' unless @raw_connection
-
-          yield
-        end
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -400,7 +400,7 @@ module ActiveRecord
 
         # === SQLServer Specific (Selecting) ============================ #
 
-        def raw_select(sql, conn, options = {})
+        def _raw_select(sql, conn, options = {})
           handle = internal_raw_execute(sql, conn)
 
           handle_to_names_and_values(handle, options)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -124,13 +124,7 @@ module ActiveRecord
           binds << Relation::QueryAttribute.new("TABLE_NAME", identifier.object, nv128)
           binds << Relation::QueryAttribute.new("TABLE_SCHEMA", identifier.schema, nv128) unless identifier.schema.blank?
 
-
-
-          # binding.pry
-
           internal_exec_query(sql, "SCHEMA", binds).map { |row| row["name"] }
-
-          # sp_executesql(sql, "SCHEMA", binds).map { |r| r["name"] }
         end
 
         def rename_table(table_name, new_name, **options)
@@ -430,13 +424,12 @@ module ActiveRecord
           view_tblnm  = view_table_name(table_name) if view_exists
 
           if view_exists
-            sql = %{
+            sql = <<~SQL
               SELECT LOWER(c.COLUMN_NAME) AS [name], c.COLUMN_DEFAULT AS [default]
               FROM #{database}.INFORMATION_SCHEMA.COLUMNS c
               WHERE c.TABLE_NAME = #{quote(view_tblnm)}
-            }.squish
-
-            results = internal_exec_query(sql, "SCHEMA", [])
+            SQL
+            results = internal_exec_query(sql, "SCHEMA")
             default_functions = results.each.with_object({}) { |row, out| out[row["name"]] = row["default"] }.compact
           end
 

--- a/lib/active_record/connection_adapters/sqlserver/showplan.rb
+++ b/lib/active_record/connection_adapters/sqlserver/showplan.rb
@@ -30,7 +30,9 @@ module ActiveRecord
 
         def set_showplan_option(enable = true)
           sql = "SET #{showplan_option} #{enable ? 'ON' : 'OFF'}"
-          raw_connection_do(sql)
+          # raw_connection_do(sql)
+
+          raw_execute(sql, "SCHEMA")
         rescue Exception
           raise ActiveRecordError, "#{showplan_option} could not be turned #{enable ? 'ON' : 'OFF'}, perhaps you do not have SHOWPLAN permissions?"
         end

--- a/lib/active_record/connection_adapters/sqlserver/showplan.rb
+++ b/lib/active_record/connection_adapters/sqlserver/showplan.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
         def explain(arel, binds = [], options = [])
           sql = to_sql(arel)
-          result = with_showplan_on { sp_executesql(sql, "EXPLAIN", binds) }
+          result = with_showplan_on { internal_exec_query(sql, "EXPLAIN", binds) }
           printer = showplan_printer.new(result)
           printer.pp
         end

--- a/lib/active_record/connection_adapters/sqlserver/showplan.rb
+++ b/lib/active_record/connection_adapters/sqlserver/showplan.rb
@@ -30,8 +30,6 @@ module ActiveRecord
 
         def set_showplan_option(enable = true)
           sql = "SET #{showplan_option} #{enable ? 'ON' : 'OFF'}"
-          # raw_connection_do(sql)
-
           raw_execute(sql, "SCHEMA")
         rescue Exception
           raise ActiveRecordError, "#{showplan_option} could not be turned #{enable ? 'ON' : 'OFF'}, perhaps you do not have SHOWPLAN permissions?"

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -501,7 +501,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection, fetch: :rows).first.first.to_s
+        @sqlserver_version ||= raw_select("SELECT @@version", @raw_connection, fetch: :rows).first.first.to_s
       end
 
       private
@@ -526,11 +526,7 @@ module ActiveRecord
         @raw_connection.execute("SET TEXTSIZE 2147483647").do
         @raw_connection.execute("SET CONCAT_NULL_YIELDS_NULL ON").do
 
-        # binding.pry
-
-        # result = @raw_connection.execute("SELECT @@SPID")
-
-        @spid = _raw_select("SELECT @@SPID", @raw_connection, fetch: :rows).first.first
+        @spid = raw_select("SELECT @@SPID", @raw_connection, fetch: :rows).first.first
 
         initialize_dateformatter
         use_database

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -234,10 +234,7 @@ module ActiveRecord
       # === Abstract Adapter (Connection Management) ================== #
 
       def active?
-        return false unless @raw_connection
-
-        raw_connection_do "SELECT 1"
-        true
+        @raw_connection&.active?
       rescue *connection_errors
         false
       end
@@ -504,7 +501,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", fetch: :rows).first.first.to_s
+        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection, fetch: :rows).first.first.to_s
       end
 
       private
@@ -529,7 +526,11 @@ module ActiveRecord
         @raw_connection.execute("SET TEXTSIZE 2147483647").do
         @raw_connection.execute("SET CONCAT_NULL_YIELDS_NULL ON").do
 
-        @spid = _raw_select("SELECT @@SPID", fetch: :rows).first.first
+        # binding.pry
+
+        # result = @raw_connection.execute("SELECT @@SPID")
+
+        @spid = _raw_select("SELECT @@SPID", @raw_connection, fetch: :rows).first.first
 
         initialize_dateformatter
         use_database

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -501,7 +501,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= raw_select("SELECT @@version", @raw_connection, fetch: :rows).first.first.to_s
+        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection, fetch: :rows).first.first.to_s
       end
 
       private
@@ -526,7 +526,7 @@ module ActiveRecord
         @raw_connection.execute("SET TEXTSIZE 2147483647").do
         @raw_connection.execute("SET CONCAT_NULL_YIELDS_NULL ON").do
 
-        @spid = raw_select("SELECT @@SPID", @raw_connection, fetch: :rows).first.first
+        @spid = _raw_select("SELECT @@SPID", @raw_connection, fetch: :rows).first.first
 
         initialize_dateformatter
         use_database


### PR DESCRIPTION
Use `internal_exec_query` and `internal_raw_execute` to run queries instead of `raw_connection_do` and `raw_connection_run`. The new methods standardise connection handling.