### PR TITLE
Fix for checking if raw connection transaction open

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2805,10 +2805,11 @@ end
 
 module ActiveRecord
   class AdapterConnectionTest < ActiveRecord::TestCase
-    # Original method defined for core adapters.
+    # Original method only handled the core adapters.
     undef_method :raw_transaction_open?
     def raw_transaction_open?(connection)
-      connection.instance_variable_get(:@raw_connection).query("SELECT @@trancount").to_a[0][0] > 0
+      transaction_count = connection.instance_variable_get(:@raw_connection).execute("SELECT @@TRANCOUNT AS TRANSACTION_COUNT").first["TRANSACTION_COUNT"]
+      transaction_count > 0
     rescue
       false
     end


### PR DESCRIPTION
Fix for checking if raw connection transaction open.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/13243848935/job/36965406558
```
  2) Failure:
ActiveRecord::AdapterConnectionTest#test_0006_unmaterialized transaction state can be restored after a reconnect [/usr/local/bundle/bundler/gems/rails-50efa73e0a96/activerecord/test/cases/adapter_test.rb:604]:
Expected false to be truthy.

  3) Failure:
ActiveRecord::AdapterConnectionTest#test_0003_materialized transaction state can be restored after a reconnect [/usr/local/bundle/bundler/gems/rails-50efa73e0a96/activerecord/test/cases/adapter_test.rb:570]:
Expected false to be truthy.

  4) Failure:
ActiveRecord::AdapterConnectionTest#test_0002_materialized transaction state is reset after a reconnect [/usr/local/bundle/bundler/gems/rails-50efa73e0a96/activerecord/test/cases/adapter_test.rb:560]:
Expected false to be truthy.

  5) Failure:
ActiveRecord::AdapterConnectionTest#test_0004_materialized transaction state is reset after a disconnect [/usr/local/bundle/bundler/gems/rails-50efa73e0a96/activerecord/test/cases/adapter_test.rb:580]:
Expected false to be truthy.
```