### PR TITLE
Fix serialized encrypted attributes

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -321,10 +321,12 @@ module ActiveRecord
 
         def sp_executesql_sql_type(attr)
           if attr.respond_to?(:type)
-            return attr.type.sqlserver_type if attr.type.respond_to?(:sqlserver_type)
+            type = attr.type.serialized? ? attr.type.subtype : attr.type
 
-            if attr.type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType) && attr.type.instance_variable_get(:@cast_type).respond_to?(:sqlserver_type)
-              return attr.type.instance_variable_get(:@cast_type).sqlserver_type
+            return type.sqlserver_type if type.respond_to?(:sqlserver_type)
+
+            if type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType) && type.instance_variable_get(:@cast_type).respond_to?(:sqlserver_type)
+              return type.instance_variable_get(:@cast_type).sqlserver_type
             end
           end
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -321,7 +321,8 @@ module ActiveRecord
 
         def sp_executesql_sql_type(attr)
           if attr.respond_to?(:type)
-            type = attr.type.serialized? ? attr.type.subtype : attr.type
+            type = attr.type.is_a?(ActiveRecord::Normalization::NormalizedValueType) ? attr.type.cast_type : attr.type
+            type = type.subtype if type.serialized?
 
             return type.sqlserver_type if type.respond_to?(:sqlserver_type)
 


### PR DESCRIPTION


Fix the following tests:

- `ActiveRecord::Encryption::EncryptableRecordTest#test_0047_serialized binary data can be encrypted`
- `ActiveRecord::Encryption::EncryptableRecordTest#test_0050_encrypts normalized data`

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/10668688433/job/29568976002