### PR TITLE
When asserting queries performed, insert placeholder query for release save-point

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/savepoints.rb
+++ b/lib/active_record/connection_adapters/sqlserver/savepoints.rb
@@ -17,6 +17,7 @@ module ActiveRecord
         end
 
         def release_savepoint(_name)
+          internal_execute("/* release #{name} savepoint */", "TRANSACTION")
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/savepoints.rb
+++ b/lib/active_record/connection_adapters/sqlserver/savepoints.rb
@@ -16,8 +16,9 @@ module ActiveRecord
           internal_execute("ROLLBACK TRANSACTION #{name}", "TRANSACTION")
         end
 
-        def release_savepoint(name)
-          internal_execute("/* release #{name} savepoint */", "TRANSACTION")
+        # SQL Server does require save-points to be explicitly released.
+        # See https://stackoverflow.com/questions/3101312/sql-server-2008-no-release-savepoint-for-current-transaction
+        def release_savepoint(_name)
         end
       end
     end

--- a/lib/active_record/connection_adapters/sqlserver/savepoints.rb
+++ b/lib/active_record/connection_adapters/sqlserver/savepoints.rb
@@ -16,7 +16,7 @@ module ActiveRecord
           internal_execute("ROLLBACK TRANSACTION #{name}", "TRANSACTION")
         end
 
-        def release_savepoint(_name)
+        def release_savepoint(name)
           internal_execute("/* release #{name} savepoint */", "TRANSACTION")
         end
       end

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -11,6 +11,7 @@ require "cases/helper"
 require "support/load_schema_sqlserver"
 require "support/coerceable_test_sqlserver"
 require "support/connection_reflection"
+require "support/query_assertions"
 require "mocha/minitest"
 
 module ActiveRecord
@@ -19,7 +20,8 @@ module ActiveRecord
 
     include ARTest::SQLServer::CoerceableTest,
             ARTest::SQLServer::ConnectionReflection,
-            ActiveSupport::Testing::Stream
+            ActiveSupport::Testing::Stream,
+            ARTest::SQLServer::QueryAssertions
 
     let(:logger) { ActiveRecord::Base.logger }
 

--- a/test/support/query_assertions.rb
+++ b/test/support/query_assertions.rb
@@ -13,9 +13,7 @@ module ARTest
           # Rails tests expect a save-point to be released at the end of the test. SQL Server does not release
           # save-points and so the number of queries will be off by one. This monkey patch adds a placeholder query
           # to the end of the queries array to account for the missing save-point release.
-          if queries.any? { |query| query =~ /SAVE TRANSACTION \S+/ }
-            queries.append "/* release savepoint placeholder for testing */"
-          end
+          queries.append "/* release savepoint placeholder for testing */" if queries.first =~ /SAVE TRANSACTION \S+/
           # End of monkey-patch
 
           if count

--- a/test/support/query_assertions.rb
+++ b/test/support/query_assertions.rb
@@ -1,0 +1,31 @@
+module ARTest
+  module SQLServer
+    module QueryAssertions
+      def assert_queries_count(count = nil, include_schema: false, &block)
+        ActiveRecord::Base.lease_connection.materialize_transactions
+
+        counter = ActiveRecord::Assertions::QueryAssertions::SQLCounter.new
+        ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+          result = _assert_nothing_raised_or_warn("assert_queries_count", &block)
+          queries = include_schema ? counter.log_all : counter.log
+
+          # Start of monkey-patch
+          # Rails tests expect a save-point to be released at the end of the test. SQL Server does not release
+          # save-points and so the number of queries will be off by one. This monkey patch adds a placeholder query
+          # to the end of the queries array to account for the missing save-point release.
+          if queries.any? { |query| query =~ /SAVE TRANSACTION \S+/ }
+            queries.append "/* release savepoint placeholder for testing */"
+          end
+          # End of monkey-patch
+
+          if count
+            assert_equal count, queries.size, "#{queries.size} instead of #{count} queries were executed. Queries: #{queries.join("\n\n")}"
+          else
+            assert_operator queries.size, :>=, 1, "1 or more queries expected, but none were executed.#{queries.empty? ? '' : "\nQueries:\n#{queries.join("\n")}"}"
+          end
+          result
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
SQL Server does not support releasing save-points. They are automatically released when transitions are committed/rolled-back. 

When the number of queries performed is asserted in tests, it is assumed that release save-point is supported. To work around this a dummy placeholder query is inserted if a transaction is saved at the start of the queries.