### PR TITLE
Update Freetds to match CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
 # TinyTDS
 RUN apt-get -y install libc6-dev \
-    && wget http://www.freetds.org/files/stable/freetds-1.1.32.tar.gz \
-    && tar -xzf freetds-1.1.32.tar.gz \
-    && cd freetds-1.1.32 \
+    && wget http://www.freetds.org/files/stable/freetds-1.4.14.tar.gz \
+    && tar -xzf freetds-1.4.14.tar.gz \
+    && cd freetds-1.4.14 \
     && ./configure --prefix=/usr/local --with-tdsver=7.3 \
     && make \
     && make install

--- a/test/cases/rake_test_sqlserver.rb
+++ b/test/cases/rake_test_sqlserver.rb
@@ -138,18 +138,22 @@ class SQLServerRakeStructureDumpLoadTest < SQLServerRakeTest
 
   it "dumps structure and accounts for defncopy oddities" do
     skip "debug defncopy on windows later" if host_windows?
+
     quietly { db_tasks.structure_dump configuration, filename }
+
     _(filedata).wont_match %r{\AUSE.*\z}
     _(filedata).wont_match %r{\AGO.*\z}
-    _(filedata).must_match %r{email\s+nvarchar\(4000\)}
-    _(filedata).must_match %r{background1\s+nvarchar\(max\)}
-    _(filedata).must_match %r{background2\s+text\s+}
+    _(filedata).must_match %r{\[email\]\s+nvarchar\(4000\)}
+    _(filedata).must_match %r{\[background1\]\s+nvarchar\(max\)}
+    _(filedata).must_match %r{\[background2\]\s+text\s+}
   end
 
   it "can load dumped structure" do
     skip "debug defncopy on windows later" if host_windows?
+
     quietly { db_tasks.structure_dump configuration, filename }
-    _(filedata).must_match %r{CREATE TABLE dbo\.users}
+
+    _(filedata).must_match %r{CREATE TABLE \[dbo\]\.\[users\]}
     db_tasks.purge(configuration)
     _(connection.tables).wont_include "users"
     db_tasks.load_schema db_config, :sql, filename


### PR DESCRIPTION
Fix the following failing tests.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9388881855/job/25855114274?pr=1190
```
  3) Failure:
SQLServerRakeStructureDumpLoadTest#test_0001_dumps structure and accounts for defncopy oddities [test/cases/rake_test_sqlserver.rb:144]:
Expected /email\s+nvarchar\(4000\)/ to match "\t/* No foreign keys reference table 'dbo.users', or you do not have permissions on referencing tables. */\n\t/* No views with schema binding reference table 'dbo.users'. */\n\nCREATE TABLE [dbo].[users]\n\t( [id]          bigint          NOT NULL\n\t, [name]        nvarchar(4000)      NULL\n\t, [email]       nvarchar(4000)      NULL\n\t, [background1] nvarchar(max)       NULL\n\t, [background2] text                NULL\n\t, [created_at]  datetime2       NOT NULL\n\t, [updated_at]  datetime2       NOT NULL\n\t)\n\nALTER TABLE [dbo].[users] ADD CONSTRAINT [PK__users__3213E83FA1874989] PRIMARY KEY clustered ([id])\n\n".

  4) Failure:
SQLServerRakeStructureDumpLoadTest#test_0002_can load dumped structure [test/cases/rake_test_sqlserver.rb:152]:
Expected /CREATE TABLE dbo\.users/ to match "\t/* No foreign keys reference table 'dbo.users', or you do not have permissions on referencing tables. */\n\t/* No views with schema binding reference table 'dbo.users'. */\n\nCREATE TABLE [dbo].[users]\n\t( [id]          bigint          NOT NULL\n\t, [name]        nvarchar(4000)      NULL\n\t, [email]       nvarchar(4000)      NULL\n\t, [background1] nvarchar(max)       NULL\n\t, [background2] text                NULL\n\t, [created_at]  datetime2       NOT NULL\n\t, [updated_at]  datetime2       NOT NULL\n\t)\n\nALTER TABLE [dbo].[users] ADD CONSTRAINT [PK__users__3213E83FA5447335] PRIMARY KEY clustered ([id])\n\n".
```