### PR TITLE
Use default inspect for database adapter

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -325,10 +325,6 @@ module ActiveRecord
         self.class::VERSION
       end
 
-      def inspect
-        "#<#{self.class} version: #{version}, azure: #{sqlserver_azure?.inspect}>"
-      end
-
       def combine_bind_parameters(from_clause: [], join_clause: [], where_clause: [], having_clause: [], limit: nil, offset: nil)
         result = from_clause + join_clause + where_clause + having_clause
         result << offset if offset

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -18,8 +18,6 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
   it "has basic and non-sensitive information in the adapters inspect method" do
     string = connection.inspect
     _(string).must_match %r{ActiveRecord::ConnectionAdapters::SQLServerAdapter}
-    _(string).must_match %r{version\: \d.\d}
-    _(string).must_match %r{azure: (true|false)}
     _(string).wont_match %r{host}
     _(string).wont_match %r{password}
     _(string).wont_match %r{username}


### PR DESCRIPTION
Fix `ActiveRecord::AdapterTest#test_0002_inspect does not show secrets`:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/9627344416/job/26554338325#step:4:274
```
1) Failure:
ActiveRecord::AdapterTest#test_0002_inspect does not show secrets [/usr/local/bundle/bundler/gems/rails-0b89a3393599/activerecord/test/cases/adapter_test.rb:330]:
Expected /ActiveRecord::ConnectionAdapters::\w+:0x[\da-f]+ env_name="\w+" role=:writing>/ to match "#<ActiveRecord::ConnectionAdapters::SQLServerAdapter version: 7.2.0.beta2, azure: false>".
```

See https://github.com/rails/rails/pull/50405