### PR TITLE
Fix view issue with default column value not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Fixed
 
 - [#1113](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1113) Fix issue with default view value not being found because of case sensitivity
+- [#1126](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1113) Fix view issue with default column value not found
 
 ## v7.0.4.0
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -620,7 +620,7 @@ module ActiveRecord
           view_definition = view_information(table_name)[:VIEW_DEFINITION]
           return column_name unless view_definition
 
-          match_data = view_definition.match(/([\w-]*)\s+as\s+#{column_name}/im)
+          match_data = view_definition.match(/CREATE\s+VIEW.*AS\s+SELECT.*\W([\w-]*)\s+AS\s+#{column_name}/im)
           match_data ? match_data[1] : column_name
         end
 

--- a/test/cases/view_test_sqlserver.rb
+++ b/test/cases/view_test_sqlserver.rb
@@ -11,10 +11,18 @@ class ViewTestSQLServer < ActiveRecord::TestCase
       connection.create_table :view_casing_table, force: true do |t|
         t.boolean :Default_Falsey, null: false, default: false
         t.boolean :Default_Truthy, null: false, default: true
+        t.string  :default_string, null: false, default: "abc"
       end
 
       connection.execute("DROP VIEW IF EXISTS view_casing_table_view;")
-      connection.execute("CREATE VIEW view_casing_table_view AS SELECT id AS id, default_falsey AS falsey, default_truthy AS truthy FROM view_casing_table")
+      connection.execute <<-SQL
+        CREATE VIEW view_casing_table_view AS
+              SELECT id AS id,
+                     default_falsey AS falsey,
+                     default_truthy AS truthy,
+                     default_string AS s
+              FROM view_casing_table
+      SQL
     end
 
     it "default values are correct when column casing used in tables and views are different" do
@@ -25,11 +33,13 @@ class ViewTestSQLServer < ActiveRecord::TestCase
       obj = klass.new
       assert_equal false, obj.falsey
       assert_equal true, obj.truthy
+      assert_equal "abc", obj.s
       assert_equal 0, klass.count
 
       obj.save!
       assert_equal false, obj.falsey
       assert_equal true, obj.truthy
+      assert_equal "abc", obj.s
       assert_equal 1, klass.count
     end
   end


### PR DESCRIPTION
Issue https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1114

This PR fixes an issue where the default value of a view column is not found when the view column name starts with the same characters as "SELECT". So this issue would affect view columns named "s", "se", "sel", etc