### PR TITLE
Coerce query assertion test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2711,3 +2711,26 @@ class ExplainTest < ActiveRecord::TestCase
     assert_match(expected_query, message)
   end
 end
+
+module ActiveRecord
+  module Assertions
+    class QueryAssertionsTest < ActiveSupport::TestCase
+      # Query slightly different in original test.
+      coerce_tests! :test_assert_queries_match
+      def test_assert_queries_match_coerced
+        assert_queries_match(/ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY/i, count: 1) { Post.first }
+        assert_queries_match(/ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY/i) { Post.first }
+
+        error = assert_raises(Minitest::Assertion) {
+          assert_queries_match(/ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY/i, count: 2) { Post.first }
+        }
+        assert_match(/1 instead of 2 queries/, error.message)
+
+        error = assert_raises(Minitest::Assertion) {
+          assert_queries_match(/ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY/i, count: 0) { Post.first }
+        }
+        assert_match(/1 instead of 0 queries/, error.message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Coerce `ActiveRecord::Assertions::QueryAssertionsTest#test_assert_queries_match`.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9149232428/job/25152652558
```
  1) Failure:
ActiveRecord::Assertions::QueryAssertionsTest#test_assert_queries_match [/usr/local/bundle/bundler/gems/rails-f31b853267ba/activerecord/test/cases/assertions/query_assertions_test.rb:44]:
0 instead of 1 queries were executed.
Queries:
EXEC sp_executesql N'SELECT [posts].* FROM [posts] ORDER BY [posts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY', N'@0 int', @0 = 1.
Expected: 1
  Actual: 0
```