### PR TITLE
Do not coerce the SerializedAttributeTest tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2595,8 +2595,3 @@ module ActiveRecord
     end
   end
 end
-
-# TODO: Need to uncoerce the 'SerializedAttributeTest' tests before releasing adapter for Rails 7.1
-class SerializedAttributeTest < ActiveRecord::TestCase
-  coerce_all_tests!
-end


### PR DESCRIPTION
No need to coerce the `SerializedAttributeTest` tests. 