### PR TITLE
Updated error message in test to include sqlserver

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2635,3 +2635,21 @@ module ActiveRecord
     end
   end
 end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PoolConfig
+      class ResolverTest < ActiveRecord::TestCase
+        # SQL Server was not included in the list of available adapters in the error message.
+        coerce_tests! :test_url_invalid_adapter
+        def test_url_invalid_adapter_coerced
+          error = assert_raises(AdapterNotFound) do
+            Base.connection_handler.establish_connection "ridiculous://foo?encoding=utf8"
+          end
+
+          assert_match "Database configuration specifies nonexistent 'ridiculous' adapter. Available adapters are: abstract, fake, mysql2, postgresql, sqlite3, sqlserver, trilogy. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile if it's not in the list of available adapters.", error.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Coerce `ActiveRecord::ConnectionAdapters::PoolConfig::ResolverTest#test_url_invalid_adapter ` test as sqlserver not included in error message.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9094436581/job/24995515248
```
ActiveRecord::ConnectionAdapters::PoolConfig::ResolverTest#test_url_invalid_adapter [/usr/local/bundle/bundler/gems/rails-cb60cc0b1539/activerecord/test/cases/database_configurations/resolver_test.rb:19]:
Expected /Database\ configuration\ specifies\ nonexistent\ 'ridiculous'\ adapter\.\ Available\ adapters\ are:\ abstract,\ fake,\ mysql2,\ postgresql,\ sqlite3,\ trilogy\.\ Ensure\ that\ the\ adapter\ is\ spelled\ correctly\ in\ config\/database\.yml\ and\ that\ you've\ added\ the\ necessary\ adapter\ gem\ to\ your\ Gemfile\ if\ it's\ not\ in\ the\ list\ of\ available\ adapters\./ to match "Database configuration specifies nonexistent 'ridiculous' adapter. Available adapters are: abstract, fake, mysql2, postgresql, sqlite3, sqlserver, trilogy. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile if it's not in the list of available adapters.".
```