### PR TITLE
Add support for `INDEX INCLUDE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+#### Added
+
+- [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for INDEX INCLUDE.
+
 #### Changed
 
 - [#1273](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1273) TinyTDS v3+ is now required.

--- a/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_creation.rb
@@ -6,6 +6,8 @@ module ActiveRecord
       class SchemaCreation < SchemaCreation
         private
 
+        delegate :quoted_include_columns_for_index, to: :@conn
+
         def supports_index_using?
           false
         end
@@ -44,9 +46,14 @@ module ActiveRecord
           sql << "INDEX"
           sql << "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
           sql << "(#{quoted_columns(index)})"
+          sql << "INCLUDE (#{quoted_include_columns(index.include)})" if supports_index_include? && index.include
           sql << "WHERE #{index.where}" if index.where
 
           sql.join(" ")
+        end
+
+        def quoted_include_columns(o)
+          (String === o) ? o : quoted_include_columns_for_index(o)
         end
 
         def add_column_options!(sql, options)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -143,6 +143,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_include?
+        true
+      end
+
       def supports_expression_index?
         false
       end


### PR DESCRIPTION
Add support for index include as requested in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/473

Running the following:

```ruby
connection.add_index("testings", "last_name", include: :foo)
```

Before this PR generates:

```SQL
CREATE INDEX [index_testings_on_last_name] ON [testings] ([last_name])
```

After the PR it will generate:

```SQL
CREATE INDEX [index_testings_on_last_name] ON [testings] ([last_name]) INCLUDE ([foo])
```

Multiple include columns are supported using:

```ruby
connection.add_index("testings", "last_name", include: [:foo, :bar])
```


Ref: https://github.com/rails/rails/pull/44803