### PR TITLE
Coerce test as cast type in SQL Server is varchar

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1961,6 +1961,20 @@ module ActiveRecord
         end
       end
 
+      # Cast type in SQL Server is :varchar rather than Unicode :string.
+      coerce_tests! :test_yaml_load_8_0_dump_without_cast_type_still_get_the_right_one
+      def test_yaml_load_8_0_dump_without_cast_type_still_get_the_right_one
+        cache = load_bound_reflection(schema_dump_8_0_path)
+
+        assert_no_queries do
+          columns = cache.columns_hash("courses")
+          assert_equal 3, columns.size
+          cast_type = columns["name"].fetch_cast_type(@connection)
+          assert_not_nil cast_type, "expected cast_type to be present"
+          assert_equal :varchar, cast_type.type
+        end
+      end
+
       private
 
       def with_marshable_time_defaults


### PR DESCRIPTION
Coerce test as cast type in SQL Server is varchar. 

Fixes:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/13285243589/job/37092391764
```
  1) Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_yaml_load_8_0_dump_without_cast_type_still_get_the_right_one [/usr/local/bundle/bundler/gems/rails-d3e1fb41e9e2/activerecord/test/cases/connection_adapters/schema_cache_test.rb:195]:
Expected: :string
  Actual: :varchar
```