### PR TITLE
Support encrypting binary columns

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -328,7 +328,13 @@ module ActiveRecord
         end
 
         def sp_executesql_sql_type(attr)
-          return attr.type.sqlserver_type if attr.respond_to?(:type) && attr.type.respond_to?(:sqlserver_type)
+          if attr.respond_to?(:type)
+            return attr.type.sqlserver_type if attr.type.respond_to?(:sqlserver_type)
+
+            if attr.type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType) && attr.type.instance_variable_get(:@cast_type).respond_to?(:sqlserver_type)
+              return attr.type.instance_variable_get(:@cast_type).sqlserver_type
+            end
+          end
 
           value = basic_attribute_type?(attr) ? attr : attr.value_for_database
 


### PR DESCRIPTION
Fix `ActiveRecord::Encryption::EncryptableRecordTest#test_0049_serialized binary data can be encrypted`.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9116557246/job/25065421824
```
 13) Error:
ActiveRecord::Encryption::EncryptableRecordTest#test_0049_serialized binary data can be encrypted:
ActiveRecord::StatementInvalid: TinyTds::Error: Implicit conversion from data type nvarchar(max) to varbinary(max) is not allowed. Use the CONVERT function to run this query.
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:434:in `each'
```

Ref: https://github.com/rails/rails/pull/50920