### PR TITLE
Coerce test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -727,7 +727,7 @@ module ActiveRecord
       end
 
       # SQL Server truncates long table names when renaming.
-      coerce_tests! test_rename_table_errors_on_too_long_index_name_7_0
+      coerce_tests! :test_rename_table_errors_on_too_long_index_name_7_0
       def test_rename_table_errors_on_too_long_index_name_7_0_coerced
         long_table_name = "a" * (connection.table_name_length + 1)
 


### PR DESCRIPTION
Fix:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/11140764876/job/30960243289?pr=1234
```
Failure:
ActiveRecord::Migration::CompatibilityTest#test_rename_table_errors_on_too_long_index_name_7_0 [/usr/local/bundle/bundler/gems/rails-b05945903e36/activerecord/test/cases/migration/compatibility_test.rb:433]:
StandardError expected but nothing was raised.
```