### PR TITLE
Fix for the Rails test schema including decimal greater than 38 precision

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -94,6 +94,18 @@ module ActiveRecord
         def json(*names, **options)
           names.each { |name| column(name, :text, **options) }
         end
+
+        def decimal(*names, **options)
+          # binding.pry if names.include? :atoms_in_universe
+          # binding.pry if options[:precision].to_i > 38
+
+          options[:precision] = 38 if options[:precision].to_i == 55
+
+          # options[:precision] ||= 18
+
+          names.each { |name| column(name, :decimal, **options) }
+        end
+
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition

--- a/lib/active_record/connection_adapters/sqlserver/table_definition.rb
+++ b/lib/active_record/connection_adapters/sqlserver/table_definition.rb
@@ -94,18 +94,6 @@ module ActiveRecord
         def json(*names, **options)
           names.each { |name| column(name, :text, **options) }
         end
-
-        def decimal(*names, **options)
-          # binding.pry if names.include? :atoms_in_universe
-          # binding.pry if options[:precision].to_i > 38
-
-          options[:precision] = 38 if options[:precision].to_i == 55
-
-          # options[:precision] ||= 18
-
-          names.each { |name| column(name, :decimal, **options) }
-        end
-
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -7,19 +7,7 @@ require "pry"
 require "support/core_ext/query_cache"
 require "support/minitest_sqlserver"
 require "support/test_in_memory_oltp"
-
-
 require "support/table_definition_sqlserver"
-module ActiveRecord
-  module ConnectionAdapters
-    module SQLServer
-      class TableDefinition < ::ActiveRecord::ConnectionAdapters::TableDefinition
-        include ARTest::SQLServer::TableDefinition
-      end
-    end
-  end
-end
-
 require "cases/helper"
 require "support/load_schema_sqlserver"
 require "support/coerceable_test_sqlserver"

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -7,6 +7,19 @@ require "pry"
 require "support/core_ext/query_cache"
 require "support/minitest_sqlserver"
 require "support/test_in_memory_oltp"
+
+
+require "support/table_definition_sqlserver"
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      class TableDefinition < ::ActiveRecord::ConnectionAdapters::TableDefinition
+        include ARTest::SQLServer::TableDefinition
+      end
+    end
+  end
+end
+
 require "cases/helper"
 require "support/load_schema_sqlserver"
 require "support/coerceable_test_sqlserver"

--- a/test/support/table_definition_sqlserver.rb
+++ b/test/support/table_definition_sqlserver.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-module ARTest
-  module SQLServer
-    module TableDefinition
-      extend ActiveSupport::Concern
-
-      included do
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      class TableDefinition < ::ActiveRecord::ConnectionAdapters::TableDefinition
         # SQL Server supports precision of 38 for decimal columns. In Rails the test schema includes a column
         # with a precision of 55. This is a problem for SQL Server 2008. This method will override the default
         # decimal method to limit the precision to 38 for the :atoms_in_universe column.
         # See https://github.com/rails/rails/pull/51826/files#diff-2a57b61bbf9ee2c23938fc571d403799f68b4b530d65e2cde219a429bbf10af5L876
         def decimal(*names, **options)
+          throw "This 'decimal' method should only be used in a test environment." unless defined?(ActiveSupport::TestCase)
+
           names.each do |name|
             options_for_name = options.dup
             options_for_name[:precision] = 38 if name == :atoms_in_universe && options_for_name[:precision].to_i == 55

--- a/test/support/table_definition_sqlserver.rb
+++ b/test/support/table_definition_sqlserver.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ARTest
+  module SQLServer
+    module TableDefinition
+      extend ActiveSupport::Concern
+
+      included do
+        # SQL Server supports precision of 38 for decimal columns. In Rails the test schema includes a column
+        # with a precision of 55. This is a problem for SQL Server 2008. This method will override the default
+        # decimal method to limit the precision to 38 for the :atoms_in_universe column.
+        # See https://github.com/rails/rails/pull/51826/files#diff-2a57b61bbf9ee2c23938fc571d403799f68b4b530d65e2cde219a429bbf10af5L876
+        def decimal(*names, **options)
+          names.each do |name|
+            options_for_name = options.dup
+            options_for_name[:precision] = 38 if name == :atoms_in_universe && options_for_name[:precision].to_i == 55
+
+            column(name, :decimal, **options_for_name)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Need work-around following this change to `rails/activerecord/test/schema/schema.rb` https://github.com/rails/rails/pull/51826/files#diff-2a57b61bbf9ee2c23938fc571d403799f68b4b530d65e2cde219a429bbf10af5L876