### PR TITLE
Fix Composite Key Inserts with Triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1152](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1152) Fix Composite Key Inserts with Triggers
+
 ## v7.1.2
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -283,7 +283,7 @@ module ActiveRecord
                     id_sql_type = exclude_output_inserted.is_a?(TrueClass) ? "bigint" : exclude_output_inserted
                     <<~SQL.squish
                       DECLARE @ssaIdInsertTable table (#{quoted_pk.map { |subkey| "#{subkey} #{id_sql_type}"}.join(", ") });
-                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk.join(', INSERTED.')} INTO @ssaIdInsertTable"}
+                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/i), " OUTPUT #{ quoted_pk.map { |subkey| "INSERTED.#{subkey}" }.join(", ") } INTO @ssaIdInsertTable"}
                       SELECT #{quoted_pk.map {|subkey| "CAST(#{subkey} AS #{id_sql_type}) #{subkey}"}.join(", ")} FROM @ssaIdInsertTable
                     SQL
                   else

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -278,13 +278,13 @@ module ActiveRecord
                   exclude_output_inserted = exclude_output_inserted_table_name?(table_name, sql)
 
                   if exclude_output_inserted
-                    quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted
+                    quoted_pk = Array(pk).map { |subkey| SQLServer::Utils.extract_identifiers(subkey).quoted }
 
                     id_sql_type = exclude_output_inserted.is_a?(TrueClass) ? "bigint" : exclude_output_inserted
                     <<~SQL.squish
-                      DECLARE @ssaIdInsertTable table (#{quoted_pk} #{id_sql_type});
-                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/i), " OUTPUT INSERTED.#{quoted_pk} INTO @ssaIdInsertTable"}
-                      SELECT CAST(#{quoted_pk} AS #{id_sql_type}) FROM @ssaIdInsertTable
+                      DECLARE @ssaIdInsertTable table (#{quoted_pk.map { |subkey| "#{subkey} #{id_sql_type}"}.join(", ") });
+                      #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk.join(', INSERTED.')} INTO @ssaIdInsertTable"}
+                      SELECT #{quoted_pk.map {|subkey| "CAST(#{subkey} AS #{id_sql_type}) #{subkey}"}.join(", ")} FROM @ssaIdInsertTable
                     SQL
                   else
                     returning_columns = returning || Array(pk)

--- a/test/cases/trigger_test_sqlserver.rb
+++ b/test/cases/trigger_test_sqlserver.rb
@@ -28,4 +28,14 @@ class SQLServerTriggerTest < ActiveRecord::TestCase
     _(obj.id).must_be :present?
     _(obj.id.to_s).must_equal SSTestTriggerHistory.first.id_source
   end
+
+  it "can insert into a table with composite pk with output inserted - with a true setting for table name" do
+    exclude_output_inserted_table_names["sst_table_with_composite_pk_trigger"] = true
+    assert SSTestTriggerHistory.all.empty?
+    obj = SSTestTriggerCompositePk.create! pk_col_one: 123, pk_col_two: 42, event_name: "test trigger"
+    _(obj.event_name).must_equal "test trigger"
+    _(obj.pk_col_one).must_equal 123
+    _(obj.pk_col_two).must_equal 42
+    _(obj.pk_col_one.to_s).must_equal SSTestTriggerHistory.first.id_source
+  end
 end

--- a/test/models/sqlserver/trigger.rb
+++ b/test/models/sqlserver/trigger.rb
@@ -7,3 +7,7 @@ end
 class SSTestTriggerUuid < ActiveRecord::Base
   self.table_name = "sst_table_with_uuid_trigger"
 end
+
+class SSTestTriggerCompositePk < ActiveRecord::Base
+  self.table_name = "sst_table_with_composite_pk_trigger"
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -232,6 +232,23 @@ ActiveRecord::Schema.define do
     SELECT id AS id_source, event_name FROM INSERTED
   SQL
 
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_table_with_composite_pk_trigger') DROP TABLE sst_table_with_composite_pk_trigger"
+  execute <<-SQL
+    CREATE TABLE sst_table_with_composite_pk_trigger(
+      pk_col_one int NOT NULL,
+      pk_col_two int NOT NULL,
+      event_name nvarchar(255),
+      CONSTRAINT PK_sst_table_with_composite_pk_trigger PRIMARY KEY (pk_col_one, pk_col_two)
+    )
+  SQL
+  execute <<-SQL
+    CREATE TRIGGER sst_table_with_composite_pk_trigger_t ON sst_table_with_composite_pk_trigger
+    FOR INSERT
+    AS
+    INSERT INTO sst_table_with_trigger_history (id_source, event_name)
+    SELECT pk_col_one AS id_source, event_name FROM INSERTED
+  SQL
+
   # Another schema.
 
   create_table :sst_schema_columns, force: true do |t|


### PR DESCRIPTION
This updates the `OUTPUT INSERTED` statement to handle the case of composite primary keys being properly returned when the table also has a trigger.