### PR TITLE
Register char types as string

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -401,7 +401,7 @@ module ActiveRecord
           m.register_type              "nvarchar(max)",     SQLServer::Type::UnicodeVarcharMax.new
           m.register_type              "nvarchar(max)",     SQLServer::Type::UnicodeVarcharMax.new
           m.register_type              "ntext",             SQLServer::Type::UnicodeText.new
-          m.register_type              %r(char)i,           SQLServer::Type::String.new
+          m.register_type              %r(varchar)i,        SQLServer::Type::String.new
 
           # Binary Strings
           register_class_with_limit m, %r{\Abinary}i,       SQLServer::Type::Binary

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -401,6 +401,7 @@ module ActiveRecord
           m.register_type              "nvarchar(max)",     SQLServer::Type::UnicodeVarcharMax.new
           m.register_type              "nvarchar(max)",     SQLServer::Type::UnicodeVarcharMax.new
           m.register_type              "ntext",             SQLServer::Type::UnicodeText.new
+          m.register_type              %r(char)i,           SQLServer::Type::String.new
 
           # Binary Strings
           register_class_with_limit m, %r{\Abinary}i,       SQLServer::Type::Binary


### PR DESCRIPTION
Fix:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/13243848935/job/36965407890#step:4:525
```
  1) Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_yaml_load_8_0_dump_without_cast_type_still_get_the_right_one [/usr/local/bundle/bundler/gems/rails-50efa73e0a96/activerecord/test/cases/connection_adapters/schema_cache_test.rb:195]:
Expected: :string
  Actual: :varchar
```