### PR TITLE
FROM subquery should work if order provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1151](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1151) FROM subquery should work if order provided
+
 ## v7.1.1
 
 #### Fixed

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -213,7 +213,7 @@ module Arel
 
       def visit_Orders_And_Let_Fetch_Happen(o, collector)
         make_Fetch_Possible_And_Deterministic o
-        unless o.orders.empty?
+        if o.orders.any?
           collector << " ORDER BY "
           len = o.orders.length - 1
           o.orders.each_with_index { |x, i|
@@ -261,15 +261,14 @@ module Arel
 
       def make_Fetch_Possible_And_Deterministic(o)
         return if o.limit.nil? && o.offset.nil?
+        return if o.orders.any?
 
         t = table_From_Statement o
         pk = primary_Key_From_Table t
         return unless pk
 
-        if o.orders.empty?
-          # Prefer deterministic vs a simple `(SELECT NULL)` expr.
-          o.orders = [pk.asc]
-        end
+        # Prefer deterministic vs a simple `(SELECT NULL)` expr.
+        o.orders = [pk.asc]
       end
 
       def distinct_One_As_One_Is_So_Not_Fetch(o)

--- a/test/cases/fetch_test_sqlserver.rb
+++ b/test/cases/fetch_test_sqlserver.rb
@@ -42,6 +42,25 @@ class FetchTestSqlserver < ActiveRecord::TestCase
     end
   end
 
+  describe "FROM subquery" do
+    let(:from_sql) { "(SELECT [books].* FROM [books]) [books]" }
+
+    it "SQL generated correctly for FROM subquery if order provided" do
+      query = Book.from(from_sql).order(:id).limit(5)
+
+      assert_equal query.to_sql, "SELECT [books].* FROM (SELECT [books].* FROM [books]) [books] ORDER BY [books].[id] ASC OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY"
+      assert_equal query.to_a.count, 5
+    end
+
+    it "exception thrown if FROM subquery is provided without an order" do
+      query = Book.from(from_sql).limit(5)
+
+      assert_raise(ActiveRecord::StatementInvalid) do
+        query.to_sql
+      end
+    end
+  end
+
   protected
 
   def create_10_books


### PR DESCRIPTION
The SQL Server adapter makes select queries deterministic by ordering by the primary key if an ordering is not provided. 

If the FROM clause is specified using:

```ruby 
Book.from("(SELECT [books].* FROM [books]) [books]")
```

Then this would require the adapter to parse the raw SQL string `(SELECT [books].* FROM [books]) [books]` to find the table being queried so that its primary key could then be determined. Parsing raw SQL is very difficult and outside the requirements of the adapter. I don't think the Rails project parses raw SQL either because of the difficulty. 

To fix the above query the ordering should be given so that the adapter does not have to try to find the primary key:

```ruby
Book.from("(SELECT [books].* FROM [books]) [books]").order(:id)
```

This does require a small fix to the adapter so that the primary key is only looked for if an ordering has not already been specified.

This PR fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1148