### PR TITLE
Fix test table name typo

### DIFF
--- a/test/cases/specific_schema_test_sqlserver.rb
+++ b/test/cases/specific_schema_test_sqlserver.rb
@@ -171,7 +171,7 @@ class SpecificSchemaTestSQLServer < ActiveRecord::TestCase
 
   it "returns the correct primary columns" do
     connection = ActiveRecord::Base.lease_connection
-    assert_equal "field_1", connection.columns("test.sst_schema_test_mulitple_schema").detect(&:is_primary?).name
-    assert_equal "field_2", connection.columns("test2.sst_schema_test_mulitple_schema").detect(&:is_primary?).name
+    assert_equal "field_1", connection.columns("test.sst_schema_test_multiple_schema").detect(&:is_primary?).name
+    assert_equal "field_2", connection.columns("test2.sst_schema_test_multiple_schema").detect(&:is_primary?).name
   end
 end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -304,17 +304,17 @@ ActiveRecord::Schema.define do
     )
   NATURALPKTABLESQLINOTHERSCHEMA
 
-  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_mulitple_schema' and TABLE_SCHEMA = 'test') DROP TABLE test.sst_schema_test_mulitple_schema"
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_multiple_schema' and TABLE_SCHEMA = 'test') DROP TABLE test.sst_schema_test_multiple_schema"
   execute <<-SCHEMATESTMULTIPLESCHEMA
-    CREATE TABLE test.sst_schema_test_mulitple_schema(
+    CREATE TABLE test.sst_schema_test_multiple_schema(
       field_1 int NOT NULL PRIMARY KEY,
       field_2 int,
     )
   SCHEMATESTMULTIPLESCHEMA
   execute "IF NOT EXISTS(SELECT * FROM sys.schemas WHERE name = 'test2') EXEC sp_executesql N'CREATE SCHEMA test2'"
-  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_mulitple_schema' and TABLE_SCHEMA = 'test2') DROP TABLE test2.sst_schema_test_mulitple_schema"
+  execute "IF EXISTS(SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'sst_schema_test_multiple_schema' and TABLE_SCHEMA = 'test2') DROP TABLE test2.sst_schema_test_multiple_schema"
   execute <<-SCHEMATESTMULTIPLESCHEMA
-    CREATE TABLE test2.sst_schema_test_mulitple_schema(
+    CREATE TABLE test2.sst_schema_test_multiple_schema(
       field_1 int,
       field_2 int NOT NULL PRIMARY KEY,
     )


### PR DESCRIPTION
Rename test table that has a typo.