### PR TITLE
Fix retrieval of temporary table's column information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+#### Fixed
+
+- [#1308](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1308) Fix retrieval of temporary table's column information.
+
 #### Added
 
 - [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for INDEX INCLUDE.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -43,8 +43,7 @@ module ActiveRecord
 
         # Returns the affected rows from results.
         def affected_rows(raw_result)
-          column_name = lowercase_schema_reflection ? "affectedrows" : "AffectedRows"
-          raw_result&.first&.fetch(column_name, nil)
+          raw_result&.first&.fetch(lowercase_schema_reflection_string("AffectedRows"), nil)
         end
 
         # Returns the affected rows from results or handle.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -43,7 +43,8 @@ module ActiveRecord
 
         # Returns the affected rows from results.
         def affected_rows(raw_result)
-          raw_result&.first&.fetch(lowercase_schema_reflection_string("AffectedRows"), nil)
+          column_name = lowercase_schema_reflection ? "affectedrows" : "AffectedRows"
+          raw_result&.first&.fetch(column_name, nil)
         end
 
         # Returns the affected rows from results or handle.

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -636,18 +636,19 @@ module ActiveRecord
 
           # database = "TEMPDB" if identifier.temporary_table?
 
-          object_name = prepared_statements ? "@0" : quote(identifier.object)
-          schema_name = if identifier.schema.blank?
-            "schema_name()"
+          schema_name = "schema_name()"
+
+          if prepared_statements
+            object_name = "@0"
+            schema_name = "@1" if identifier.schema.present?
           else
-            prepared_statements ? "@1" : quote(identifier.schema)
+            object_name = quote(identifier.object)
+            schema_name = quote(identifier.schema) if identifier.schema.present?
           end
 
-          object_id_arg = if identifier.schema.present?
-                            "CONCAT(@1,''.'',@0)"
-                          else
-                            "@0"
-                          end
+          object_id_arg = identifier.schema.present? ? "CONCAT(#{schema_name},'.',#{object_name})" : object_name
+
+
 
           %{
             SELECT
@@ -702,8 +703,7 @@ module ActiveRecord
               AND k.unique_index_id = ic.index_id
               AND c.column_id = ic.column_id
             WHERE
-              o.name = #{object_name}
-              /* o.Object_ID = Object_ID(#{object_id_arg}) */
+              o.Object_ID = Object_ID(#{object_id_arg})
               AND s.name = #{schema_name}
             ORDER BY
               c.column_id

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -772,10 +772,6 @@ module ActiveRecord
           lowercase_schema_reflection ? "LOWER(#{node})" : node
         end
 
-        def lowercase_schema_reflection_string(str)
-          lowercase_schema_reflection ? str.downcase : str
-        end
-
         # === SQLServer Specific (View Reflection) ====================== #
 
         def view_table_name(table_name)

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -634,7 +634,9 @@ module ActiveRecord
           # puts "column_definitions_sql: identifier=#{identifier}"
           # puts "column_definitions_sql: database=#{database}"
 
-          # database = "TEMPDB" if identifier.temporary_table?
+
+
+
 
           schema_name = "schema_name()"
 
@@ -648,7 +650,10 @@ module ActiveRecord
 
           object_id_arg = identifier.schema.present? ? "CONCAT(#{schema_name},'.',#{object_name})" : object_name
 
-
+          if identifier.temporary_table?
+            database = "TEMPDB"
+            object_id_arg = "CONCAT('#{database}','..',#{object_name})"
+          end
 
           %{
             SELECT

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -631,6 +631,11 @@ module ActiveRecord
         end
 
         def column_definitions_sql(database, identifier)
+          # puts "column_definitions_sql: identifier=#{identifier}"
+          # puts "column_definitions_sql: database=#{database}"
+
+          # database = "TEMPDB" if identifier.temporary_table?
+
           object_name = prepared_statements ? "@0" : quote(identifier.object)
           schema_name = if identifier.schema.blank?
             "schema_name()"
@@ -691,7 +696,7 @@ module ActiveRecord
               AND k.unique_index_id = ic.index_id
               AND c.column_id = ic.column_id
             WHERE
-              o.name = #{object_name}
+              o.Object_ID = Object_ID(#{object_name})
               AND s.name = #{schema_name}
             ORDER BY
               c.column_id

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -631,13 +631,6 @@ module ActiveRecord
         end
 
         def column_definitions_sql(database, identifier)
-          # puts "column_definitions_sql: identifier=#{identifier}"
-          # puts "column_definitions_sql: database=#{database}"
-
-
-
-
-
           schema_name = "schema_name()"
 
           if prepared_statements
@@ -730,7 +723,7 @@ module ActiveRecord
         end
 
         def remove_default_constraint(table_name, column_name)
-          # If their are foreign keys in this table, we could still get back a 2D array, so flatten just in case.
+          # If there are foreign keys in this table, we could still get back a 2D array, so flatten just in case.
           execute_procedure(:sp_helpconstraint, table_name, "nomsg").flatten.select do |row|
             row["constraint_type"] == "DEFAULT on column #{column_name}"
           end.each do |row|

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -81,6 +81,10 @@ module ActiveRecord
             parts.hash
           end
 
+          def temporary_table?
+            object.start_with?("#")
+          end
+
           protected
 
           def parse_raw_name

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -85,10 +85,6 @@ module ActiveRecord
             object.start_with?("#")
           end
 
-          # def temporary_database
-          #   "TEMPDB"
-          # end
-
           protected
 
           def parse_raw_name

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -85,6 +85,10 @@ module ActiveRecord
             object.start_with?("#")
           end
 
+          # def temporary_database
+          #   "TEMPDB"
+          # end
+
           protected
 
           def parse_raw_name

--- a/test/cases/temporary_table_test_sqlserver.rb
+++ b/test/cases/temporary_table_test_sqlserver.rb
@@ -3,48 +3,17 @@
 require "cases/helper_sqlserver"
 
 class TemporaryTableSQLServer < ActiveRecord::TestCase
-  # setup do
-  #   @connection = ActiveRecord::Base.lease_connection
-  #   @connection.create_table(:barcodes, primary_key: "code", id: :uuid, force: true)
-  # end
-  #
-  # # teardown do
-  # #   @connection.drop_table(:barcodes, if_exists: true)
-  # # end
-  #
   def test_insert_into_temporary_table
-    ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
-      puts payload[:sql]
-    end
-
-
     ActiveRecord::Base.with_connection do |conn|
-      temp_table = "#temp_users"
-      # connection.exec_query("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL DROP TABLE #{temp_table}")
+      conn.exec_query("CREATE TABLE #temp_users (id INT IDENTITY(1,1), name NVARCHAR(100))")
 
-      puts "Creating table"
-      conn.exec_query("CREATE TABLE #{temp_table} (id INT IDENTITY(1,1), name NVARCHAR(100))")
+      result = conn.exec_query("SELECT * FROM #temp_users")
+      assert_equal 0, result.count
 
-      puts "Selecting table"
-      result = conn.exec_query("SELECT * FROM #{temp_table}")
-      puts "Result: #{result.to_a}"
+      conn.exec_query("INSERT INTO #temp_users (name) VALUES ('John'), ('Doe')")
 
-      puts "Inserting into table"
-
-      # ❌ This raises "Table doesn’t exist" error
-      conn.exec_query("INSERT INTO #{temp_table} (name) VALUES ('John')")
-
-
-
-      # ✅ Workaround: Only runs if the table still exists in this session
-      # conn.exec_query("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL INSERT INTO #{temp_table} (name) VALUES ('John')")
-
-      # ✅ Workaround: raw_connection works without issue
-      # conn.raw_connection.execute("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL INSERT INTO #{temp_table} (name) VALUES ('John')")
-
-      puts "Selecting table again"
-      result = conn.exec_query("SELECT * FROM #{temp_table}")
-      puts "Result: #{result.to_a}"
+      result = conn.exec_query("SELECT * FROM #temp_users")
+      assert_equal 2, result.count
     end
   end
 end

--- a/test/cases/temporary_table_test_sqlserver.rb
+++ b/test/cases/temporary_table_test_sqlserver.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+
+class TemporaryTableSQLServer < ActiveRecord::TestCase
+  # setup do
+  #   @connection = ActiveRecord::Base.lease_connection
+  #   @connection.create_table(:barcodes, primary_key: "code", id: :uuid, force: true)
+  # end
+  #
+  # # teardown do
+  # #   @connection.drop_table(:barcodes, if_exists: true)
+  # # end
+  #
+  def test_insert_into_temporary_table
+    ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _start, _finish, _id, payload|
+      puts payload[:sql]
+    end
+
+
+    ActiveRecord::Base.with_connection do |conn|
+      temp_table = "#temp_users"
+      # connection.exec_query("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL DROP TABLE #{temp_table}")
+
+      puts "Creating table"
+      conn.exec_query("CREATE TABLE #{temp_table} (id INT IDENTITY(1,1), name NVARCHAR(100))")
+
+      puts "Selecting table"
+      result = conn.exec_query("SELECT * FROM #{temp_table}")
+      puts "Result: #{result.to_a}"
+
+      puts "Inserting into table"
+
+      # ❌ This raises "Table doesn’t exist" error
+      conn.exec_query("INSERT INTO #{temp_table} (name) VALUES ('John')")
+
+
+
+      # ✅ Workaround: Only runs if the table still exists in this session
+      # conn.exec_query("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL INSERT INTO #{temp_table} (name) VALUES ('John')")
+
+      # ✅ Workaround: raw_connection works without issue
+      # conn.raw_connection.execute("IF OBJECT_ID('tempdb..#{temp_table}') IS NOT NULL INSERT INTO #{temp_table} (name) VALUES ('John')")
+
+      puts "Selecting table again"
+      result = conn.exec_query("SELECT * FROM #{temp_table}")
+      puts "Result: #{result.to_a}"
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes an issue with inserting into temporary tables (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1307). 

Temporary tables names start with the `#` character. The issue was happening because we were retrieving the temporary table's column information from the normal database rather than the `TEMPDB` database.

SQL Server does not store the temporary table name as it is given. For example, the `#temp_users` table might be stored in the `TEMPDB..objects` table's `name` column as `#temp_users_________________________________________________________________________________________________________00000000000B`. To get around this the `column_definitions_sql` query has been updated to use the `Object_ID` column instead. 

Ref:

- https://www.sqlservertutorial.net/sql-server-basics/sql-server-temporary-tables
- https://stackoverflow.com/questions/41289527/get-list-of-columns-in-a-temp-table-in-sql-server#41289550
- https://learn.microsoft.com/en-us/sql/t-sql/functions/object-id-transact-sql?view=sql-server-ver16