### PR TITLE
Fixed the ordering of optimizer hints in the generated SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1244](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1244) Allow INSERT statements with SELECT notation
 - [#1247](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1247) Fix queries with date and date-time placeholder conditions
 - [#1249](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1249) Binary basic columns should be limitable
+- [#1255](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1255)Fixed the ordering of optimizer hints in the generated SQL
 
 ## v7.2.1
 

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -140,13 +140,10 @@ module Arel
           collector = visit o.with, collector
           collector << " "
         end
-        collector = o.cores.inject(collector) { |c, x|
-          if x.is_a? Arel::Nodes::SelectCore
-            # optimizer hints in SQL Server have to be at the very end of the query, so we need to hold onto these for now
-            optimizer_hints = x.optimizer_hints
-          end
-          visit_Arel_Nodes_SelectCore(x, c)
-        }
+        collector = o.cores.inject(collector) do |collect, core|
+          optimizer_hints = core.optimizer_hints if core.optimizer_hints
+          visit_Arel_Nodes_SelectCore(core, collect)
+        end
         collector = visit_Orders_And_Let_Fetch_Happen o, collector
         collector = visit_Make_Fetch_Happen o, collector
         collector = maybe_visit optimizer_hints, collector

--- a/test/cases/optimizer_hints_test_sqlserver.rb
+++ b/test/cases/optimizer_hints_test_sqlserver.rb
@@ -36,6 +36,15 @@ class OptimizerHitsTestSQLServer < ActiveRecord::TestCase
     end
   end
 
+
+  it "support order" do
+    assert_queries_match(%r{\ASELECT .+ FROM .+ ORDER .+ OPTION .+\z}) do
+      companies = Company.optimizer_hints("LABEL='FindCompanies'")
+      companies = companies.order(:id)
+      companies.to_a
+    end
+  end
+
   it "sanitize values" do
     assert_queries_match(%r{\ASELECT .+ FROM .+ OPTION \(HASH GROUP\)\z}) do
       companies = Company.optimizer_hints("OPTION (HASH GROUP)")


### PR DESCRIPTION
When optimization hints and ordering are used in the same query the ordering should come first in the generated SQL.

Fix for #1240.