### PR TITLE
Coerce relation test

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1537,8 +1537,11 @@ module ActiveRecord
       assert_equal expected, query
     end
 
-    # Order column must be in the GROUP clause. However, with implicit ordering we can't test this when selecting expression column.
-    coerce_tests! %r{runs queries when using pick with expression column and empty IN}
+    # Order column must be in the GROUP clause. However, with implicit ordering we can't test this when selecting non-aggregate expression column.
+    coerce_tests! %r{no queries when using pick with non-aggregate expression and empty IN}
+
+    # Order column must be in the GROUP clause. However, with implicit ordering we can't test this when selecting aggregate expression column.
+    coerce_tests! %r{runs queries when using pick with aggregate expression despite empty IN}
   end
 end
 


### PR DESCRIPTION
Fix `ActiveRecord::RelationTest#test_0011_runs queries when using pick with aggregate expression despite empty IN`. Test added by https://github.com/rails/rails/pull/53775

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/13261486046/job/37018909018
```
 2) Error:
ActiveRecord::RelationTest#test_0011_runs queries when using pick with aggregate expression despite empty IN:
ActiveRecord::StatementInvalid: TinyTds::Error: Column "posts.id" is invalid in the ORDER BY clause because it is not contained in either an aggregate function or the GROUP BY clause.
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:446:in `each'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:446:in `handle_to_names_and_values'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:67:in `internal_exec_sql_query'
    lib/active_record/connection_adapters/sqlserver/database_statements.rb:25:in `perform_query'
```