### PR TITLE
Allow INSERT statements with SELECT notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixed
 
-- [#](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/) Allow INSERT statements with SELECT notation
+- [#1245](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1245) Allow INSERT statements with SELECT notation
 
 ## v7.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/) Allow INSERT statements with SELECT notation
+
 ## v7.1.8
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -681,6 +681,7 @@ module ActiveRecord
             s.split(/INSERT INTO/i)[1]
               .split(/OUTPUT INSERTED/i)[0]
               .split(/(DEFAULT)?\s+VALUES/i)[0]
+              .split(/\bSELECT\b(?![^\[]*\])/i)[0]
               .match(/\s*([^(]*)/i)[0]
           elsif s.match?(/^\s*UPDATE\s+.*/i)
             s.match(/UPDATE\s+([^\(\s]+)\s*/i)[1]

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -96,6 +96,10 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       it do
         assert_equal "[test].[aliens]", connection.send(:get_raw_table_name, "EXEC sp_executesql N'INSERT INTO [test].[aliens] ([name]) OUTPUT INSERTED.[id] VALUES (@0)', N'@0 varchar(255)', @0 = 'Trisolarans'")
       end
+
+      it do
+        assert_equal "[with].[select notation]", connection.send(:get_raw_table_name, "INSERT INTO [with].[select notation] SELECT * FROM [table_name]")
+      end
     end
   end
 end


### PR DESCRIPTION
Backport of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1238