### PR TITLE
Fix for text showplan

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -432,7 +432,11 @@ module ActiveRecord
             qo[:as] = (options[:ar_result] || options[:fetch] == :rows) ? :array : :hash
           end
           results = handle.each(query_options)
-          columns = lowercase_schema_reflection ? handle.fields.map { |c| c.downcase } : handle.fields
+
+          columns = handle.fields
+          # If query returns multiple result sets, only return the columns of the last one.
+          columns = columns.last if columns.all? { |e| e.is_a?(Array) }
+          columns = columns.map(&:downcase) if lowercase_schema_reflection
 
           options[:ar_result] ? ActiveRecord::Result.new(columns, results) : results
         end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -435,7 +435,7 @@ module ActiveRecord
 
           columns = handle.fields
           # If query returns multiple result sets, only return the columns of the last one.
-          columns = columns.last if columns.all? { |e| e.is_a?(Array) }
+          columns = columns.last if columns.any? && columns.all? { |e| e.is_a?(Array) }
           columns = columns.map(&:downcase) if lowercase_schema_reflection
 
           options[:ar_result] ? ActiveRecord::Result.new(columns, results) : results


### PR DESCRIPTION
Fix for text showplan, which returns 2 result sets for single query. The multiple column headers were causing the following bug.

<img width="827" alt="Screenshot 2024-05-15 at 17 05 15" src="https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/assets/1769416/3777beed-04cc-402c-9ed4-ac036af9747f">

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9085233159/job/24968052134?pr=1173
```
ShowplanTestSQLServer::With SHOWPLAN_TEXT option#test_0001_use simple table printer:
RuntimeError: Wrapped undumpable exception for: ActiveRecord::StatementInvalid: NoMethodError: undefined method `-@' for an instance of Array
    /usr/local/bundle/bundler/gems/rails-1d681e341c01/activerecord/lib/active_record/result.rb:52:in `each'
    /usr/local/bundle/bundler/gems/rails-1d681e341c01/activerecord/lib/active_record/result.rb:52:in `initialize'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:437:in `new'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:437:in `handle_to_names_and_values'
    /activerecord-sqlserver-adapter/lib/active_record/connection_adapters/sqlserver/database_statements.rb:61:in `internal_exec_sql_query'
```