### PR TITLE
Fix SQL statement to calculate `updated_at` when upserting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@
 #### Fixed
 
 - [#1313](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313) Correctly retrieve the SQL Server database version.
+- [#1320](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1320) Fix SQL statement to calculate `updated_at` when upserting
 
 Please check [8-0-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8-0-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -592,7 +592,7 @@ module ActiveRecord
         def build_sql_for_recording_timestamps_when_updating(insert:)
           insert.model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if insert.send(:touch_timestamp_attribute?, column_name)
-              "target.#{quote_column_name(column_name)}=CASE WHEN (#{insert.updatable_columns.map { |column| "(COALESCE(target.#{quote_column_name(column)}, 'NULL') = COALESCE(source.#{quote_column_name(column)}, 'NULL'))" }.join(" AND ")}) THEN target.#{quote_column_name(column_name)} ELSE #{high_precision_current_timestamp} END,"
+              "target.#{quote_column_name(column_name)}=CASE WHEN (#{insert.updatable_columns.map { |column| "(source.#{quote_column_name(column)} = target.#{quote_column_name(column)} OR (source.#{quote_column_name(column)} IS NULL AND target.#{quote_column_name(column)} IS NULL))" }.join(" AND ")}) THEN target.#{quote_column_name(column_name)} ELSE #{high_precision_current_timestamp} END,"
             end
           end.join
         end

--- a/test/cases/insert_all_test_sqlserver.rb
+++ b/test/cases/insert_all_test_sqlserver.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "cases/helper_sqlserver"
+require "models/sqlserver/recurring_task"
+
+class InsertAllTestSQLServer < ActiveRecord::TestCase
+  test "upsert_all recording of timestamps works with mixed datatypes" do
+    task = RecurringTask.create!(
+      key: "abcdef",
+      priority: 5
+    )
+
+    RecurringTask.upsert_all([{
+      id: task.id,
+      priority: nil
+    }])
+
+    assert_not_equal task.updated_at, RecurringTask.find(task.id).updated_at
+  end
+end

--- a/test/models/sqlserver/recurring_task.rb
+++ b/test/models/sqlserver/recurring_task.rb
@@ -1,0 +1,3 @@
+class RecurringTask < ActiveRecord::Base
+  self.table_name = "recurring_tasks"
+end

--- a/test/schema/sqlserver_specific_schema.rb
+++ b/test/schema/sqlserver_specific_schema.rb
@@ -372,4 +372,12 @@ ActiveRecord::Schema.define do
       name varchar(255)
     )
   TABLE_IN_OTHER_SCHEMA_USED_BY_MODEL
+
+  create_table "recurring_tasks", force: true do |t|
+    t.string :key
+    t.integer :priority, default: 0
+
+    t.datetime2 :created_at
+    t.datetime2 :updated_at
+  end
 end


### PR DESCRIPTION
The previous `CASE` statement used `COALESCE` with `'NULL'` as a fallback value if either `source` or `target` were `NULL`. However, `'NULL'` as written in this statement, is a `varchar` and therefore does not work when comparing with other datatypes (e.g. `int`).

This commit changes the switch statement to check if either both values are equal, or both values are actually `NULL`.