### PR TITLE
Fix missing assertion warning

### DIFF
--- a/test/cases/execute_procedure_test_sqlserver.rb
+++ b/test/cases/execute_procedure_test_sqlserver.rb
@@ -42,12 +42,16 @@ class ExecuteProcedureTestSQLServer < ActiveRecord::TestCase
     assert_equal date_base.change(usec: 0), date_proc.change(usec: 0)
   end
 
+  def transaction_with_procedure_and_return
+    ActiveRecord::Base.transaction do
+      connection.execute_procedure("my_getutcdate")
+      return
+    end
+  end
+
   it 'test deprecation with transaction return when executing procedure' do
-    assert_deprecated(ActiveRecord.deprecator) do
-      ActiveRecord::Base.transaction do
-        connection.execute_procedure("my_getutcdate")
-        return
-      end
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      transaction_with_procedure_and_return
     end
   end
 end


### PR DESCRIPTION
Fix missing assertions message. Issue caused by `return` in block returning from the calling test.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9437921639/job/25994350714
```
Test is missing assertions: `test_0006_test deprecation with transaction return when executing procedure` /activerecord-sqlserver-adapter/test/cases/execute_procedure_test_sqlserver.rb:45
```