### PR TITLE
Support `insert_all` and `upsert_all` using `MERGE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Added
 
 - [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for INDEX INCLUDE.
+- [#1312](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1312) Add support for `insert_all` and `upsert_all`
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ ActiveRecord::ConnectionAdapters::SQLServerAdapter.showplan_option = 'SHOWPLAN_X
 ```
 **NOTE:** The method we utilize to make SHOWPLANs work is very brittle to complex SQL. There is no getting around this as we have to deconstruct an already prepared statement for the sp_executesql method. If you find that explain breaks your app, simple disable it. Do not open a github issue unless you have a patch.  Please [consult the Rails guides](http://guides.rubyonrails.org/active_record_querying.html#running-explain) for more info.
 
+#### `insert_all` / `upsert_all` support
+
+`insert_all` and `upsert_all` on other database system like MySQL, SQlite or PostgreSQL use a clause with their `INSERT` statement to either skip duplicates (`ON DUPLICATE KEY IGNORE`) or to update the existing record (`ON DUPLICATE KEY UPDATE`). Microsoft SQL Server does not offer these clauses, so the support for these two options is implemented slightly different.
+
+Behind the scenes, we execute a `MERGE` query, which joins your data that you want to insert or update into the table existing on the server. The emphasis here is "JOINING", so we also need to remove any duplicates that might make the `JOIN` operation fail, e.g. something like this:
+
+```ruby
+Book.insert_all [
+  { id: 200, author_id: 8, name: "Refactoring" },
+  { id: 200, author_id: 8, name: "Refactoring" }
+]
+```
+
+The removal of duplicates happens during the SQL query.
+
+Because of this implementation, if you pass `on_duplicate` to `upsert_all`, make sure to assign your value to `target.[column_name]` (e.g. `target.status = GREATEST(target.status, 1)`). To access the values that you want to upsert, use `source.[column_name]`.
 
 ## New Rails Applications
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -156,47 +156,23 @@ module ActiveRecord
         def build_insert_sql(insert) # :nodoc:
           if insert.skip_duplicates? || insert.update_duplicates?
             insert_all = insert.send(:insert_all)
-            conflict_columns = get_conflicted_columns(insert_all:, insert:)
+            columns_with_uniqueness_constraints = get_columns_with_uniqueness_constraints(insert_all:, insert:)
 
             # if we do not have any columns that might have conflicting values, just execute a regular insert
-            return build_sql_for_regular_insert(insert) if conflict_columns.flatten.empty?
+            return build_sql_for_regular_insert(insert) if columns_with_uniqueness_constraints.flatten.empty?
 
-            # why is the "PARTITION BY" clause needed?
-            # in every DBMS system, insert_all / upsert_all is usually implemented with INSERT, that allows to define what happens
-            # when duplicates are found (SKIP OR UPDATE)
-            # by default rows are considered to be unique by every unique index on the table
-            # but since we have to use MERGE in MSSQL, which in return is a JOIN, we have to perform the "de-duplication" ourselves
-            # otherwise the "JOIN" clause would complain about non-unique values and being unable to JOIN the two tables
-            # this works easiest by using PARTITION and make sure that any record
-            # we are trying to insert is "the first one seen across all the potential conflicted columns"
             sql = <<~SQL
-
               MERGE INTO #{insert.model.quoted_table_name} WITH (UPDLOCK, HOLDLOCK) AS target
               USING (
                 SELECT *
                 FROM (
-                  SELECT #{insert.send(:columns_list)}, #{conflict_columns.map.with_index do |group_of_conflicted_columns, index|
-                                                          <<~PARTITION_BY
-                                                            ROW_NUMBER() OVER (
-                                                              PARTITION BY #{group_of_conflicted_columns.map { |column| quote_column_name(column) }.join(",")}
-                                                              ORDER BY #{group_of_conflicted_columns.map { |column| "#{quote_column_name(column)} DESC" }.join(",")}
-                                                            ) AS rn_#{index}
-                                                          PARTITION_BY
-                                                        end.join(", ")
-                                                        }
+                  SELECT #{insert.send(:columns_list)}, #{partition_by_columns_with_uniqueness_constraints(columns_with_uniqueness_constraints:)}
                   FROM (#{insert.values_list})
                   AS t1 (#{insert.send(:columns_list)})
                 ) AS ranked_source
-                WHERE #{conflict_columns.map.with_index do |group_of_conflicted_columns, index|
-                  "rn_#{index} = 1"
-                end.join(" AND ")
-                      }
+                WHERE #{is_first_record_across_all_uniqueness_constraints(columns_with_uniqueness_constraints:)}
               ) AS source
-              ON (#{conflict_columns.map do |columns|
-                columns.map do |column|
-                  "target.#{quote_column_name(column)} = source.#{quote_column_name(column)}"
-                end.join(" AND ")
-              end.join(") OR (")})
+              ON (#{joining_on_columns_with_uniqueness_constraints(columns_with_uniqueness_constraints:)})
             SQL
 
             if insert.update_duplicates?
@@ -206,11 +182,7 @@ module ActiveRecord
                 sql << insert.raw_update_sql
               else
                 if insert.record_timestamps?
-                  sql << insert.model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
-                    if insert.send(:touch_timestamp_attribute?, column_name)
-                      "target.#{quote_column_name(column_name)}=CASE WHEN (#{insert.updatable_columns.map { |column| "(COALESCE(target.#{quote_column_name(column)}, 'NULL') = COALESCE(source.#{quote_column_name(column)}, 'NULL'))" }.join(" AND ")}) THEN target.#{quote_column_name(column_name)} ELSE #{high_precision_current_timestamp} END,"
-                    end
-                  end.join
+                  sql << build_sql_for_recording_timestamps_when_updating(insert:)
                 end
 
                 sql << insert.updatable_columns.map { |column| "target.#{quote_column_name(column)}=source.#{quote_column_name(column)}" }.join(",")
@@ -227,48 +199,6 @@ module ActiveRecord
 
           build_sql_for_regular_insert(insert)
         end
-
-        def build_sql_for_returning(insert:, insert_all:)
-          return "" unless insert_all.returning
-
-          returning_values_sql = if insert_all.returning.is_a?(String)
-            insert_all.returning
-          else
-            Array(insert_all.returning).map do |attribute|
-              if insert.model.attribute_alias?(attribute)
-                "INSERTED.#{quote_column_name(insert.model.attribute_alias(attribute))} AS #{quote_column_name(attribute)}"
-              else
-                "INSERTED.#{quote_column_name(attribute)}"
-              end
-            end.join(",")
-          end
-
-          " OUTPUT #{returning_values_sql}"
-        end
-        private :build_sql_for_returning
-
-        def get_conflicted_columns(insert_all:, insert:)
-          if (unique_by = insert_all.unique_by)
-            [unique_by.columns]
-          else
-            # Compare against every unique constraint (primary key included).
-            # Discard constraints that are not fully included on insert.keys. Prevents invalid queries.
-            # Example: ignore unique index for columns ["name"] if insert keys is ["description"]
-            (insert_all.send(:unique_indexes).map(&:columns) + [insert_all.primary_keys]).select do |columns|
-              columns.to_set.subset?(insert.keys)
-            end
-          end
-        end
-        private :get_conflicted_columns
-
-        def build_sql_for_regular_insert(insert)
-          sql = "INSERT #{insert.into}"
-
-          sql << build_sql_for_returning(insert:, insert_all: insert.send(:insert_all))
-          sql << " #{insert.values_list}"
-          sql
-        end
-        private :build_sql_for_regular_insert
 
         # === SQLServer Specific ======================================== #
 
@@ -571,6 +501,98 @@ module ActiveRecord
           result = raw_connection.execute(sql)
           perform_do ? result.do : result
         end
+
+        # === SQLServer Specific (insert_all / upsert_all support) ===================== #
+        def build_sql_for_returning(insert:, insert_all:)
+          return "" unless insert_all.returning
+
+          returning_values_sql = if insert_all.returning.is_a?(String)
+            insert_all.returning
+          else
+            Array(insert_all.returning).map do |attribute|
+              if insert.model.attribute_alias?(attribute)
+                "INSERTED.#{quote_column_name(insert.model.attribute_alias(attribute))} AS #{quote_column_name(attribute)}"
+              else
+                "INSERTED.#{quote_column_name(attribute)}"
+              end
+            end.join(",")
+          end
+
+          " OUTPUT #{returning_values_sql}"
+        end
+        private :build_sql_for_returning
+
+        def get_columns_with_uniqueness_constraints(insert_all:, insert:)
+          if (unique_by = insert_all.unique_by)
+            [unique_by.columns]
+          else
+            # Compare against every unique constraint (primary key included).
+            # Discard constraints that are not fully included on insert.keys. Prevents invalid queries.
+            # Example: ignore unique index for columns ["name"] if insert keys is ["description"]
+            (insert_all.send(:unique_indexes).map(&:columns) + [insert_all.primary_keys]).select do |columns|
+              columns.to_set.subset?(insert.keys)
+            end
+          end
+        end
+        private :get_columns_with_uniqueness_constraints
+
+        def build_sql_for_regular_insert(insert)
+          sql = "INSERT #{insert.into}"
+
+          sql << build_sql_for_returning(insert:, insert_all: insert.send(:insert_all))
+
+          sql << " #{insert.values_list}"
+          sql
+        end
+        private :build_sql_for_regular_insert
+
+        # why is the "PARTITION BY" clause needed?
+        # in every DBMS system, insert_all / upsert_all is usually implemented with INSERT, that allows to define what happens
+        # when duplicates are found (SKIP OR UPDATE)
+        # by default rows are considered to be unique by every unique index on the table
+        # but since we have to use MERGE in MSSQL, which in return is a JOIN, we have to perform the "de-duplication" ourselves
+        # otherwise the "JOIN" clause would complain about non-unique values and being unable to JOIN the two tables
+        # this works easiest by using PARTITION and make sure that any record
+        # we are trying to insert is "the first one seen across all the potential columns with uniquness constraints"
+        def partition_by_columns_with_uniqueness_constraints(columns_with_uniqueness_constraints:)
+          columns_with_uniqueness_constraints.map.with_index do |group_of_columns_with_uniqueness_constraints, index|
+            <<~PARTITION_BY
+              ROW_NUMBER() OVER (
+                PARTITION BY #{group_of_columns_with_uniqueness_constraints.map { |column| quote_column_name(column) }.join(",")}
+                ORDER BY #{group_of_columns_with_uniqueness_constraints.map { |column| "#{quote_column_name(column)} DESC" }.join(",")}
+              ) AS rn_#{index}
+            PARTITION_BY
+          end.join(", ")
+        end
+        private :partition_by_columns_with_uniqueness_constraints
+
+        def is_first_record_across_all_uniqueness_constraints(columns_with_uniqueness_constraints:)
+          columns_with_uniqueness_constraints.map.with_index do |group_of_columns_with_uniqueness_constraints, index|
+            "rn_#{index} = 1"
+          end.join(" AND ")
+        end
+        private :is_first_record_across_all_uniqueness_constraints
+
+        def joining_on_columns_with_uniqueness_constraints(columns_with_uniqueness_constraints:)
+          columns_with_uniqueness_constraints.map do |columns|
+            columns.map do |column|
+              "target.#{quote_column_name(column)} = source.#{quote_column_name(column)}"
+            end.join(" AND ")
+          end.join(") OR (")
+        end
+        private :joining_on_columns_with_uniqueness_constraints
+
+        # normally, generating the CASE SQL is done entirely by Rails
+        # and you would just hook into "touch_model_timestamps_unless" to add your database-specific instructions
+        # however, since we need to have "target." for the assignment, we also generate the CASE switch ourselves
+        def build_sql_for_recording_timestamps_when_updating(insert:)
+          insert.model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
+            if insert.send(:touch_timestamp_attribute?, column_name)
+              "target.#{quote_column_name(column_name)}=CASE WHEN (#{insert.updatable_columns.map { |column| "(COALESCE(target.#{quote_column_name(column)}, 'NULL') = COALESCE(source.#{quote_column_name(column)}, 'NULL'))" }.join(" AND ")}) THEN target.#{quote_column_name(column_name)} ELSE #{high_precision_current_timestamp} END,"
+            end
+          end.join
+        end
+        private :build_sql_for_recording_timestamps_when_updating
       end
     end
   end

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -759,6 +759,8 @@ module ActiveRecord
               .match(/\s*([^(]*)/i)[0]
           elsif s.match?(/^\s*UPDATE\s+.*/i)
             s.match(/UPDATE\s+([^\(\s]+)\s*/i)[1]
+          elsif s.match?(/^\s*MERGE INTO.*/i)
+            s.match(/^\s*MERGE\s+INTO\s+(\[?[a-z_ -]+\]?\.?\[?[a-z_ -]+\]?)\s+(AS|WITH|USING)/i)[1]
           else
             s.match(/FROM[\s|\(]+((\[[^\(\]]+\])|[^\(\s]+)\s*/i)[1]
           end.strip

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -216,7 +216,7 @@ module ActiveRecord
       end
 
       def supports_insert_on_duplicate_skip?
-        false
+        true
       end
 
       def supports_insert_on_duplicate_update?

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -220,7 +220,7 @@ module ActiveRecord
       end
 
       def supports_insert_on_duplicate_update?
-        false
+        true
       end
 
       def supports_insert_conflict_target?

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2552,6 +2552,18 @@ class InsertAllTest < ActiveRecord::TestCase
     Book.where(author_id: nil, name: '["Array"]').delete_all
     Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
   end
+
+  # Same as original but using target.status for assignment and GREATEST for operator
+  coerce_tests! :test_upsert_all_updates_using_provided_sql
+  def test_upsert_all_updates_using_provided_sql_coerced
+    Book.upsert_all(
+      [{id: 1, status: 1}, {id: 2, status: 1}],
+      on_duplicate: Arel.sql("target.status = GREATEST(target.status, 1)")
+    )
+
+    assert_equal "published", Book.find(1).status
+    assert_equal "written", Book.find(2).status
+  end
 end
 
 module ActiveRecord

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -102,6 +102,24 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       end
     end
 
+    describe "MERGE statements" do
+      it do
+        assert_equal "[dashboards]", connection.send(:get_raw_table_name, "MERGE INTO [dashboards] AS target")
+      end
+
+      it do
+        assert_equal "lock_without_defaults", connection.send(:get_raw_table_name, "MERGE INTO lock_without_defaults AS target")
+      end
+
+      it do
+        assert_equal "[WITH - SPACES]", connection.send(:get_raw_table_name, "MERGE INTO [WITH - SPACES] AS target")
+      end
+
+      it do
+        assert_equal "[with].[select notation]", connection.send(:get_raw_table_name, "MERGE INTO [with].[select notation] AS target")
+      end
+    end
+
     describe "CREATE VIEW statements" do
       it do
         assert_equal "test_table_as", connection.send(:get_raw_table_name, "CREATE VIEW test_views ( test_table_a_id, test_table_b_id ) AS SELECT test_table_as.id as test_table_a_id, test_table_bs.id as test_table_b_id FROM (test_table_as with(nolock) LEFT JOIN test_table_bs with(nolock) ON (test_table_as.id = test_table_bs.test_table_a_id))")


### PR DESCRIPTION
This PR adds support for `insert_all` and `upsert_all` in the `activerecord-sqlserver-adapter`. As initially propsed on #859 / #869, it uses `MERGE` to achieve so.

The benefit of `ON DUPLICATE` clauses in other database systems is that you can pass it every data that you have in your Rails app without the need for de-duplication. With `MERGE`, it technically executes a join between the data we want to insert and the data in the target table. therefore, the values in the columns of our source data, which will be joined, need to be unique. Unique means unique across all primary keys and indexes with uniqueness. The following Rails test show-cases this well:

```ruby
 def test_insert_all_with_skip_duplicates_and_autonumber_id_not_given
    skip unless supports_insert_on_duplicate_skip?

    assert_difference "Book.count", 1 do
      # These two books are duplicates according to an index on %i[author_id name]
      # but their IDs are not specified so they will be assigned different IDs
      # by autonumber. We will get an exception from MySQL if we attempt to skip
      # one of these records by assigning its ID.
      Book.insert_all [
        { author_id: 8, name: "Refactoring" },
        { author_id: 8, name: "Refactoring" }
      ]
    end
  end
```

From the adapter, we can ask Rails about indexes with uniqueness and all the primary keys for a given table. With that information, I run a `PARTITION BY` for each affected column (in the example above, one is the combination of `author_id` and `name`, the second is just the `id` column as primary key) over the source data, retrieve a `ROW NUMBER` and only keep the records where their `ROW NUMBER` is 1.

The rest of the code is then mostly as in other database adapters. More details are also provided in the code comments.

**Performance**

The big advantage of `insert_all` and `upsert_all` is performance. I did not run extensive benchmarks for now, but just tried a basic case, which is to insert 50'000 simple post records.

If I insert them all one by one ([gist](https://gist.github.com/andyundso/f63d3c651ec4d193bb82a4b37229bf14)), this takes about 144 seconds on my machine. If use `insert_all`, this takes 0.48 seconds. ([gist](https://gist.github.com/andyundso/665907d0257ded3f8fc2596672b2cf34)). If `insert_all` has a lot of collisions, like in [this gist](https://gist.github.com/andyundso/1fb249cd9bd20d12e70a568283f57f7f), the time goes up to 5 seconds. I also tested this collision script with MySQL, where the time to insert remains constant at 0.5 seconds.

I need to test some more.