### PR TITLE
Coerce test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -383,6 +383,22 @@ module ActiveRecord
 end
 
 class CalculationsTest < ActiveRecord::TestCase
+  # SELECT columns must be in the GROUP clause.
+  coerce_tests! :test_should_count_with_group_by_qualified_name_on_loaded
+  def test_should_count_with_group_by_qualified_name_on_loaded_coerced
+    accounts = Account.group("accounts.id").select("accounts.id")
+
+    expected = { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1 }
+
+    assert_not_predicate accounts, :loaded?
+    assert_equal expected, accounts.count
+
+    accounts.load
+
+    assert_predicate accounts, :loaded?
+    assert_equal expected, accounts.count(:id)
+  end
+
   # Fix randomly failing test. The loading of the model's schema was affecting the test.
   coerce_tests! :test_offset_is_kept
   def test_offset_is_kept_coerced


### PR DESCRIPTION
Coerce `CalculationsTest#test_should_count_with_group_by_qualified_name_on_loaded` test.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/12397362939/job/34607551888
```
  1) Error:
CalculationsTest#test_should_count_with_group_by_qualified_name_on_loaded:
ActiveRecord::StatementInvalid: TinyTds::Error: Column 'accounts.firm_id' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause.
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:446:in `each'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:446:in `handle_to_names_and_values'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:67:in `internal_exec_sql_query'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:25:in `perform_query'
```