### PR TITLE
Return row-count for pluck

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         end
 
         def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
-          log(sql, name, async: async) do
+          log(sql, name, async: async) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
               result = if id_insert_table_name = query_requires_identity_insert?(sql)
                          with_identity_insert_enabled(id_insert_table_name, conn) { internal_raw_execute(sql, conn, perform_do: true) }
@@ -22,6 +22,7 @@ module ActiveRecord
                          internal_raw_execute(sql, conn, perform_do: true)
                        end
               verified!
+              notification_payload[:row_count] = result
               result
             end
           end

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -364,6 +364,17 @@ module ActiveRecord
     end
 
     # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+    coerce_tests! :test_payload_row_count_on_pluck
+    def test_payload_row_count_on_pluck_coerced
+      connection.remove_index(:books, column: [:author_id, :name])
+
+      original_test_payload_row_count_on_pluck
+    ensure
+      Book.where(author_id: nil, name: 'row count book 2').delete_all
+      Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
+    end
+    
+    # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
     coerce_tests! :test_payload_row_count_on_raw_sql
     def test_payload_row_count_on_raw_sql_coerced
       connection.remove_index(:books, column: [:author_id, :name])

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -373,7 +373,7 @@ module ActiveRecord
       Book.where(author_id: nil, name: 'row count book 2').delete_all
       Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
     end
-    
+
     # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
     coerce_tests! :test_payload_row_count_on_raw_sql
     def test_payload_row_count_on_raw_sql_coerced


### PR DESCRIPTION
Fix:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9061194112/job/24892482330
```
25) Error:
ActiveRecord::InstrumentationTest#test_payload_row_count_on_pluck:
ActiveRecord::RecordNotUnique: TinyTds::Error: Cannot insert duplicate key row in object 'dbo.books' with unique index 'index_books_on_author_id_and_name'. The duplicate key value is (<NULL>, row count book 2).
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:433:in `each'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:433:in `handle_to_names_and_values'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:60:in `internal_exec_sql_query'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:48:in `block (2 levels) in internal_exec_query'
    /usr/local/bundle/bundler/gems/rails-dae4867b3350/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:997:in `block in with_raw_connection'
    /usr/local/bundle/bundler/gems/rails-dae4867b3350/activesupport/lib/active_support/c
```