### PR TITLE
Ensure pre-7.1 migrations use legacy index names when using rename_table

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -132,7 +132,7 @@ module ActiveRecord
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)
           execute "EXEC sp_rename '#{table_name}', '#{new_name}'"
-          rename_table_indexes(table_name, new_name)
+          rename_table_indexes(table_name, new_name, **options)
         end
 
         def remove_column(table_name, column_name, type = nil, **options)


### PR DESCRIPTION
Implemented change made in https://github.com/rails/rails/pull/50837

Fixes the `ActiveRecord::Migration::CompatibilityTest#test_rename_table_errors_on_too_long_index_name_7_0` test.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9109903293/job/25043759601?pr=1174
```
 24) Failure:
ActiveRecord::Migration::CompatibilityTest#test_rename_table_errors_on_too_long_index_name_7_0 [/usr/local/bundle/bundler/gems/rails-f92c8a3539ee/activerecord/test/cases/migration/compatibility_test.rb:434]:
StandardError expected but nothing was raised.
```