### PR TITLE
Exist queries are retryable

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/finder_methods.rb
@@ -33,7 +33,7 @@ module ActiveRecord
               end
               # End of monkey-patch
             else
-              relation = except(:select, :distinct, :order)._select!(::ActiveRecord::FinderMethods::ONE_AS_ONE).limit!(1)
+              relation = except(:select, :distinct, :order)._select!(Arel.sql(::ActiveRecord::FinderMethods::ONE_AS_ONE, retryable: true)).limit!(1)
             end
 
             case conditions

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1971,7 +1971,7 @@ module ActiveRecord
         # Revert changes
         @connection.change_column_default(:sst_datatypes, :datetime, current_default) if current_default.present?
       end
-      
+
       # We need to give the full paths for this to work.
       undef_method :schema_dump_5_1_path
       def schema_dump_5_1_path
@@ -2796,3 +2796,14 @@ module ActiveRecord
   end
 end
 
+module ActiveRecord
+  class AdapterConnectionTest < ActiveRecord::TestCase
+    # Original method defined for core adapters.
+    undef_method :raw_transaction_open?
+    def raw_transaction_open?(connection)
+      connection.instance_variable_get(:@raw_connection).query("SELECT @@trancount").to_a[0][0] > 0
+    rescue
+      false
+    end
+  end
+end


### PR DESCRIPTION
Fix following tests:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/13201053254/job/36852898476
```
  4) Failure:
ActiveRecord::AdapterConnectionTest#test_0015_idempotent SELECT queries allow retries [/usr/local/bundle/bundler/gems/rails-cd4708bbcd0d/activerecord/test/cases/adapter_test.rb:716]:
Expected false to be truthy.

Skipped:
ActiveRecord::AdapterConnectionTest#test_0015_idempotent SELECT queries allow retries [/usr/local/bundle/bundler/gems/rails-cd4708bbcd0d/activerecord/test/cases/adapter_test.rb:716]:
kill_connection_from_server unsupported

  5) Failure:
ActiveRecord::AdapterConnectionTest#test_0016_query cacheable idempotent SELECT queries allow retries [/usr/local/bundle/bundler/gems/rails-cd4708bbcd0d/activerecord/test/cases/adapter_test.rb:735]:
EXEC sp_executesql N'SELECT 1 AS one FROM [posts] ORDER BY [posts].[id] ASC OFFSET 0 ROWS FETCH NEXT @0 ROWS ONLY', N'@0 int', @0 = 1 was not retryable

Skipped:
ActiveRecord::AdapterConnectionTest#test_0016_query cacheable idempotent SELECT queries allow retries [/usr/local/bundle/bundler/gems/rails-cd4708bbcd0d/activerecord/test/cases/adapter_test.rb:735]:
kill_connection_from_server unsupported
```


Ref: https://github.com/rails/rails/pull/54436