### PR TITLE
Redefine isolation level method as MSSSQL resets isolation after transaction

### DIFF
--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1842,6 +1842,16 @@ class TransactionIsolationTest < ActiveRecord::TestCase
 
   # I really need some help understanding this one.
   coerce_tests! %r{repeatable read}
+
+  private
+
+  # The isolation level is set twice. Once by the transaction and once when the connection is reset
+  # by `SQLServerRealTransaction#commit`. MySQL & PostgreSQL do not reset the connection and SQLite does support
+  # transaction isolation.
+  undef_method :assert_begin_isolation_level_event
+  def assert_begin_isolation_level_event(events)
+    assert_equal 2, events.select { _1.match(/SET TRANSACTION ISOLATION LEVEL READ COMMITTED/) }.size
+  end
 end
 
 class ViewWithPrimaryKeyTest < ActiveRecord::TestCase

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1852,8 +1852,9 @@ class TransactionIsolationTest < ActiveRecord::TestCase
   def assert_begin_isolation_level_event(events, isolation: "READ COMMITTED")
     isolation_events = events.select { _1.match(/SET TRANSACTION ISOLATION LEVEL/) }
 
-    reset_starting_isolation_level_event = isolation_events.delete("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
-    assert reset_starting_isolation_level_event.present?
+    index_of_reset_starting_isolation_level_event = isolation_events.index("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+    assert index_of_reset_starting_isolation_level_event.present?
+    isolation_events.delete_at(index_of_reset_starting_isolation_level_event)
 
     assert_equal 1, isolation_events.select { _1.match(/SET TRANSACTION ISOLATION LEVEL #{isolation}/) }.size
   end


### PR DESCRIPTION
Redefine isolation level method as MSSSQL resets isolation level after transaction unlike MySQL/PostgreSQL.

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/14250370905/job/39941435835
```
 1) Failure:
TransactionIsolationTest#test_0003_default_isolation_level [/usr/local/bundle/bundler/gems/rails-e0452e80137c/activerecord/test/cases/transaction_isolation_test.rb:80]:
Expected: 1
  Actual: 2
```