### PR TITLE
Remove Ruby 2.7.8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.7.8
           - 3.0.6
           - 3.1.4
           - 3.2.2


### PR DESCRIPTION
Ruby 2.7.8 has reached EOL (https://www.ruby-lang.org/en/downloads/branches/).