### PR TITLE
Fix test bad connection test

### DIFF
--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -102,8 +102,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     assert_raise ActiveRecord::NoDatabaseError do
       db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       configuration = db_config.configuration_hash.merge(database: "nonexistent_activerecord_unittest")
-
-      connection = ActiveRecord::Base.sqlserver_connection configuration
+      connection = ActiveRecord::ConnectionAdapters::SQLServerAdapter(configuration)
       connection.exec_query("SELECT 1")
     end
   end

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -102,7 +102,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     assert_raise ActiveRecord::NoDatabaseError do
       db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       configuration = db_config.configuration_hash.merge(database: "nonexistent_activerecord_unittest")
-      connection = ActiveRecord::ConnectionAdapters::SQLServerAdapter(configuration)
+      connection = ActiveRecord::ConnectionAdapters::SQLServerAdapter.new(configuration)
       connection.exec_query("SELECT 1")
     end
   end


### PR DESCRIPTION
Fixes:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9033092031/job/24822623240
```
AdapterTestSQLServer#test_0010_test bad connection [/activerecord-sqlserver-adapter/test/cases/adapter_test_sqlserver.rb:102]:
[ActiveRecord::NoDatabaseError] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `sqlserver_connection' for class ActiveRecord::Base">
---Backtrace---
/usr/local/bundle/bundler/gems/rails-2744b74216e5/activerecord/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/activerecord-sqlserver-adapter/test/cases/adapter_test_sqlserver.rb:106:in `block (2 levels) in <class:AdapterTestSQLServer>'
```