### PR TITLE
Coerce calculations test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -520,6 +520,9 @@ class CalculationsTest < ActiveRecord::TestCase
 
   # SELECT columns must be in the GROUP clause. Since since `ids` only selects the primary key you cannot perform this query in SQL Server.
   coerce_tests! :test_ids_with_includes_and_non_primary_key_order
+
+  # To limit the results in SQL Server we use `FETCH NEXT @0 ROWS ONLY` instead of `LIMIT @0`. To use `FETCH NEXT` an order must be provided.
+  coerce_tests! :test_no_order_by_when_counting_all
 end
 
 module ActiveRecord


### PR DESCRIPTION
To limit the results in SQL Server we use `FETCH NEXT @0 ROWS ONLY` instead of `LIMIT @0`. To use `FETCH NEXT` an order must be provided.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/11104499885/job/30848683699
```
  1) Failure:
CalculationsTest#test_no_order_by_when_counting_all [/usr/local/bundle/bundler/gems/rails-ebd9beebebe9/activerecord/test/cases/calculations_test.rb:315]:
Expected /ORDER BY/ to not match "EXEC sp_executesql N'SELECT COUNT(*) FROM (SELECT 1 AS one FROM [accounts] ORDER BY [accounts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY) subquery_for_count', N'@0 int', @0 = 10".
```