### PR TITLE
Coerce test as no query to release savepoint

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -243,6 +243,25 @@ class BasicsTest < ActiveRecord::TestCase
   end
 end
 
+class HasManyThroughAssociationsTest < ActiveRecord::TestCase
+  # SQL Server does not have query for release_savepoint
+  coerce_tests! :test_associate_existing
+  def test_associate_existing_coerced
+    post   = posts(:thinking)
+    person = people(:david)
+
+    assert_queries_count(2) do
+      post.people << person
+    end
+
+    assert_queries_count(1) do
+      assert_includes post.people, person
+    end
+
+    assert_includes post.reload.people.reload, person
+  end
+end
+
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   # Since @client.firm is a single first/top, and we use FETCH the order clause is used.
   coerce_tests! :test_belongs_to_does_not_use_order_by


### PR DESCRIPTION
Coerce `HasManyThroughAssociationsTest#test_associate_existing` test as MSSSQL has no release savepoint query.

```
HasManyThroughAssociationsTest#test_associate_existing [/usr/local/bundle/bundler/gems/rails-087260d0fce3/activerecord/test/cases/associations/has_many_through_associations_test.rb:224]:
2 instead of 3 queries were executed. Queries: SAVE TRANSACTION active_record_1

EXEC sp_executesql N'INSERT INTO [readers] ([post_id], [person_id]) OUTPUT INSERTED.[id] VALUES (@0, @1)', N'@0 int, @1 int', @0 = 2, @1 = 2.
Expected: 3
  Actual: 2

bin/rails test /usr/local/bundle/bundler/gems/rails-087260d0fce3/activerecord/test/cases/associations/has_many_through_associations_test.rb:220
```

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/8928362210/job/24523775374
