### PR TITLE
Fix retrieval of temporary table's column information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1308](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1308) Fix retrieval of temporary table's column information.
+
 ## v7.2.4
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -571,12 +571,22 @@ module ActiveRecord
         end
 
         def column_definitions_sql(database, identifier)
-          object_name = prepared_statements ? "@0" : quote(identifier.object)
-          schema_name = if identifier.schema.blank?
-                          "schema_name()"
-                        else
-                          prepared_statements ? "@1" : quote(identifier.schema)
-                        end
+          schema_name = "schema_name()"
+
+          if prepared_statements
+            object_name = "@0"
+            schema_name = "@1" if identifier.schema.present?
+          else
+            object_name = quote(identifier.object)
+            schema_name = quote(identifier.schema) if identifier.schema.present?
+          end
+
+          object_id_arg = identifier.schema.present? ? "CONCAT(#{schema_name},'.',#{object_name})" : object_name
+
+          if identifier.temporary_table?
+            database = "TEMPDB"
+            object_id_arg = "CONCAT('#{database}','..',#{object_name})"
+          end
 
           %{
             SELECT
@@ -631,7 +641,7 @@ module ActiveRecord
               AND k.unique_index_id = ic.index_id
               AND c.column_id = ic.column_id
             WHERE
-              o.name = #{object_name}
+              o.Object_ID = Object_ID(#{object_id_arg})
               AND s.name = #{schema_name}
             ORDER BY
               c.column_id
@@ -653,7 +663,7 @@ module ActiveRecord
         end
 
         def remove_default_constraint(table_name, column_name)
-          # If their are foreign keys in this table, we could still get back a 2D array, so flatten just in case.
+          # If there are foreign keys in this table, we could still get back a 2D array, so flatten just in case.
           execute_procedure(:sp_helpconstraint, table_name, "nomsg").flatten.select do |row|
             row["constraint_type"] == "DEFAULT on column #{column_name}"
           end.each do |row|

--- a/lib/active_record/connection_adapters/sqlserver/utils.rb
+++ b/lib/active_record/connection_adapters/sqlserver/utils.rb
@@ -81,6 +81,10 @@ module ActiveRecord
             parts.hash
           end
 
+          def temporary_table?
+            object.start_with?("#")
+          end
+
           protected
 
           def parse_raw_name

--- a/test/cases/temporary_table_test_sqlserver.rb
+++ b/test/cases/temporary_table_test_sqlserver.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+
+class TemporaryTableSQLServer < ActiveRecord::TestCase
+  def test_insert_into_temporary_table
+    ActiveRecord::Base.with_connection do |conn|
+      conn.exec_query("CREATE TABLE #temp_users (id INT IDENTITY(1,1), name NVARCHAR(100))")
+
+      result = conn.exec_query("SELECT * FROM #temp_users")
+      assert_equal 0, result.count
+
+      conn.exec_query("INSERT INTO #temp_users (name) VALUES ('John'), ('Doe')")
+
+      result = conn.exec_query("SELECT * FROM #temp_users")
+      assert_equal 2, result.count
+    end
+  end
+end


### PR DESCRIPTION
Back-port of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1308