### PR TITLE
Fix queries with date and date-time placeholder conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@
 - [#1215](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1215) Fix mismatched foreign key errors
 - [#1228](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1228) Enable identity insert on view's base table
 - [#1238](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1238) Allow INSERT statements with SELECT notation
+- [#1246](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1246) Fix queries with date and date-time placeholder conditions
 
 Please check [7-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/7-1-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -334,7 +334,7 @@ module ActiveRecord
             end
           end
 
-          value = basic_attribute_type?(attr) ? attr : attr.value_for_database
+          value = active_model_attribute?(attr) ? attr.value_for_database : attr
 
           if value.is_a?(Numeric)
             value > 2_147_483_647 ? "bigint".freeze : "int".freeze
@@ -344,7 +344,7 @@ module ActiveRecord
         end
 
         def sp_executesql_sql_param(attr)
-          return quote(attr) if basic_attribute_type?(attr)
+          return quote(attr) unless active_model_attribute?(attr)
 
           case value = attr.value_for_database
           when Type::Binary::Data, ActiveRecord::Type::SQLServer::Data
@@ -354,15 +354,8 @@ module ActiveRecord
           end
         end
 
-        def basic_attribute_type?(type)
-          type.is_a?(Symbol) ||
-            type.is_a?(String) ||
-            type.is_a?(Numeric) ||
-            type.is_a?(Time) ||
-            type.is_a?(Date) ||
-            type.is_a?(TrueClass) ||
-            type.is_a?(FalseClass) ||
-            type.is_a?(NilClass)
+        def active_model_attribute?(type)
+          type.is_a?(::ActiveModel::Attribute)
         end
 
         def sp_executesql_sql(sql, types, params, name)

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -359,6 +359,7 @@ module ActiveRecord
             type.is_a?(String) ||
             type.is_a?(Numeric) ||
             type.is_a?(Time) ||
+            type.is_a?(Date) ||
             type.is_a?(TrueClass) ||
             type.is_a?(FalseClass) ||
             type.is_a?(NilClass)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -602,4 +602,18 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       @conn.execute("ALTER TABLE engines DROP COLUMN old_car_id") rescue nil
     end
   end
+
+  describe "placeholder conditions" do
+    it 'using time placeholder' do
+      assert_equal Task.where("starting < ?", Time.now).count, 1
+    end
+
+    it 'using date placeholder' do
+      assert_equal Task.where("starting < ?", Date.today).count, 1
+    end
+
+    it 'using date-time placeholder' do
+      assert_equal Task.where("starting < ?", DateTime.current).count, 1
+    end
+  end
 end


### PR DESCRIPTION
Fix queries with date and date-time placeholder conditions such as:

```ruby
where("written_on < ?", Date.today)
where("written_on < ?", DateTime.current) 
```

This should fix #1243.