### PR TITLE
Add row_count field to sql.active_record notification

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -351,6 +351,28 @@ module ActiveRecord
       Book.send(:load_schema!)
       original_test_payload_name_on_load
     end
+
+    # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+    coerce_tests! :test_payload_row_count_on_select_all
+    def test_payload_row_count_on_select_all_coerced
+      connection.remove_index(:books, column: [:author_id, :name])
+
+      original_test_payload_row_count_on_select_all
+    ensure
+      Book.where(author_id: nil, name: 'row count book 1').delete_all
+      Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
+    end
+
+    # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+    coerce_tests! :test_payload_row_count_on_raw_sql
+    def test_payload_row_count_on_raw_sql_coerced
+      connection.remove_index(:books, column: [:author_id, :name])
+
+      original_test_payload_row_count_on_raw_sql
+    ensure
+      Book.where(author_id: nil, name: 'row count book 3').delete_all
+      Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
+    end
   end
 end
 


### PR DESCRIPTION
Fix:

- `ActiveRecord::InstrumentationTest#test_payload_row_count_on_pluck`
- `ActiveRecord::InstrumentationTest#test_payload_row_count_on_raw_sql`

See https://github.com/rails/rails/pull/50887