### PR TITLE
Rename test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1576,7 +1576,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       @schema_migration.create_version(v)
     end
 
-    schema_info = ActiveRecord::Base.lease_connection.dump_schema_information
+    schema_info = ActiveRecord::Base.lease_connection.dump_schema_versions
     expected = <<~STR
     INSERT INTO #{quote_table_name("schema_migrations")} (version) VALUES
     (N'20100301010101'),

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1569,8 +1569,8 @@ end
 
 class SchemaDumperTest < ActiveRecord::TestCase
   # Use nvarchar string (N'') in assert
-  coerce_tests! :test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order
-  def test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order_coerced
+  coerce_tests! :test_dump_schema_versions_outputs_lexically_reverse_ordered_versions_regardless_of_database_order
+  def test_dump_schema_versions_outputs_lexically_reverse_ordered_versions_regardless_of_database_order_coerced
     versions = %w{ 20100101010101 20100201010101 20100301010101 }
     versions.shuffle.each do |v|
       @schema_migration.create_version(v)
@@ -1578,7 +1578,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     schema_info = ActiveRecord::Base.lease_connection.dump_schema_information
     expected = <<~STR
-    INSERT INTO #{ActiveRecord::Base.lease_connection.quote_table_name("schema_migrations")} (version) VALUES
+    INSERT INTO #{quote_table_name("schema_migrations")} (version) VALUES
     (N'20100301010101'),
     (N'20100201010101'),
     (N'20100101010101');


### PR DESCRIPTION
Fix:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/12541738225/job/34970653846#step:4:486
```
1) Error:
SchemaDumperTest#test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order_coerced:
NoMethodError: undefined method `dump_schema_information' for an instance of ActiveRecord::ConnectionAdapters::SQLServerAdapter
    test/cases/coerced_tests.rb:1579:in `test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order_coerced'

  2) Failure:
SchemaDumperTest#test_dump_schema_versions_outputs_lexically_reverse_ordered_versions_regardless_of_database_order [/usr/local/bundle/bundler/gems/rails-92b3160dd65f/activerecord/test/cases/schema_dumper_test.rb:40]:
--- expected
+++ actual
@@ -1,4 +1,4 @@
 "INSERT INTO [schema_migrations] (version) VALUES
-('20100301010101'),
-('20100201010101'),
-('20100101010101');"
+(N'20100301010101'),
+(N'20100201010101'),
+(N'20100101010101');"

```