### PR TITLE
Reset connections after READ COMMITTED isolation test

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,7 @@ services:
   ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=sqlserver
-      - CI=true
+      - SQLSERVER_CI=true
     build:
       context: .
       dockerfile: Dockerfile.ci

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,6 @@ services:
   ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=sqlserver
-      - SQLSERVER_CI=true
     build:
       context: .
       dockerfile: Dockerfile.ci

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,6 +5,7 @@ services:
   ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=sqlserver
+      - CI=true
     build:
       context: .
       dockerfile: Dockerfile.ci

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -54,7 +54,7 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
 
   describe "when READ_COMMITTED_SNAPSHOT is set" do
     it "should use READ COMMITTED as an isolation level" do
-      skip "This test sometimes causes subsequent tests to fail with error 'DBPROCESS is dead or not enabled'. The test passes if run alone."
+      skip "This test sometimes causes subsequent tests to fail with error 'DBPROCESS is dead or not enabled'. The test passes if run alone." if ENV["CI"]
 
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET ALLOW_SNAPSHOT_ISOLATION ON"
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE"

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -54,7 +54,7 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
 
   describe "when READ_COMMITTED_SNAPSHOT is set" do
     it "should use READ COMMITTED as an isolation level" do
-      skip "This test sometimes causes subsequent tests to fail with error 'DBPROCESS is dead or not enabled'. The test passes if run alone." if ENV["CI"]
+      skip "This test sometimes causes subsequent tests to fail with error 'DBPROCESS is dead or not enabled'. The test passes if run alone." if ENV["SQLSERVER_CI"]
 
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET ALLOW_SNAPSHOT_ISOLATION ON"
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE"

--- a/test/cases/transaction_test_sqlserver.rb
+++ b/test/cases/transaction_test_sqlserver.rb
@@ -53,17 +53,12 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
   end
 
   describe "when READ_COMMITTED_SNAPSHOT is set" do
-    before do
+    it "should use READ COMMITTED as an isolation level" do
+      skip "This test sometimes causes subsequent tests to fail with error 'DBPROCESS is dead or not enabled'. The test passes if run alone."
+
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET ALLOW_SNAPSHOT_ISOLATION ON"
       connection.execute "ALTER DATABASE [#{connection.current_database}] SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE"
-    end
 
-    after do
-      connection.execute "ALTER DATABASE [#{connection.current_database}] SET ALLOW_SNAPSHOT_ISOLATION OFF"
-      connection.execute "ALTER DATABASE [#{connection.current_database}] SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE"
-    end
-
-    it "should use READ COMMITTED as an isolation level" do
       _(connection.user_options_isolation_level).must_match "read committed snapshot"
 
       Ship.transaction(isolation: :serializable) do
@@ -74,6 +69,10 @@ class TransactionTestSQLServer < ActiveRecord::TestCase
       # "READ COMMITTED", and that no exception was raised (it's reported back
       # by SQL Server as "read committed snapshot").
       _(connection.user_options_isolation_level).must_match "read committed snapshot"
+
+    ensure
+      connection.execute "ALTER DATABASE [#{connection.current_database}] SET ALLOW_SNAPSHOT_ISOLATION OFF"
+      connection.execute "ALTER DATABASE [#{connection.current_database}] SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE"
     end
   end
 


### PR DESCRIPTION
Reset database connections after `TransactionTestSQLServer#should use READ COMMITTED as an isolation level`. This test sometimes causes the following tests to fail with the "TinyTds::Error: DBPROCESS is dead or not enabled" error (see https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6783660587/job/18438377982?pr=1130). 