### PR TITLE
Added Dev Container CLI to run the tests

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,80 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
+
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
+ARG VARIANT="3"
+FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+#ARG NODE_VERSION="lts/*"
+#RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        mariadb-client libmariadb-dev \
+        postgresql-client postgresql-contrib libpq-dev \
+        ffmpeg mupdf mupdf-tools libvips poppler-utils
+
+
+#apt-get -y install "$@" >/dev/null 2>&1 \
+
+
+# TinyTDS
+RUN apt-get -y install libc6-dev \
+    && wget http://www.freetds.org/files/stable/freetds-1.1.32.tar.gz \
+    && tar -xzf freetds-1.1.32.tar.gz \
+    && cd freetds-1.1.32 \
+    && ./configure --prefix=/usr/local --with-tdsver=7.3 \
+    && make \
+    && make install
+
+# Install the SQL Server command-line tools
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc \
+    && curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
+    && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> /root/.bashrc
+
+
+#ARG IMAGEMAGICK_VERSION="7.1.0-5"
+#RUN wget -qO /tmp/im.tar.xz https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz \
+#    && wget -qO /tmp/im.sig https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz.asc \
+#    && gpg --batch --keyserver keyserver.ubuntu.com --recv 89AB63D48277377A \
+#    && gpg --batch --verify /tmp/im.sig /tmp/im.tar.xz \
+#    && tar xJf /tmp/im.tar.xz -C /tmp \
+#    && cd /tmp/ImageMagick-$IMAGEMAGICK_VERSION \
+#    && ./configure --with-rsvg && make -j 9 && make install \
+#    && ldconfig /usr/local/lib \
+#    && rm -rf /tmp/*
+
+# Add the Rails main Gemfile and install the gems. This means the gem install can be done
+# during build instead of on start. When a fork or branch has different gems, we still have an
+# advantage due to caching of the other gems.
+#RUN mkdir -p /tmp/rails
+#COPY Gemfile Gemfile.lock RAILS_VERSION rails.gemspec package.json yarn.lock /tmp/rails/
+#COPY actioncable/actioncable.gemspec /tmp/rails/actioncable/
+#COPY actionmailbox/actionmailbox.gemspec /tmp/rails/actionmailbox/
+#COPY actionmailer/actionmailer.gemspec /tmp/rails/actionmailer/
+#COPY actionpack/actionpack.gemspec /tmp/rails/actionpack/
+#COPY actiontext/actiontext.gemspec /tmp/rails/actiontext/
+#COPY actionview/actionview.gemspec /tmp/rails/actionview/
+#COPY activejob/activejob.gemspec /tmp/rails/activejob/
+#COPY activemodel/activemodel.gemspec /tmp/rails/activemodel/
+#COPY activerecord/activerecord.gemspec /tmp/rails/activerecord/
+#COPY activestorage/activestorage.gemspec /tmp/rails/activestorage/
+#COPY activesupport/activesupport.gemspec /tmp/rails/activesupport/
+#COPY railties/railties.gemspec /tmp/rails/railties/
+#RUN cd /tmp/rails \
+#    && bundle install \
+#    && yarn install \
+#    && rm -rf /tmp/rails
+#RUN chown -R vscode:vscode /usr/local/rvm
+
+# Add the SQL Server main Gemfile and install the gems.
+RUN mkdir -p /tmp/activerecord-sqlserver-adapter
+COPY Gemfile VERSION activerecord-sqlserver-adapter.gemspec /tmp/activerecord-sqlserver-adapter/
+RUN cd /tmp/activerecord-sqlserver-adapter \
+    && bundle install \
+    && rm -rf /tmp/activerecord-sqlserver-adapter
+RUN chown -R vscode:vscode /usr/local/rvm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,13 +4,6 @@
 ARG VARIANT="3"
 FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
-        mariadb-client libmariadb-dev \
-        postgresql-client postgresql-contrib libpq-dev \
-        ffmpeg mupdf mupdf-tools libvips poppler-utils
-
 # TinyTDS
 RUN apt-get -y install libc6-dev \
     && wget http://www.freetds.org/files/stable/freetds-1.1.32.tar.gz \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,20 +4,12 @@
 ARG VARIANT="3"
 FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-#ARG NODE_VERSION="lts/*"
-#RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
-
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
         ffmpeg mupdf mupdf-tools libvips poppler-utils
-
-
-#apt-get -y install "$@" >/dev/null 2>&1 \
-
 
 # TinyTDS
 RUN apt-get -y install libc6-dev \
@@ -35,41 +27,6 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/t
     && ACCEPT_EULA=Y apt-get install -y mssql-tools18 unixodbc-dev \
     && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
     && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> /root/.bashrc
-
-
-#ARG IMAGEMAGICK_VERSION="7.1.0-5"
-#RUN wget -qO /tmp/im.tar.xz https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz \
-#    && wget -qO /tmp/im.sig https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz.asc \
-#    && gpg --batch --keyserver keyserver.ubuntu.com --recv 89AB63D48277377A \
-#    && gpg --batch --verify /tmp/im.sig /tmp/im.tar.xz \
-#    && tar xJf /tmp/im.tar.xz -C /tmp \
-#    && cd /tmp/ImageMagick-$IMAGEMAGICK_VERSION \
-#    && ./configure --with-rsvg && make -j 9 && make install \
-#    && ldconfig /usr/local/lib \
-#    && rm -rf /tmp/*
-
-# Add the Rails main Gemfile and install the gems. This means the gem install can be done
-# during build instead of on start. When a fork or branch has different gems, we still have an
-# advantage due to caching of the other gems.
-#RUN mkdir -p /tmp/rails
-#COPY Gemfile Gemfile.lock RAILS_VERSION rails.gemspec package.json yarn.lock /tmp/rails/
-#COPY actioncable/actioncable.gemspec /tmp/rails/actioncable/
-#COPY actionmailbox/actionmailbox.gemspec /tmp/rails/actionmailbox/
-#COPY actionmailer/actionmailer.gemspec /tmp/rails/actionmailer/
-#COPY actionpack/actionpack.gemspec /tmp/rails/actionpack/
-#COPY actiontext/actiontext.gemspec /tmp/rails/actiontext/
-#COPY actionview/actionview.gemspec /tmp/rails/actionview/
-#COPY activejob/activejob.gemspec /tmp/rails/activejob/
-#COPY activemodel/activemodel.gemspec /tmp/rails/activemodel/
-#COPY activerecord/activerecord.gemspec /tmp/rails/activerecord/
-#COPY activestorage/activestorage.gemspec /tmp/rails/activestorage/
-#COPY activesupport/activesupport.gemspec /tmp/rails/activesupport/
-#COPY railties/railties.gemspec /tmp/rails/railties/
-#RUN cd /tmp/rails \
-#    && bundle install \
-#    && yarn install \
-#    && rm -rf /tmp/rails
-#RUN chown -R vscode:vscode /usr/local/rvm
 
 # Add the SQL Server main Gemfile and install the gems.
 RUN mkdir -p /tmp/activerecord-sqlserver-adapter

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,0 +1,27 @@
+#bundle install
+#yarn install
+
+sudo chown -R vscode:vscode /usr/local/bundle
+
+#cd activerecord
+#
+## Create PostgreSQL databases
+#bundle exec rake db:postgresql:rebuild
+#
+## Create MySQL databases
+#MYSQL_CODESPACES=1 bundle exec rake db:mysql:rebuild
+
+
+/opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "MSSQLadmin!" <<SQL
+CREATE DATABASE [activerecord_unittest];
+CREATE DATABASE [activerecord_unittest2];
+GO
+CREATE LOGIN [rails] WITH PASSWORD = '', CHECK_POLICY = OFF, DEFAULT_DATABASE = [activerecord_unittest];
+GO
+USE [activerecord_unittest];
+CREATE USER [rails] FOR LOGIN [rails];
+GO
+EXEC sp_addrolemember N'db_owner', N'rails';
+EXEC master..sp_addsrvrolemember @loginame = N'rails', @rolename = N'sysadmin';
+GO
+SQL

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,17 +1,9 @@
-#bundle install
-#yarn install
-
 sudo chown -R vscode:vscode /usr/local/bundle
 
-#cd activerecord
-#
-## Create PostgreSQL databases
-#bundle exec rake db:postgresql:rebuild
-#
-## Create MySQL databases
-#MYSQL_CODESPACES=1 bundle exec rake db:mysql:rebuild
+# Wait for 5 seconds to make sure SQL Server came up.
+sleep 5
 
-
+# Setup test databases and users.
 /opt/mssql-tools18/bin/sqlcmd -C -S sqlserver -U sa -P "MSSQLadmin!" <<SQL
 CREATE DATABASE [activerecord_unittest];
 CREATE DATABASE [activerecord_unittest2];
@@ -25,3 +17,6 @@ EXEC sp_addrolemember N'db_owner', N'rails';
 EXEC master..sp_addsrvrolemember @loginame = N'rails', @rolename = N'sysadmin';
 GO
 SQL
+
+# Mark directory as safe in Git so that commands run without warnings.
+git config --global --add safe.directory /workspaces/activerecord-sqlserver-adapter

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "ActiveRecord SQL Server Adapter project development",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "activerecord-sqlserver-adapter",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"version": "latest"
+		}
+	},
+
+	"containerEnv": {
+    "ACTIVERECORD_UNITTEST_HOST": "sqlserver"
+//		"PGHOST": "postgres",
+//		"PGUSER": "postgres",
+//		"PGPASSWORD": "postgres",
+//		"MYSQL_HOST": "mariadb",
+//		"REDIS_URL": "redis://redis/0",
+//		"MEMCACHE_SERVERS": "memcached:11211"
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	// "forwardPorts": [3000, 5432],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/boot.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"Shopify.ruby-lsp"
+			]
+		}
+	},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,6 @@
 
 	"containerEnv": {
     "ACTIVERECORD_UNITTEST_HOST": "sqlserver"
-//		"PGHOST": "postgres",
-//		"PGUSER": "postgres",
-//		"PGPASSWORD": "postgres",
-//		"MYSQL_HOST": "mariadb",
-//		"REDIS_URL": "redis://redis/0",
-//		"MEMCACHE_SERVERS": "memcached:11211"
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,10 +18,6 @@ services:
 
     depends_on:
       - sqlserver
-#      - postgres
-#      - mariadb
-#      - redis
-#      - memcached
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
@@ -35,47 +31,5 @@ services:
       MSSQL_SA_PASSWORD: MSSQLadmin!
       ACCEPT_EULA: Y
 
-#  postgres:
-#    image: postgres:latest
-#    restart: unless-stopped
-#    networks:
-#      - default
-#    volumes:
-#      - postgres-data:/var/lib/postgresql/data
-#    environment:
-#      POSTGRES_USER: postgres
-#      POSTGRES_DB: postgres
-#      POSTGRES_PASSWORD: postgres
-#
-#  mariadb:
-#    image: mariadb:latest
-#    restart: unless-stopped
-#    networks:
-#      - default
-#    volumes:
-#      - mariadb-data:/var/lib/mysql
-#    environment:
-#      MARIADB_ROOT_PASSWORD: root
-#
-#  redis:
-#    image: redis:latest
-#    restart: unless-stopped
-#    networks:
-#      - default
-#    volumes:
-#      - redis-data:/data
-#
-#  memcached:
-#    image: memcached:latest
-#    restart: unless-stopped
-#    command: ["-m", "1024"]
-#    networks:
-#      - default
-
 networks:
   default:
-
-#volumes:
-#  postgres-data:
-#  mariadb-data:
-#  redis-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,81 @@
+version: '3'
+
+services:
+  activerecord-sqlserver-adapter:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    networks:
+      - default
+
+    depends_on:
+      - sqlserver
+#      - postgres
+#      - mariadb
+#      - redis
+#      - memcached
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    restart: unless-stopped
+    networks:
+      - default
+    environment:
+      MSSQL_SA_PASSWORD: MSSQLadmin!
+      ACCEPT_EULA: Y
+
+#  postgres:
+#    image: postgres:latest
+#    restart: unless-stopped
+#    networks:
+#      - default
+#    volumes:
+#      - postgres-data:/var/lib/postgresql/data
+#    environment:
+#      POSTGRES_USER: postgres
+#      POSTGRES_DB: postgres
+#      POSTGRES_PASSWORD: postgres
+#
+#  mariadb:
+#    image: mariadb:latest
+#    restart: unless-stopped
+#    networks:
+#      - default
+#    volumes:
+#      - mariadb-data:/var/lib/mysql
+#    environment:
+#      MARIADB_ROOT_PASSWORD: root
+#
+#  redis:
+#    image: redis:latest
+#    restart: unless-stopped
+#    networks:
+#      - default
+#    volumes:
+#      - redis-data:/data
+#
+#  memcached:
+#    image: memcached:latest
+#    restart: unless-stopped
+#    command: ["-m", "1024"]
+#    networks:
+#      - default
+
+networks:
+  default:
+
+#volumes:
+#  postgres-data:
+#  mariadb-data:
+#  redis-data:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ more detailed information on running unit tests.
 ### Dev Container CLI
 
 With [Docker](https://www.docker.com) and [npm](https://github.com/npm/cli) installed, you can run [Dev Container CLI](https://github.com/devcontainers/cli) to
-utilize the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration from the command line.
+utilize the [`.devcontainer`](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/tree/main/.devcontainer) configuration from the command line.
 
 ```bash
 $ npm install -g @devcontainers/cli

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ setup your development environment.
 
 ## Setting Up Your Development Environment
 
-To run the test suite you can use any of the following methods.
+To run the test suite you can use any of the following methods below. See [RUNNING_UNIT_TESTS](RUNNING_UNIT_TESTS.md) for
+more detailed information on running unit tests.
 
 ### Dev Container CLI
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,48 @@ gem 'activerecord-sqlserver-adapter'
 
 ## Contributing
 
-If you would like to contribute a feature or bugfix, thanks! To make sure your fix/feature has a high chance of being added, please read the following guidelines. First, ask on the Gitter, or post a ticket on github issues. Second, make sure there are tests! We will not accept any patch that is not tested. Please read the [`RUNNING_UNIT_TESTS`](RUNNING_UNIT_TESTS.md) file for the details of how to run the unit tests.
+Please contribute to the project by submitting bug fixes and features. To make sure your fix/feature has
+a high chance of being added, please include tests in your pull request. To run the tests you will need to
+setup your development environment.
 
-* Github: http://github.com/rails-sqlserver/activerecord-sqlserver-adapter
-* Gitter: https://gitter.im/rails-sqlserver/activerecord-sqlserver-adapter
+## Setting Up Your Development Environment
 
+To run the test suite you can use any of the following methods.
+
+### Dev Container CLI
+
+With [Docker](https://www.docker.com) and [npm](https://github.com/npm/cli) installed, you can run [Dev Container CLI](https://github.com/devcontainers/cli) to
+utilize the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration from the command line.
+
+```bash
+$ npm install -g @devcontainers/cli
+$ cd rails
+$ devcontainer up --workspace-folder .
+$ devcontainer exec --workspace-folder . bash
+```
+
+From within the container, you can run the tests using the following command:
+
+```bash
+$ bundle install
+$ bundle exec rake test
+```
+
+_Note: The setup we use is based on the [Rails Dev Container setup.](https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#using-dev-container-cli)_
+
+### VirtualBox & Vagrant
+
+The [activerecord-sqlserver-adapter-dev-box](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter-dev-box)
+is a Vagrant/VirtualBox virtual machine that has MS SQL Server installed. However, the
+activerecord-sqlserver-adapter-dev-box uses Vagrant and Virtual Box which will not work on Macs with Apple silicon.
+
+### Local Development
+
+See the [RUNNING_UNIT_TESTS](RUNNING_UNIT_TESTS.md) file for the details of how to run the unit tests locally.
+
+## Community
+
+There is a [Gitter channel](https://gitter.im/rails-sqlserver/activerecord-sqlserver-adapter) for the project where you are free to ask questions about the project.
 
 ## Credits & Contributions
 

--- a/RUNNING_UNIT_TESTS.md
+++ b/RUNNING_UNIT_TESTS.md
@@ -1,5 +1,5 @@
 
-# How To Run The Test!
+# How To Run The Tests
 
 This process is much easier than it has been before!
 

--- a/RUNNING_UNIT_TESTS.md
+++ b/RUNNING_UNIT_TESTS.md
@@ -1,9 +1,8 @@
+# How To Run The Tests Locally
 
-# How To Run The Tests
+The following is a description of how to run the tests for the SQL Server adapter on a local environment.
 
-This process is much easier than it has been before!
-
-## MS SQL SERVER
+## MS SQL Server instance
 
 If you don't have easy access to MS SQL Server, you can set up a Vagrant/VirtualBox virtual machine with MS SQL Server. [Here's how](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter-dev-box).
 


### PR DESCRIPTION
The [activerecord-sqlserver-adapter-dev-box](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter-dev-box) relies on [VirtualBox](https://www.virtualbox.org), which does not support Apple Silicon chips (see https://forums.virtualbox.org/viewtopic.php?t=98742). 

As an alternative to VirtualBox we can use Dev Container CLI to create a developer environment for the SQL Server adapter. This is the same option is available for Rails development (see https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#using-dev-container-cli). 