### PR TITLE
Handle blank SQL when parsing table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1210](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1210) Handle blank SQL when parsing table name
+
 ## v7.1.6
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,6 +673,8 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
+          return nil if sql.blank?
+
           s = sql.gsub(/^\s*EXEC sp_executesql N'/i, "")
 
           if s.match?(/^\s*INSERT INTO.*/i)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -673,7 +673,7 @@ module ActiveRecord
 
         # Parses the raw table name that is used in the SQL. Table name could include database/schema/etc.
         def get_raw_table_name(sql)
-          return nil if sql.blank?
+          return if sql.blank?
 
           s = sql.gsub(/^\s*EXEC sp_executesql N'/i, "")
 

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -66,6 +66,10 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       it do
         assert_equal "[WITH - SPACES$DOLLAR]", connection.send(:get_raw_table_name, "SELECT id FROM [WITH - SPACES$DOLLAR]")
       end
+
+      it do
+        assert_nil connection.send(:get_raw_table_name, nil)
+      end
     end
 
     describe 'INSERT statements' do


### PR DESCRIPTION
When parsing the table name from raw SQL, return `nil` if the raw SQL is blank. This fixes a issue caused by https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1206

The actual bug is described in a https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1209. The testing setup required to recreate the actual bug is complicated as you would need to create another database user who doesn't have the permissions to run `EXEC sp_help` on the affected view and you would need to create the ActiveRecord connection with that database user. Instead of recreating the actual bug, I just added check that the updated `get_raw_table_name` method checks for nil.