### PR TITLE
Add assertions to tests missing any assertions

### DIFF
--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -289,7 +289,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
 
     it "ALLOW deletion of referenced parent using #disable_referential_integrity block" do
-      SSTestHasPk.lease_connection.disable_referential_integrity { @parent.destroy }
+      assert_difference("SSTestHasPk.count", -1) do
+        SSTestHasPk.lease_connection.disable_referential_integrity { @parent.destroy }
+      end
     end
 
     it "again NOT ALLOW deletion of referenced parent after #disable_referential_integrity block" do
@@ -549,11 +551,15 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   describe 'table is in non-dbo schema' do
     it "records can be created successfully" do
-      Alien.create!(name: 'Trisolarans')
+      assert_difference("Alien.count", 1) do
+        Alien.create!(name: 'Trisolarans')
+      end
     end
 
     it 'records can be inserted using SQL' do
-      Alien.lease_connection.exec_insert("insert into [test].[aliens] (id, name) VALUES(1, 'Trisolarans'), (2, 'Xenomorph')")
+      assert_difference("Alien.count", 2) do
+        Alien.lease_connection.exec_insert("insert into [test].[aliens] (id, name) VALUES(1, 'Trisolarans'), (2, 'Xenomorph')")
+      end
     end
   end
 

--- a/test/cases/disconnected_test_sqlserver.rb
+++ b/test/cases/disconnected_test_sqlserver.rb
@@ -19,7 +19,10 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
   test "execute procedure after disconnect reconnects" do
     @connection.execute_procedure :sp_tables, "sst_datatypes"
     @connection.disconnect!
-    @connection.execute_procedure :sp_tables, "sst_datatypes"
+
+    assert_nothing_raised do
+      @connection.execute_procedure :sp_tables, "sst_datatypes"
+    end
   end
 
   test "execute query after disconnect reconnects" do
@@ -31,6 +34,9 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
 
     @connection.exec_query sql, "TEST", binds
     @connection.disconnect!
-    @connection.exec_query sql, "TEST", binds
+
+    assert_nothing_raised do
+      @connection.exec_query sql, "TEST", binds
+    end
   end
 end

--- a/test/cases/index_test_sqlserver.rb
+++ b/test/cases/index_test_sqlserver.rb
@@ -41,7 +41,9 @@ class IndexTestSQLServer < ActiveRecord::TestCase
   end
 
   it "add index with expression" do
-    connection.execute "ALTER TABLE [testings] ADD [first_name_upper] AS UPPER([first_name])"
-    connection.add_index "testings", "first_name_upper"
+    assert_nothing_raised do
+      connection.execute "ALTER TABLE [testings] ADD [first_name_upper] AS UPPER([first_name])"
+      connection.add_index "testings", "first_name_upper"
+    end
   end
 end

--- a/test/cases/scratchpad_test_sqlserver.rb
+++ b/test/cases/scratchpad_test_sqlserver.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require "cases/helper_sqlserver"
-
-class ScratchpadTestSQLServer < ActiveRecord::TestCase
-  it "helps debug things" do
-  end
-end

--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -6,8 +6,12 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
   after { SSTestEdgeSchema.delete_all }
 
   it "handle dollar symbols" do
-    SSTestDollarTableName.create!
-    SSTestDollarTableName.limit(20).offset(1)
+    assert_difference("SSTestDollarTableName.count", 1) do
+      SSTestDollarTableName.create!
+    end
+    assert_nothing_raised do
+      SSTestDollarTableName.limit(20).offset(1)
+    end
   end
 
   it "models can use tinyint pk tables" do


### PR DESCRIPTION
Fix missing assertions warnings like:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9430052163/job/25977137751?pr=1189
```
Test is missing assertions: `test_0001_records can be created successfully` /activerecord-sqlserver-adapter/test/cases/adapter_test_sqlserver.rb:551
```