### PR TITLE
Coerce tests that are not testing SQL Server

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1605,6 +1605,9 @@ class SchemaDumperTest < ActiveRecord::TestCase
     output = dump_all_table_schema([/^[^n]/])
     assert_match %r{precision: 3,[[:space:]]+scale: 2,[[:space:]]+default: 2\.78}, output
   end
+
+  # Tests are not about a specific adapter.
+  coerce_tests! :test_do_not_dump_foreign_keys_when_bypassed_by_config
 end
 
 class SchemaDumperDefaultsTest < ActiveRecord::TestCase
@@ -2609,6 +2612,47 @@ end
 class StoreTest < ActiveRecord::TestCase
   # Set the attribute as JSON type for the `StoreTest#saved changes tracking for accessors with json column` test.
   Admin::User.attribute :json_options, ActiveRecord::Type::SQLServer::Json.new
+end
+
+class TestDatabasesTest < ActiveRecord::TestCase
+  # Tests are not about a specific adapter.
+  coerce_all_tests!
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionHandlersShardingDbTest  < ActiveRecord::TestCase
+      # Tests are not about a specific adapter.
+      coerce_all_tests!
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionSwappingNestedTest < ActiveRecord::TestCase
+      # Tests are not about a specific adapter.
+      coerce_all_tests!
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionHandlersMultiDbTest < ActiveRecord::TestCase
+      # Tests are not about a specific adapter.
+      coerce_tests! :test_switching_connections_via_handler
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionHandlersMultiPoolConfigTest < ActiveRecord::TestCase
+      # Tests are not about a specific adapter.
+      coerce_all_tests!
+    end
+  end
 end
 
 # TODO: Need to uncoerce the 'SerializedAttributeTest' tests before releasing adapter for Rails 7.1

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -27,7 +27,6 @@ module ActiveRecord
 
     setup :ensure_clean_rails_env
     setup :remove_backtrace_silencers
-    setup :cleanup_sqlite_databases
 
     private
 
@@ -37,12 +36,6 @@ module ActiveRecord
 
     def remove_backtrace_silencers
       Rails.backtrace_cleaner.remove_silencers!
-    end
-
-    # Cleanup the SQLite database created by previous runs of the Rails ActiveRecord test suite.
-    def cleanup_sqlite_databases
-      sqlite_db_dir = File.join(ARTest::SQLServer.test_root_sqlserver, "db")
-      Dir.glob("#{sqlite_db_dir}/**").each { |f| File.delete(f) }
     end
 
     def host_windows?


### PR DESCRIPTION
Coerce tests that are not testing SQL Server but using SQLite to test non-specific adapter functionality.

This fixes an issue with SQLite databases from previous tests runs causing tests to fail. Issue seems to have been caused by https://github.com/rails/rails/pull/38620

Previous attempt to remove the SQLite databases before the test suite runs doesn't work as multiple tests use the same databases.