### PR TITLE
Add savepoint placeholder for each savepoint created

### DIFF
--- a/test/support/query_assertions.rb
+++ b/test/support/query_assertions.rb
@@ -13,17 +13,17 @@ module ARTest
           # Rails tests expect a save-point to be created and released. SQL Server does not release
           # save-points and so the number of queries will be off. This monkey patch adds a placeholder queries
           # to replace the missing save-point releases.
-          grouped_savepoint_queries = [[]]
+          grouped_queries = [[]]
 
           queries.each do |query|
             if query =~ /SAVE TRANSACTION \S+/
-              grouped_savepoint_queries << [query]
+              grouped_queries << [query]
             else
-              grouped_savepoint_queries.last << query
+              grouped_queries.last << query
             end
           end
 
-          grouped_savepoint_queries.each do |group|
+          grouped_queries.each do |group|
             group.append "/* release savepoint placeholder for testing */" if group.first =~ /SAVE TRANSACTION \S+/
           end
 

--- a/test/support/query_assertions.rb
+++ b/test/support/query_assertions.rb
@@ -10,24 +10,7 @@ module ARTest
           queries = include_schema ? counter.log_all : counter.log
 
           # Start of monkey-patch
-          # Rails tests expect a save-point to be created and released. SQL Server does not release
-          # save-points and so the number of queries will be off. This monkey patch adds a placeholder queries
-          # to replace the missing save-point releases.
-          grouped_queries = [[]]
-
-          queries.each do |query|
-            if query =~ /SAVE TRANSACTION \S+/
-              grouped_queries << [query]
-            else
-              grouped_queries.last << query
-            end
-          end
-
-          grouped_queries.each do |group|
-            group.append "/* release savepoint placeholder for testing */" if group.first =~ /SAVE TRANSACTION \S+/
-          end
-
-          queries = grouped_queries.flatten
+          queries = include_release_savepoint_placeholder_queries(queries)
           # End of monkey-patch
 
           if count
@@ -37,6 +20,29 @@ module ARTest
           end
           result
         end
+      end
+
+      private
+
+      # Rails tests expect a save-point to be created and released. SQL Server does not release
+      # save-points and so the number of queries will be off. This monkey patch adds a placeholder queries
+      # to replace the missing save-point releases.
+      def include_release_savepoint_placeholder_queries(queries)
+        grouped_queries = [[]]
+
+        queries.each do |query|
+          if query =~ /SAVE TRANSACTION \S+/
+            grouped_queries << [query]
+          else
+            grouped_queries.last << query
+          end
+        end
+
+        grouped_queries.each do |group|
+          group.append "/* release savepoint placeholder for testing */" if group.first =~ /SAVE TRANSACTION \S+/
+        end
+
+        grouped_queries.flatten
       end
     end
   end


### PR DESCRIPTION
Fix `DirtyTest#test_partial_update`:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9127055748/job/25096554308
```
DirtyTest#test_partial_update [/usr/local/bundle/bundler/gems/rails-fb4300ce193c/activerecord/test/cases/dirty_test.rb:365]:
5 instead of 6 queries were executed. Queries: SAVE TRANSACTION active_record_1

EXEC sp_executesql N'INSERT INTO [pirates] ([catchphrase], [parrot_id], [non_validated_parrot_id], [created_on], [updated_on]) OUTPUT INSERTED.[id] VALUES (@0, @1, @2, @3, @4)', N'@0 nvarchar(4000), @1 int, @2 int, @3 datetime2(6), @4 datetime2(6)', @0 = N'foo', @1 = NULL, @2 = NULL, @3 = '05-17-2024 10:53:27.262222', @4 = '05-17-2024 10:53:27.262222'

SAVE TRANSACTION active_record_1

EXEC sp_executesql N'UPDATE [pirates] SET [catchphrase] = @0, [parrot_id] = @1, [non_validated_parrot_id] = @2, [created_on] = @3, [updated_on] = @4 WHERE [pirates].[id] = @5; SELECT @@ROWCOUNT AS AffectedRows', N'@0 nvarchar(4000), @1 int, @2 int, @3 datetime2(6), @4 datetime2(6), @5 bigint', @0 = N'foo', @1 = NULL, @2 = NULL, @3 = '05-17-2024 10:53:27.262222', @4 = '05-17-2024 10:53:27.263973', @5 = 959118371

/* release savepoint placeholder for testing */.
Expected: 6
  Actual: 5
```