### PR TITLE
Revert "Not compatible with TinyTDS v3+"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 #### Fixed
 
 - [#1272](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1272) Fix parsing of raw table name from SQL with extra parentheses
-- [#1276](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1276) Not compatible with TinyTDS v3+
 
 ## v8.0.1
 

--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", "~> 8.0.0"
-  spec.add_dependency "tiny_tds", "~> 2.0"
+  spec.add_dependency "tiny_tds"
 end


### PR DESCRIPTION
Reverts rails-sqlserver/activerecord-sqlserver-adapter#1276