### PR TITLE
Enable identity insert on view's base table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@
 #### Fixed
 
 - [#1215](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1215) Fix mismatched foreign key errors
+- [#1228](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1228) Enable identity insert on view's base table
 
 Please check [7-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/7-1-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -15,6 +15,9 @@ module ActiveRecord
 
         def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch:)
           result = if id_insert_table_name = query_requires_identity_insert?(sql)
+                     # If the table name is a view, we need to get the base table name for enabling identity insert.
+                     id_insert_table_name = view_table_name(id_insert_table_name) if view_exists?(id_insert_table_name)
+
                      with_identity_insert_enabled(id_insert_table_name, raw_connection) do
                        internal_exec_sql_query(sql, raw_connection)
                      end

--- a/test/cases/view_test_sqlserver.rb
+++ b/test/cases/view_test_sqlserver.rb
@@ -47,4 +47,12 @@ class ViewTestSQLServer < ActiveRecord::TestCase
       assert_equal 1, klass.count
     end
   end
+
+  describe 'identity insert' do
+    it "identity insert works with views" do
+      assert_difference("SSTestCustomersView.count", 1) do
+        SSTestCustomersView.create!(id: 5, name: "Bob")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Enable identity insert on view's base table as it cannot be enabled on the view itself.

Fix for https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1224