### PR TITLE
Remove special handling for older TDS connections

### DIFF
--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -277,7 +277,7 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       _(col.sql_type).must_equal           "date"
       _(col.type).must_equal               :date
       _(col.null).must_equal               true
-      _(col.default).must_equal            connection_tds_73 ? Date.civil(1, 1, 1) : "0001-01-01"
+      _(col.default).must_equal            Date.civil(1, 1, 1)
       _(obj.date).must_equal               Date.civil(1, 1, 1)
       _(col.default_function).must_be_nil
       type = connection.lookup_cast_type_from_column(col)
@@ -357,7 +357,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it "datetime2" do
-      skip "datetime2 not supported in this protocol version" unless connection_tds_73
       col = column("datetime2_7")
       _(col.sql_type).must_equal           "datetime2(7)"
       _(col.type).must_equal               :datetime
@@ -422,7 +421,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it "datetimeoffset" do
-      skip "datetimeoffset not supported in this protocol version" unless connection_tds_73
       col = column("datetimeoffset_7")
       _(col.sql_type).must_equal           "datetimeoffset(7)"
       _(col.type).must_equal               :datetimeoffset
@@ -491,7 +489,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it "time(7)" do
-      skip "time() not supported in this protocol version" unless connection_tds_73
       col = column("time_7")
       _(col.sql_type).must_equal           "time(7)"
       _(col.type).must_equal               :time
@@ -523,7 +520,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it "time(2)" do
-      skip "time() not supported in this protocol version" unless connection_tds_73
       col = column("time_2")
       _(col.sql_type).must_equal           "time(2)"
       _(col.type).must_equal               :time
@@ -553,7 +549,6 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
     end
 
     it "time using default precision" do
-      skip "time() not supported in this protocol version" unless connection_tds_73
       col = column("time_default")
       _(col.sql_type).must_equal           "time(7)"
       _(col.type).must_equal               :time

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -28,17 +28,13 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     # Date and Time
     assert_line :date,              type: "date",                                                       default: "01-01-0001"
     assert_line :datetime,          type: "datetime",                    precision: nil,                default: "01-01-1753 00:00:00.123"
-    if connection_tds_73
-      assert_line :datetime2_7,     type: "datetime",                    precision: 7,                  default: "12-31-9999 23:59:59.9999999"
-      assert_line :datetime2_3,     type: "datetime",                    precision: 3
-      assert_line :datetime2_1,     type: "datetime",                    precision: 1
-    end
+    assert_line :datetime2_7,       type: "datetime",                    precision: 7,                  default: "12-31-9999 23:59:59.9999999"
+    assert_line :datetime2_3,       type: "datetime",                    precision: 3
+    assert_line :datetime2_1,       type: "datetime",                    precision: 1
     assert_line :smalldatetime,     type: "smalldatetime",                                              default: "01-01-1901 15:45:00.0"
-    if connection_tds_73
-      assert_line :time_7,          type: "time",                        precision: 7,                  default: "04:20:00.2883215"
-      assert_line :time_2,          type: "time",                        precision: 2
-      assert_line :time_default,    type: "time",                        precision: 7,                  default: "15:03:42.0621978"
-    end
+    assert_line :time_7,            type: "time",                        precision: 7,                  default: "04:20:00.2883215"
+    assert_line :time_2,            type: "time",                        precision: 2
+    assert_line :time_default,      type: "time",                        precision: 7,                  default: "15:03:42.0621978"
     # Character Strings
     assert_line :char_10,           type: "char",          limit: 10,                                   default: "1234567890"
     assert_line :varchar_50,        type: "varchar",       limit: 50,                                   default: "test varchar_50"

--- a/test/support/connection_reflection.rb
+++ b/test/support/connection_reflection.rb
@@ -15,11 +15,6 @@ module ARTest
         connection.instance_variable_get :@connection_parameters
       end
 
-      def connection_tds_73
-        rc = connection.raw_connection
-        rc.respond_to?(:tds_73?) && rc.tds_73?
-      end
-
       def connection_sqlserver_azure?
         connection.sqlserver_azure?
       end


### PR DESCRIPTION
`tiny_tds` v3 will raise an exception when using a TDS version older than v7.3 for the server connections. This is mostly to enforce that people do no longer use `tiny_tds` with ancient SQL servers (and report issues). But therefore, we can remove a couple of special cases in the `sqlserver-adapter` tests where they behaved differently if ran against older versions.