### PR TITLE
Switch Github runners to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run test suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       COMPOSE_FILE: docker-compose.ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run test suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # TODO: Change back to 'ubuntu-latest' when https://github.com/microsoft/mssql-docker/issues/899 resolved.
 
     env:
       COMPOSE_FILE: docker-compose.ci.yml


### PR DESCRIPTION
Temporary until https://github.com/microsoft/mssql-docker/issues/899 is resolved.

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/10987500629/job/30510421634 for example of CI not working.