### PR TITLE
Fix distinct alias when multiple databases used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 #### Fixed
 
-- [#1262](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1262) Fix distinct alias when multiple databases used
+- [#1262](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1262) Fix distinct alias when multiple databases used.
 
 ## v8.0.0
 
 #### Changed
 
-- [#1216](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1216) Refactor adapter interface to match abstract adapter
-- [#1225](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1225) Drop support to Ruby 3.1
+- [#1216](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1216) Refactor adapter interface to match abstract adapter.
+- [#1225](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1225) Drop support to Ruby 3.1.
 
 #### Fixed
 
-- [#1215](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1215) Fix mismatched foreign key errors
+- [#1215](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1215) Fix mismatched foreign key errors.
 
 Please check [7-2-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/7-2-stable/CHANGELOG.md) for previous changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1262](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1262) Fix distinct alias when multiple databases used
+
 ## v8.0.0
 
 #### Changed

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -347,12 +347,16 @@ module ActiveRecord
 
         def columns_for_distinct(columns, orders)
           order_columns = orders.reject(&:blank?).map { |s|
-                            s = s.to_sql unless s.is_a?(String)
+                            s = visitor.compile(s) unless s.is_a?(String)
                             s.gsub(/\s+(?:ASC|DESC)\b/i, "")
                              .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
-                          }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
+                            }
+                            .reject(&:blank?)
+                            .reject { |s| columns.include?(s) }
 
-          (order_columns << super).join(", ")
+          order_columns_aliased = order_columns.map.with_index { |column, i| "#{column} AS alias_#{i}" }
+
+          (order_columns_aliased << super).join(", ")
         end
 
         def update_table_definition(table_name, base)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -616,4 +616,13 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal Task.where("starting < ?", DateTime.current).count, 1
     end
   end
+
+  describe "distinct select query" do
+    it "generated SQL does not contain unnecessary alias projection" do
+      sqls = capture_sql do
+        Post.includes(:comments).joins(:comments).first
+      end
+      assert_no_match(/AS alias_0/, sqls.first)
+    end
+  end
 end


### PR DESCRIPTION
Fix issue with the generated SQL for DISTINCT queries as reported in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1256. The generated SQL:
- Unnecessarily added a ALIAS AS projection. 
- The column used of the ALIAS AS was being incorrectly quoted. This was caused by MySQL database also being used in multi database Rails application.

```ruby
Post.includes(:comments).joins(:comments).first
```

**Before:**

```sql
SELECT DISTINCT [posts].[id] AS alias_0, [posts].[id] FROM [posts] INNER JOIN [comments] ON [comments].[post_id] = [posts].[id] ORDER BY [posts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY
```

**After:**

```sql
SELECT DISTINCT [posts].[id] FROM [posts] INNER JOIN [comments] ON [comments].[post_id] = [posts].[id] ORDER BY [posts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY
```