### PR TITLE
Support table names containing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### Added
 
-- [#1201](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1201) Support non-dbo schemas in schema dumper.
+- [#1201](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1201) Support non-dbo schemas in schema dumper
+- [#1206](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1206) Support table names containing spaces
 
 ## v7.1.4
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -32,6 +32,9 @@ module ActiveRecord
 
         def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           result = nil
+
+          puts "******** SQL: #{sql}"
+
           sql = transform_query(sql)
 
           check_if_write_query(sql)
@@ -394,6 +397,8 @@ module ActiveRecord
 
         def query_requires_identity_insert?(sql)
           return false unless insert_sql?(sql)
+
+          # binding.pry if $DEBUG
 
           raw_table_name = get_raw_table_name(sql)
           id_column = identity_columns(raw_table_name).first

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -401,6 +401,15 @@ module ActiveRecord
           id_column = identity_columns(raw_table_name).first
 
           id_column && sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)[^(]+\([^)]*\b(#{id_column.name})\b,?[^)]*\)/i ? SQLServer::Utils.extract_identifiers(raw_table_name).quoted : false
+
+        rescue StandardError => e
+
+          puts "*" * 100
+          puts "sql: #{sql}"
+          puts "raw_table_name: #{raw_table_name}"
+          puts "*" * 100
+
+          raise e
         end
 
         def insert_sql?(sql)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -32,9 +32,6 @@ module ActiveRecord
 
         def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           result = nil
-
-          puts "******** SQL: #{sql}"
-
           sql = transform_query(sql)
 
           check_if_write_query(sql)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -395,8 +395,6 @@ module ActiveRecord
         def query_requires_identity_insert?(sql)
           return false unless insert_sql?(sql)
 
-          # binding.pry if $DEBUG
-
           raw_table_name = get_raw_table_name(sql)
           id_column = identity_columns(raw_table_name).first
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -401,15 +401,6 @@ module ActiveRecord
           id_column = identity_columns(raw_table_name).first
 
           id_column && sql =~ /^\s*(INSERT|EXEC sp_executesql N'INSERT)[^(]+\([^)]*\b(#{id_column.name})\b,?[^)]*\)/i ? SQLServer::Utils.extract_identifiers(raw_table_name).quoted : false
-
-        rescue StandardError => e
-
-          puts "*" * 100
-          puts "sql: #{sql}"
-          puts "raw_table_name: #{raw_table_name}"
-          puts "*" * 100
-
-          raise e
         end
 
         def insert_sql?(sql)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -674,7 +674,7 @@ module ActiveRecord
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
           case sql
-          when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(\s]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
+          when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
             Regexp.last_match[3] || Regexp.last_match[4]
           when /FROM\s+([^\(\s]+)\s*/i
             Regexp.last_match[1]

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -674,13 +674,26 @@ module ActiveRecord
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
 
+          s = sql.gsub(/^\s*EXEC sp_executesql N'/i, "")
 
-          case sql
-          when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+(\[[^\(\]]+\])\s*|^\s*update\s+([^\(\s]+)\s*/i
-            Regexp.last_match[3] || Regexp.last_match[4]
-          when /FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i
-            Regexp.last_match[1]
+          # binding.pry
+
+          if s.match?(/^\s*INSERT INTO.*/i)
+            s = s.split(/INSERT INTO/i)[1].split(/OUTPUT INSERTED/i)[0].split(/(DEFAULT)?\s+VALUES/i)[0]
+
+            s.match(/\s*([^(]*)/i)[0]
+          else
+            s.match(/FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i)[1]
           end.strip
+
+          # table_name
+
+          # case sql
+          # when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+(\[[^\(\]]+\])\s*|^\s*update\s+([^\(\s]+)\s*/i
+          #   Regexp.last_match[3] || Regexp.last_match[4]
+          # when /FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i
+          #   Regexp.last_match[1]
+          # end.strip
         end
 
         def default_constraint_name(table_name, column_name)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,8 +673,6 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
-          puts "get_raw_table_name: SQL: #{sql}"
-
           case sql
           when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
             Regexp.last_match[3] || Regexp.last_match[4]

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,29 +673,18 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
-
           s = sql.gsub(/^\s*EXEC sp_executesql N'/i, "")
 
-          # binding.pry
-
           if s.match?(/^\s*INSERT INTO.*/i)
-            s = s.split(/INSERT INTO/i)[1].split(/OUTPUT INSERTED/i)[0].split(/(DEFAULT)?\s+VALUES/i)[0]
-
-            s.match(/\s*([^(]*)/i)[0]
+            s.split(/INSERT INTO/i)[1]
+              .split(/OUTPUT INSERTED/i)[0]
+              .split(/(DEFAULT)?\s+VALUES/i)[0]
+              .match(/\s*([^(]*)/i)[0]
           elsif s.match?(/^\s*UPDATE\s+.*/i)
             s.match(/UPDATE\s+([^\(\s]+)\s*/i)[1]
           else
             s.match(/FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i)[1]
           end.strip
-
-          # table_name
-
-          # case sql
-          # when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+(\[[^\(\]]+\])\s*|^\s*update\s+([^\(\s]+)\s*/i
-          #   Regexp.last_match[3] || Regexp.last_match[4]
-          # when /FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i
-          #   Regexp.last_match[1]
-          # end.strip
         end
 
         def default_constraint_name(table_name, column_name)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -682,6 +682,8 @@ module ActiveRecord
             s = s.split(/INSERT INTO/i)[1].split(/OUTPUT INSERTED/i)[0].split(/(DEFAULT)?\s+VALUES/i)[0]
 
             s.match(/\s*([^(]*)/i)[0]
+          elsif s.match?(/^\s*UPDATE\s+.*/i)
+            s.match(/UPDATE\s+([^\(\s]+)\s*/i)[1]
           else
             s.match(/FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i)[1]
           end.strip

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,10 +673,12 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
+
+
           case sql
-          when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
+          when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+(\[[^\(\]]+\])\s*|^\s*update\s+([^\(\s]+)\s*/i
             Regexp.last_match[3] || Regexp.last_match[4]
-          when /FROM\s+([^\(\s]+)\s*/i
+          when /FROM\s+((\[[^\(\]]+\])|[^\(\s]+)\s*/i
             Regexp.last_match[1]
           end.strip
         end

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,12 +673,14 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
+          puts "get_raw_table_name: SQL: #{sql}"
+
           case sql
           when /^\s*(INSERT|EXEC sp_executesql N'INSERT)(\s+INTO)?\s+([^\(]+)\s*|^\s*update\s+([^\(\s]+)\s*/i
             Regexp.last_match[3] || Regexp.last_match[4]
           when /FROM\s+([^\(\s]+)\s*/i
             Regexp.last_match[1]
-          end
+          end.strip
         end
 
         def default_constraint_name(table_name, column_name)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -550,11 +550,23 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
 
   describe 'table is in non-dbo schema' do
     it "records can be created successfully" do
-      Alien.create!(name: 'Trisolarans')
+      assert_difference("Alien.count", 1) do
+        Alien.create!(name: 'Trisolarans')
+      end
     end
 
     it 'records can be inserted using SQL' do
-      Alien.connection.exec_insert("insert into [test].[aliens] (id, name) VALUES(1, 'Trisolarans'), (2, 'Xenomorph')")
+      assert_difference("Alien.count", 2) do
+        Alien.connection.exec_insert("insert into [test].[aliens] (id, name) VALUES(1, 'Trisolarans'), (2, 'Xenomorph')")
+      end
+    end
+  end
+
+  describe 'table names contains spaces' do
+    it 'records can be created successfully' do
+      assert_difference("TableWithSpaces.count", 1) do
+        TableWithSpaces.create!(name: 'Bob')
+      end
     end
   end
 

--- a/test/models/sqlserver/table_with_spaces.rb
+++ b/test/models/sqlserver/table_with_spaces.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TableWithSpaces < ActiveRecord::Base
+  self.table_name = "A Table With Spaces"
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -151,6 +151,10 @@ ActiveRecord::Schema.define do
     SELECT GETUTCDATE() utcdate
   SQL
 
+  create_table 'A Table With Spaces', force: true do |t|
+    t.string :name
+  end
+
   # Constraints
 
   create_table(:sst_has_fks, force: true) do |t|


### PR DESCRIPTION
Added support for table names that contain spaces. This is related to https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1203

The regex to handle insert/update/select raw SQL was getting to complicated so I have broken it up for each case.