### PR TITLE
Fix for PredicateBuilderTest

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1340,6 +1340,12 @@ module ActiveRecord
     def test_registering_new_handlers_for_association_coerced
       assert_match %r{#{Regexp.escape(topic_title)} ~ N'rails'}i, Reply.joins(:topic).where(topics: { title: /rails/ }).to_sql
     end
+
+    private
+
+    def topic_title
+      Topic.lease_connection.quote_table_name("topics.title")
+    end
   end
 end
 


### PR DESCRIPTION
Fix for `PredicateBuilderTest`. Not sure why tests suddenly failing.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/11208481488/job/31152221363
```
  1) Error:
ActiveRecord::PredicateBuilderTest#test_registering_new_handlers_for_association_coerced:
NameError: undefined local variable or method `topic_title' for an instance of ActiveRecord::PredicateBuilderTest
    /usr/local/bundle/bundler/gems/rails-967c33d493e5/activerecord/lib/active_record/test_fixtures.rb:280:in `method_missing'
    test/cases/coerced_tests.rb:1341:in `test_registering_new_handlers_for_association_coerced'

  2) Error:
ActiveRecord::PredicateBuilderTest#test_registering_new_handlers_coerced:
NameError: undefined local variable or method `topic_title' for an instance of ActiveRecord::PredicateBuilderTest
    /usr/local/bundle/bundler/gems/rails-967c33d493e5/activerecord/lib/active_record/test_fixtures.rb:280:in `method_missing'
    test/cases/coerced_tests.rb:1335:in `test_registering_new_handlers_coerced'
```