### PR TITLE
Correctly retrieve the SQL Server database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,8 @@
 
 - [#1273](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1273) TinyTDS v3+ is now required.
 
+#### Fixed
+
+- [#1313](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313) Correctly retrieve the SQL Server database version.
 
 Please check [8-0-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8-0-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -486,13 +486,12 @@ module ActiveRecord
       end
 
       def version_year
-        @version_year ||= begin
+        @version_year ||=
           if /vNext/.match?(sqlserver_version)
             2016
           else
             /SQL Server (\d+)/.match(sqlserver_version).to_a.last.to_s.to_i
           end
-        end
       end
 
       def sqlserver_version

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -496,7 +496,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= execute("SELECT @@VERSION").rows.first.first.to_s
+        @sqlserver_version ||= execute("SELECT @@version").rows.first.first.to_s
       end
 
       private

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -492,13 +492,11 @@ module ActiveRecord
           else
             /SQL Server (\d+)/.match(sqlserver_version).to_a.last.to_s.to_i
           end
-        rescue
-          2016
         end
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        @sqlserver_version ||= execute("SELECT @@VERSION").rows.first.first.to_s
       end
 
       private

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -496,7 +496,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= execute("SELECT @@version").rows.first.first.to_s
+        @sqlserver_version ||= execute("SELECT @@version", "SCHEMA").rows.first.first.to_s
       end
 
       private

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -15,6 +15,14 @@ require "support/connection_reflection"
 require "support/query_assertions"
 require "mocha/minitest"
 
+Minitest.after_run do
+  puts "\n\n"
+  puts "=" * 80
+  puts ActiveRecord::Base.lease_connection.send(:sqlserver_version)
+  puts "\nSQL Server Version Year: #{ActiveRecord::Base.lease_connection.get_database_version}"
+  puts "=" * 80
+end
+
 module ActiveSupport
   class TestCase < ::Minitest::Test
     include ARTest::SQLServer::CoerceableTest


### PR DESCRIPTION
An exception was being silently thrown when getting the database version, and then defaulting to `2016`. 

In this PR:

- Fix the bug when retrieving the database version
- Stops the exception from being silently swallowed in future
- Outputs the database version after each test run to help debugging