### PR TITLE
Coerced some explain tests

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2684,3 +2684,30 @@ module ActiveRecord
     end
   end
 end
+
+require "models/car"
+class ExplainTest < ActiveRecord::TestCase
+  # Expected query slightly different from because of 'sp_executesql' and query parameters.
+  coerce_tests! :test_relation_explain_with_first
+  def test_relation_explain_with_first_coerced
+    expected_query = capture_sql {
+      Car.all.first
+    }.first[/EXEC sp_executesql N'(.*?) NEXT/, 1]
+    message = Car.all.explain.first
+    assert_match(/^EXPLAIN/, message)
+    assert_match(expected_query, message)
+  end
+
+  # Expected query slightly different from because of 'sp_executesql' and query parameters.
+  coerce_tests! :test_relation_explain_with_last
+  def test_relation_explain_with_last_coerced
+    expected_query = capture_sql {
+      Car.all.last
+    }.first[/EXEC sp_executesql N'(.*?) NEXT/, 1]
+    expected_query = expected_query
+    message = Car.all.explain.last
+
+    assert_match(/^EXPLAIN/, message)
+    assert_match(expected_query, message)
+  end
+end


### PR DESCRIPTION
Fix following tests:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9149232428/job/25152652558

```
 4) Failure:
ExplainTest#test_relation_explain_with_first [/usr/local/bundle/bundler/gems/rails-f31b853267ba/activerecord/test/cases/explain_test.rb:98]:
Expected /EXEC\ sp_executesql\ N'SELECT\ \[cars\]\.\*\ FROM\ \[cars\]\ ORDER\ BY\ \[cars\]\.\[id\]\ ASC\ OFFSET\ 0\ ROWS\ FETCH\ NEXT\ @0\ ROWS\ ONLY',\ N'@0\ int',\ @0\ =\ 1/ to match EXPLAIN for: SELECT [cars].* FROM [cars] ORDER BY [cars].[id] ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY [["LIMIT", 1]]
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
| StmtText                                           | StmtId | NodeId | Parent | PhysicalOp           | LogicalOp            | Argument                                           | DefinedValues                                      | EstimateRows | EstimateIO | EstimateCPU | AvgRowSize | TotalSubtreeCost | OutputList                                         | Warnings | Type     | Parallel | EstimateExecutions |
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
| SELECT [cars].* FROM [cars] ORDER BY [cars].[id... | 1      | 1      | 0      | NULL                 | NULL                 | 1                                                  | NULL                                               | 1.0          | NULL       | NULL        | NULL       | 0.00328320       | NULL                                               | NULL     | SELECT   | false    | NULL               |
|   |--Top(TOP EXPRESSION:((1)))                     | 1      | 2      | 1      | Top                  | Top                  | TOP EXPRESSION:((1))                               | NULL                                               | 1.0          | 0.0        | 1.00000001  | 4072       | 0.00328320       | [activerecord_unittest].[dbo].[cars].[id], [act... | NULL     | PLAN_ROW | false    | 1.0                |
|        |--Clustered Index Scan(OBJECT:([activer... | 1      | 3      | 2      | Clustered Index Scan | Clustered Index Scan | OBJECT:([activerecord_unittest].[dbo].[cars].[P... | [activerecord_unittest].[dbo].[cars].[id], [act... | 1.0          | 0.00312500 | 0.00015920  | 4072       | 0.00328309       | [activerecord_unittest].[dbo].[cars].[id], [act... | NULL     | PLAN_ROW | false    | 1.0                |
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
.

  5) Failure:
ExplainTest#test_relation_explain_with_last [/usr/local/bundle/bundler/gems/rails-f31b853267ba/activerecord/test/cases/explain_test.rb:107]:
Expected /EXEC\ sp_executesql\ N'SELECT\ \[cars\]\.\*\ FROM\ \[cars\]\ ORDER\ BY\ \[cars\]\.\[id\]\ DESC\ OFFSET\ 0\ ROWS\ FETCH\ NEXT\ @0\ ROWS\ ONLY',\ N'@0\ int',\ @0\ =\ 1/ to match EXPLAIN for: SELECT [cars].* FROM [cars] ORDER BY [cars].[id] DESC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY [["LIMIT", 1]]
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
| StmtText                                           | StmtId | NodeId | Parent | PhysicalOp           | LogicalOp            | Argument                                           | DefinedValues                                      | EstimateRows | EstimateIO | EstimateCPU | AvgRowSize | TotalSubtreeCost | OutputList                                         | Warnings | Type     | Parallel | EstimateExecutions |
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
| SELECT [cars].* FROM [cars] ORDER BY [cars].[id... | 1      | 1      | 0      | NULL                 | NULL                 | 1                                                  | NULL                                               | 1.0          | NULL       | NULL        | NULL       | 0.00328320       | NULL                                               | NULL     | SELECT   | false    | NULL               |
|   |--Top(TOP EXPRESSION:((1)))                     | 1      | 2      | 1      | Top                  | Top                  | TOP EXPRESSION:((1))                               | NULL                                               | 1.0          | 0.0        | 1.00000001  | 4072       | 0.00328320       | [activerecord_unittest].[dbo].[cars].[id], [act... | NULL     | PLAN_ROW | false    | 1.0                |
|        |--Clustered Index Scan(OBJECT:([activer... | 1      | 3      | 2      | Clustered Index Scan | Clustered Index Scan | OBJECT:([activerecord_unittest].[dbo].[cars].[P... | [activerecord_unittest].[dbo].[cars].[id], [act... | 1.0          | 0.00312500 | 0.00015920  | 4072       | 0.00328309       | [activerecord_unittest].[dbo].[cars].[id], [act... | NULL     | PLAN_ROW | false    | 1.0                |
+----------------------------------------------------+--------+--------+--------+----------------------+----------------------+----------------------------------------------------+----------------------------------------------------+--------------+------------+-------------+------------+------------------+----------------------------------------------------+----------+----------+----------+--------------------+
.
```
