### PR TITLE
Revert "Not compatible with TinyTDS v3+"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 #### Fixed
 
 - [#1270](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1270) Fix parsing of raw table name from SQL with extra parentheses
-- [#1277](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1277) Not compatible with TinyTDS v3+
--
+
 ## v7.2.3
 
 #### Fixed

--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", "~> 7.2.0"
-  spec.add_dependency "tiny_tds", "~> 2.0"
+  spec.add_dependency "tiny_tds"
 end


### PR DESCRIPTION
Reverts rails-sqlserver/activerecord-sqlserver-adapter#1277