### PR TITLE
TinyTDS v3+ is now required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Unreleased
 
+#### Changed
+
+- [#1273](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1273) TinyTDS v3+ is now required.
+
 
 Please check [8-0-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8-0-stable/CHANGELOG.md) for previous changes.

--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", "~> 8.1.0.alpha"
-  spec.add_dependency "tiny_tds"
+  spec.add_dependency "tiny_tds", "~> 3"
 end

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -461,13 +461,8 @@ module ActiveRecord
           handle
         end
 
-        # TinyTDS returns false instead of raising an exception if connection fails.
-        # Getting around this by raising an exception ourselves while PR
-        # https://github.com/rails-sqlserver/tiny_tds/pull/469 is not released.
         def internal_raw_execute(sql, raw_connection, perform_do: false)
           result = raw_connection.execute(sql)
-          raise TinyTds::Error, "failed to execute statement" if result.is_a?(FalseClass)
-
           perform_do ? result.do : result
         end
       end


### PR DESCRIPTION
`tiny_tds` now raises an error message in case it is unable to send a query, removing the need for the respective workaround in `activerecord-sql-adapter`.

https://github.com/rails-sqlserver/tiny_tds/pull/560