### PR TITLE
Reintroduce visit_Arel_Nodes_HomogeneousIn monkey-patch

### DIFF
--- a/lib/active_record/tasks/sqlserver_database_tasks.rb
+++ b/lib/active_record/tasks/sqlserver_database_tasks.rb
@@ -53,7 +53,7 @@ module ActiveRecord
       end
 
       def clear_active_connections!
-        ActiveRecord::Base.connection_handler.clear_active_connections!
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
       end
 
       def structure_dump(filename, extra_flags)

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -67,7 +67,7 @@ module Arel
       def visit_Arel_Nodes_HomogeneousIn(o, collector)
         collector.preparable = false
 
-        collector = visit o.left, collector
+        visit o.left, collector
 
         if o.type == :in
           collector << " IN ("
@@ -90,7 +90,7 @@ module Arel
           collector.add_binds(attrs, &bind_block)
           # Monkey-patch end.
         else
-          collector.add_binds(values, &bind_block)
+          collector.add_binds(values, o.proc_for_binds, &bind_block)
         end
 
         collector << ")"

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -83,11 +83,14 @@ module Arel
           # Monkey-patch start. Add query attribute bindings rather than just values.
           column_name = o.attribute.name
           column_type = o.attribute.relation.type_for_attribute(column_name)
-          # Use cast_type on encrypted attributes. Don't encrypt them again
-          column_type = column_type.cast_type if column_type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
-          attrs = values.map { |value| ActiveRecord::Relation::QueryAttribute.new(column_name, value, column_type) }
+          column_type = column_type.cast_type if column_type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType) # Use cast_type on encrypted attributes. Don't encrypt them again
 
-          collector.add_binds(attrs, &bind_block)
+          if column_type.serialized?
+            collector.add_binds(values, o.proc_for_binds, &bind_block)
+          else
+            attrs = values.map { |value| ActiveRecord::Relation::QueryAttribute.new(column_name, value, column_type) }
+            collector.add_binds(attrs, &bind_block)
+          end
           # Monkey-patch end.
         else
           collector.add_binds(values, o.proc_for_binds, &bind_block)


### PR DESCRIPTION
The `visit_Arel_Nodes_HomogeneousIn` method was incorrectly removed in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1068. This PR adds the method back in while also fixing the method for Rails 7.1

This fixes the following failing test that started in Rails 7.1.2 (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/6849256715/job/18621067933?pr=1136):

```
Failure:
ActiveRecord::BindParameterTest#test_bind_params_to_sql_with_prepared_statements_coerced [/activerecord-sqlserver-adapter/test/cases/coerced_tests.rb:298]:
Query pattern(s) "EXEC sp_executesql N'SELECT [authors].* FROM [authors] WHERE ([authors].[id] IN (@0, @1, @2) OR [authors].[id] IS NULL)', N'@0 bigint, @1 bigint, @2 bigint', @0 = 1, @1 = 2, @2 = 3" not found.
Queries:
EXEC sp_executesql N'SELECT [authors].* FROM [authors] WHERE ([authors].[id] IN (@0, @1, @2) OR [authors].[id] IS NULL)', N'@0 int, @1 int, @2 int', @0 = 1, @1 = 2, @2 = 3

bin/rails test /activerecord-sqlserver-adapter/test/cases/coerced_tests.rb:297
```

The method has also been updated for serialized columns so that the `SerializedAttributeTest#test_where_by_serialized_attribute_with_hash_in_array` test passes.