### PR TITLE
Allow basic attribute types to be query parameters

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -331,11 +331,7 @@ module ActiveRecord
         def sp_executesql_sql_type(attr)
           return attr.type.sqlserver_type if attr.respond_to?(:type) && attr.type.respond_to?(:sqlserver_type)
 
-          value = if attr.is_a?(Symbol) || attr.is_a?(String) || attr.is_a?(Numeric)
-                    attr
-                  else
-                    attr.value_for_database
-                  end
+          value = basic_attribute_type?(attr) ? attr : attr.value_for_database
 
           if value.is_a?(Numeric)
             value > 2_147_483_647 ? "bigint".freeze : "int".freeze
@@ -345,7 +341,7 @@ module ActiveRecord
         end
 
         def sp_executesql_sql_param(attr)
-          return quote(attr) if attr.is_a?(Symbol) || attr.is_a?(String) || attr.is_a?(Numeric)
+          return quote(attr) if basic_attribute_type?(attr)
 
           case value = attr.value_for_database
           when Type::Binary::Data, ActiveRecord::Type::SQLServer::Data
@@ -353,6 +349,15 @@ module ActiveRecord
           else
             quote(type_cast(value))
           end
+        end
+
+        def basic_attribute_type?(type)
+          type.is_a?(Symbol) ||
+            type.is_a?(String) ||
+            type.is_a?(Numeric) ||
+            type.is_a?(Time) ||
+            type.is_a?(TrueClass) ||
+            type.is_a?(FalseClass)
         end
 
         def sp_executesql_sql(sql, types, params, name)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -357,7 +357,8 @@ module ActiveRecord
             type.is_a?(Numeric) ||
             type.is_a?(Time) ||
             type.is_a?(TrueClass) ||
-            type.is_a?(FalseClass)
+            type.is_a?(FalseClass) ||
+            type.is_a?(NilClass)
         end
 
         def sp_executesql_sql(sql, types, params, name)


### PR DESCRIPTION
Previously when using place-holder conditions (`where("written_on < ?", time)`), the value was interpolated into the query (`WHERE written_on < "2024-01-01 12:00:00"`). Now the place-holder condition is a query parameter (`WHERE written_on < @1`).

Fixes the "undefined method 'value_for_database'" errors seen in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/8910633467/job/24470268020