### PR TITLE
Fix test

### DIFF
--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -43,7 +43,7 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
   end
 
   it 'test deprecation with transaction return when executing procedure' do
-    assert_deprecated(ActiveRecord.deprecator) do
+    assert_deprecated(ActiveSupport::Deprecation) do
       ActiveRecord::Base.transaction do
         connection.execute_procedure("my_getutcdate")
         return


### PR DESCRIPTION
Fix warning:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9437921639/job/25994350714
```
Test is missing assertions: `test_0006_test deprecation with transaction return when executing procedure` /activerecord-sqlserver-adapter/test/cases/execute_procedure_test_sqlserver.rb:45
```