### PR TITLE
Exclude "guest" schmea in schema dumper

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -400,7 +400,7 @@ module ActiveRecord
             FROM sys.schemas
             WHERE
             name NOT LIKE 'db_%' AND
-            name NOT IN ('INFORMATION_SCHEMA', 'sys')
+            name NOT IN ('INFORMATION_SCHEMA', 'sys', 'guest')
           SQL
 
           query_values(sql, "SCHEMA")

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -167,6 +167,10 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
 
     # Only generate non-default schemas. Default schema is 'dbo'.
     assert_not_includes generated_schema, 'create_schema "dbo"'
+    assert_not_includes generated_schema, 'create_schema "db_owner"'
+    assert_not_includes generated_schema, 'create_schema "INFORMATION_SCHEMA"'
+    assert_not_includes generated_schema, 'create_schema "sys"'
+    assert_not_includes generated_schema, 'create_schema "guest"'
     assert_includes generated_schema, 'create_schema "test"'
     assert_includes generated_schema, 'create_schema "test2"'
 


### PR DESCRIPTION
This PR resolves the Issue #1207.

I added "guest" to the SQL query, and added a few extra lines of test code to check that the schema dumper does not add lines to create any of the MSSQL default schemas.