### PR TITLE
Fix precision handling in time migration

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -303,6 +303,15 @@ module ActiveRecord
             when 5..8       then  "bigint"
             else raise(ActiveRecordError, "No integer type has byte size #{limit}. Use a numeric with precision 0 instead.")
             end
+          when "time"
+            # default value of precision for time is 7
+            # see https://learn.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql
+            precision ||= 7
+            if (0..7) === precision
+              "time(#{precision})"
+            else
+              raise(ActiveRecordError, "The time type has precision of #{precision}. The allowed range of precision is from 0 to 7")
+            end
           when "datetime2"
             column_type_sql = super
             if precision

--- a/test/cases/create_precision_7_column_test_sqlserver.rb
+++ b/test/cases/create_precision_7_column_test_sqlserver.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+require "migrations/create_table_with_precision_7_time"
+
+class CreatePrecision7ColumnTestSQLServer < ActiveRecord::TestCase
+  before do
+    @old_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after do
+    CreateTableWithPrecision7Time.new.down
+    ActiveRecord::Migration.verbose = @old_verbose
+  end
+
+  it "can add time column whose precision is 7" do
+    assert_nothing_raised { CreateTableWithPrecision7Time.new.up }
+  end
+end

--- a/test/migrations/create_table_with_precision_7_time.rb
+++ b/test/migrations/create_table_with_precision_7_time.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateTableWithPrecision7Time < ActiveRecord::Migration[5.2]
+  def up
+    create_table :test_precision_7_time do |t|
+      t.time :time_with_precision_7, precision: 7
+    end
+  end
+
+  def down
+    drop_table :test_precision_7_time
+  end
+end


### PR DESCRIPTION
Resolved an issue where creating a time column with a precision of 7 would trigger the following error.

> ArgumentError: No time type has precision of 7. The allowed range of precision is from 0 to 6 (ArgumentError)