### PR TITLE
Limit `tiny_tds` to v3

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", "~> 8.1.0.alpha"
-  spec.add_dependency "tiny_tds", "~> 3"
+  spec.add_dependency "tiny_tds", "~> 3.0"
 end


### PR DESCRIPTION
I am somewhat ashamed, but I only recently learned how the lazy operator (`~>`) resolves.

I think it would be good to restrict `tiny_tds` to the current major version. I have plans for v4, which would have breaking API changes, and the current `~> 3` would allow people to upgrade to v4, which we should prevent.

Sorry about that!