### PR TITLE
Support any Rails branch in CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,6 +9,6 @@ WORKDIR $WORKDIR
 
 COPY . $WORKDIR
 
-RUN RAILS_MAIN=1 bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
+RUN RAILS_BRANCH=7-2-stable bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
 
 CMD ["sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gem "msgpack", ">= 1.7.0"
 
 if ENV["RAILS_SOURCE"]
   gemspec path: ENV["RAILS_SOURCE"]
-elsif ENV["RAILS_MAIN"]
-  gem "rails", github: "rails/rails", branch: 'main'
+elsif ENV["RAILS_BRANCH"]
+  gem "rails", github: "rails/rails", branch: ENV["RAILS_BRANCH"]
 else
   # Need to get rails source because the gem doesn't include tests
   version = ENV["RAILS_VERSION"] || begin

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,7 @@ services:
   ci:
     environment:
       - ACTIVERECORD_UNITTEST_HOST=sqlserver
-      - RAILS_MAIN=1
+      - RAILS_BRANCH=7-2-stable
     build:
       context: .
       dockerfile: Dockerfile.ci


### PR DESCRIPTION
Rails has cut a `7-2-stable` branch from `main` before Rails 7.2 has been released. Rather than supporting just the `main` branch on CI, allow any branch to be supported.