### PR TITLE
Reverse order of values when upserting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for INDEX INCLUDE.
 - [#1312](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1312) Add support for `insert_all` and `upsert_all`
+- [#1317](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1317) Reverse order of values when upserting
 
 #### Changed
 

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -169,6 +169,8 @@ module ActiveRecord
         end
 
         def build_sql_for_merge_insert(insert:, insert_all:, columns_with_uniqueness_constraints:) # :nodoc:
+          insert_all.inserts.reverse! if insert.update_duplicates?
+
           sql = <<~SQL
             MERGE INTO #{insert.model.quoted_table_name} WITH (UPDLOCK, HOLDLOCK) AS target
             USING (


### PR DESCRIPTION
I contributed [two tests to Rails](https://github.com/rails/rails/pull/54790) because I was not sure how `insert_all` and `upsert_all` should behave with duplicate identifiers, but with different values in other columns.

For `insert_all`, all DBMS only insert the first value. For `upsert_all`, PostgreSQL throws an error in this scenario, but with sqlite and MySQL, the last entry ends up in the database.

For now, I do not have a smarter idea than reversing the `inserts`, which ultimately provide the `values_list`. Adding `MAX` would be another idea, but I fear the SQL query would get much more complicated.