### PR TITLE
Eliminate uses of lease_connection

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
@@ -17,6 +17,7 @@ module ActiveRecord
                 column = self.class.columns_hash[name]
                 column && column.respond_to?(:is_identity?) && column.is_identity?
               end
+            end
           end
         end
       end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/attribute_methods.rb
@@ -10,12 +10,13 @@ module ActiveRecord
           private
 
           def attributes_for_update(attribute_names)
-            return super unless self.class.lease_connection.adapter_name == "SQLServer"
+            self.class.with_connection do |connection|
+              return super(attribute_names) unless connection.sqlserver?
 
-            super.reject do |name|
-              column = self.class.columns_hash[name]
-              column && column.respond_to?(:is_identity?) && column.is_identity?
-            end
+              super(attribute_names).reject do |name|
+                column = self.class.columns_hash[name]
+                column && column.respond_to?(:is_identity?) && column.is_identity?
+              end
           end
         end
       end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -15,6 +15,7 @@ module ActiveRecord
               else
                 super
               end
+            end
           end
 
           private

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/calculations.rb
@@ -9,11 +9,12 @@ module ActiveRecord
       module CoreExt
         module Calculations
           def calculate(operation, column_name)
-            if klass.lease_connection.sqlserver?
-              _calculate(operation, column_name)
-            else
-              super
-            end
+            klass.with_connection do |connection|
+              if connection.sqlserver?
+                _calculate(operation, column_name)
+              else
+                super
+              end
           end
 
           private
@@ -54,9 +55,10 @@ module ActiveRecord
           end
 
           def build_count_subquery(relation, column_name, distinct)
-            return super unless klass.lease_connection.adapter_name == "SQLServer"
-
-            super(relation.unscope(:order), column_name, distinct)
+            klass.with_connection do |connection|
+              relation = relation.unscope(:order) if connection.sqlserver?
+              super(relation, column_name, distinct)
+            end
           end
         end
       end

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/explain.rb
@@ -9,12 +9,15 @@ module ActiveRecord
           SQLSERVER_STATEMENT_REGEXP = /N'(.+)', N'(.+)', (.+)/
 
           def exec_explain(queries, options = [])
-            return super unless lease_connection.adapter_name == "SQLServer"
+            with_connection do |connection|
+              return super(queries, options) unless connection.sqlserver?
 
-            unprepared_queries = queries.map do |(sql, binds)|
-              [unprepare_sqlserver_statement(sql, binds), binds]
+              unprepared_queries = queries.map do |(sql, binds)|
+                [unprepare_sqlserver_statement(sql, binds), binds]
+              end
+
+              super(unprepared_queries, options)
             end
-            super(unprepared_queries, options)
           end
 
           private

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
@@ -11,10 +11,12 @@ module ActiveRecord
           private
 
           def construct_relation_for_exists(conditions)
-            if klass.lease_connection.sqlserver?
-              _construct_relation_for_exists(conditions)
-            else
-              super
+            klass.with_connection do |connection|
+              if connection.sqlserver?
+                _construct_relation_for_exists(conditions)
+              else
+                super
+              end
             end
           end
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           result
         end
 
-        def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+        def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false, allow_retry: false)
           result = nil
           sql = transform_query(sql)
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -61,8 +61,8 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
   end
 
   it "test table existence across database schemas" do
-    arunit_connection = Topic.connection
-    arunit2_connection = College.connection
+    arunit_connection = Topic.lease_connection
+    arunit2_connection = College.lease_connection
 
     arunit_database = arunit_connection.pool.db_config.database
     arunit2_database = arunit2_connection.pool.db_config.database

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1018,7 +1018,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal topics(:fifth), Topic.first
     assert_equal topics(:third), Topic.last
 
-    c = Topic.connection
+    c = Topic.lease_connection
     assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.title"))} DESC, #{Regexp.escape(c.quote_table_name("topics.id"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
       Topic.last
     }
@@ -1032,7 +1032,7 @@ class FinderTest < ActiveRecord::TestCase
     old_implicit_order_column = Topic.implicit_order_column
     Topic.implicit_order_column = "id"
 
-    c = Topic.connection
+    c = Topic.lease_connection
     assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
       Topic.last
     }
@@ -1046,7 +1046,7 @@ class FinderTest < ActiveRecord::TestCase
     old_implicit_order_column = NonPrimaryKey.implicit_order_column
     NonPrimaryKey.implicit_order_column = "created_at"
 
-    c = NonPrimaryKey.connection
+    c = NonPrimaryKey.lease_connection
 
     assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("non_primary_keys.created_at"))} DESC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY.*@0 = 1/i) {
       NonPrimaryKey.last
@@ -1067,7 +1067,7 @@ class FinderTest < ActiveRecord::TestCase
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
   coerce_tests! :test_implicit_order_column_prepends_query_constraints
   def test_implicit_order_column_prepends_query_constraints_coerced
-    c = ClothingItem.connection
+    c = ClothingItem.lease_connection
     ClothingItem.implicit_order_column = "description"
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
@@ -1083,7 +1083,7 @@ class FinderTest < ActiveRecord::TestCase
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
   coerce_tests! %r{#last for a model with composite query constraints}
   test "#last for a model with composite query constraints coerced" do
-    c = ClothingItem.connection
+    c = ClothingItem.lease_connection
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
 
@@ -1095,7 +1095,7 @@ class FinderTest < ActiveRecord::TestCase
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
   coerce_tests! %r{#first for a model with composite query constraints}
   test "#first for a model with composite query constraints coerced" do
-    c = ClothingItem.connection
+    c = ClothingItem.lease_connection
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
 
@@ -1107,7 +1107,7 @@ class FinderTest < ActiveRecord::TestCase
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
   coerce_tests! :test_implicit_order_column_reorders_query_constraints
   def test_implicit_order_column_reorders_query_constraints_coerced
-    c = ClothingItem.connection
+    c = ClothingItem.lease_connection
     ClothingItem.implicit_order_column = "color"
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
@@ -1131,7 +1131,7 @@ class FinderTest < ActiveRecord::TestCase
   # Check for `FETCH NEXT x ROWS` rather then `LIMIT`.
   coerce_tests! :test_nth_to_last_with_order_uses_limit
   def test_nth_to_last_with_order_uses_limit_coerced
-    c = Topic.connection
+    c = Topic.lease_connection
     assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC OFFSET @(\d) ROWS FETCH NEXT @(\d) ROWS ONLY.*@\1 = 1.*@\2 = 1/i) do
       Topic.second_to_last
     end
@@ -2338,7 +2338,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::OrderAgreement.connection
+    c = Cpk::OrderAgreement.lease_connection
     order_id_column = Regexp.escape(c.quote_table_name("cpk_order_agreements.order_id"))
     order_id_constraint = /#{order_id_column} = @0.*@0 = \d+$/
     expectation = /SELECT.*WHERE.* #{order_id_constraint}/
@@ -2362,7 +2362,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::Order.connection
+    c = Cpk::Order.lease_connection
     order_id = Regexp.escape(c.quote_table_name("cpk_orders.id"))
     order_constraint = /#{order_id} = @0.*@0 = \d+$/
     expectation = /SELECT.*WHERE.* #{order_constraint}/


### PR DESCRIPTION
- Eliminate uses of `lease_connection`. See rails/rails#51353
- Update the `internal_exec_query` method signature. See https://github.com/rails/rails/pull/51336
