### PR TITLE
Fix Preloader to not generate a query for already loaded association with query_constraints

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/preloader.rb
@@ -10,6 +10,8 @@ module ActiveRecord
           def load_records_for_keys(keys, &block)
             return super unless scope.connection.sqlserver?
 
+            return [] if keys.empty?
+
             if association_key_name.is_a?(Array)
               query_constraints = Hash.new { |hsh, key| hsh[key] = Set.new }
 


### PR DESCRIPTION
Ported fix in https://github.com/rails/rails/pull/50325 to the adapter. This will fix the test suite for the Rails 7.1.3 release.