### PR TITLE
Fix affected rows count when lowercase schema reflection enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1306](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1306) Fix affected rows count when lowercase schema reflection enabled
+
 ## v8.0.2
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -39,7 +39,8 @@ module ActiveRecord
         end
 
         def affected_rows(raw_result)
-          raw_result.first['AffectedRows']
+          column_name = lowercase_schema_reflection ? 'affectedrows' : 'AffectedRows'
+          raw_result.first[column_name]
         end
 
         def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true, batch: false)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -7,6 +7,7 @@ require "models/post"
 require "models/subscriber"
 require "models/minimalistic"
 require "models/college"
+require "models/discount"
 
 class AdapterTestSQLServer < ActiveRecord::TestCase
   fixtures :tasks
@@ -182,6 +183,24 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal "Got a minute?", SSTestUppered.first.column1
       assert_equal "Favorite number?", SSTestUppered.last.column1
       assert SSTestUppered.columns_hash["column2"]
+    end
+
+    it "destroys model with no associations" do
+      connection.lowercase_schema_reflection = true
+
+      rec = Discount.create!
+      assert_equal 1, Discount.count
+      rec.destroy!
+      assert_equal 0, Discount.count
+    end
+
+    it "destroys model with association" do
+      connection.lowercase_schema_reflection = true
+
+      post = Post.create!(title: 'Setup', body: 'Record to be deleted')
+      assert_equal 1, Post.count
+      post.destroy!
+      assert_equal 0, Post.count
     end
   end
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -188,9 +188,9 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     it "destroys model with no associations" do
       connection.lowercase_schema_reflection = true
 
-      rec = Discount.create!
+      discount = Discount.create!
       assert_equal 1, Discount.count
-      rec.destroy!
+      discount.destroy!
       assert_equal 0, Discount.count
     end
 

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -188,19 +188,19 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     it "destroys model with no associations" do
       connection.lowercase_schema_reflection = true
 
-      discount = Discount.create!
-      assert_equal 1, Discount.count
-      discount.destroy!
-      assert_equal 0, Discount.count
+      assert_nothing_raised do
+        discount = Discount.create!
+        discount.destroy!
+      end
     end
 
     it "destroys model with association" do
       connection.lowercase_schema_reflection = true
 
-      post = Post.create!(title: 'Setup', body: 'Record to be deleted')
-      assert_equal 1, Post.count
-      post.destroy!
-      assert_equal 0, Post.count
+      assert_nothing_raised do
+        post = Post.create!(title: 'Setup', body: 'Record to be deleted')
+        post.destroy!
+      end
     end
   end
 


### PR DESCRIPTION
The code to retrieve the rows affected from the results did not take into account that the column name `AffectedRows` could be in lowercase if `lowercase_schema_reflection` setting enabled.

Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1304