### PR TITLE
Added support for check constraints (#1141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Added
+
+- [#1141](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1141) Added support for check constraints.
+
 ## v7.0.5.1
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -250,7 +250,7 @@ module ActiveRecord
             st.name = '#{table_name}'
           SQL
 
-          chk_info = internal_exec_query(sql, "SCHEMA")
+          chk_info = exec_query(sql, "SCHEMA")
 
           chk_info.map do |row|
             options = {

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -240,6 +240,29 @@ module ActiveRecord
           end
         end
 
+        def check_constraints(table_name)
+          sql = <<~SQL
+            select chk.name AS 'name',
+                   chk.definition AS 'expression'
+            from sys.check_constraints chk
+            inner join sys.tables st on chk.parent_object_id = st.object_id
+            where
+            st.name = '#{table_name}'
+          SQL
+
+          chk_info = internal_exec_query(sql, "SCHEMA")
+
+          chk_info.map do |row|
+            options = {
+              name: row["name"]
+            }
+            expression = row["expression"]
+            expression = expression[1..-2] if expression.start_with?("(") && expression.end_with?(")")
+
+            CheckConstraintDefinition.new(table_name, expression, options)
+          end
+        end
+
         def type_to_sql(type, limit: nil, precision: nil, scale: nil, **)
           type_limitable = %w(string integer float char nchar varchar nvarchar).include?(type.to_s)
           limit = nil unless type_limitable

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -228,6 +228,10 @@ module ActiveRecord
         true
       end
 
+      def supports_check_constraints?
+        true
+      end
+
       def supports_json?
         @version_year >= 2016
       end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2345,9 +2345,6 @@ module ActiveRecord
         assert_equal "trades", constraint.table_name
         assert_equal "price_check", constraint.name
         assert_equal "[price]>(0)", constraint.expression
-
-        @connection.remove_check_constraint :trades, name: :price_check # name as a symbol
-        assert_empty @connection.check_constraints("trades")
       end
     end
   end


### PR DESCRIPTION
Back-port https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1141 to the `7-0-stable` branch.