### PR TITLE
Use latest Ubuntu image on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run test suite
-    runs-on: ubuntu-20.04 # TODO: Change back to 'ubuntu-latest' when https://github.com/microsoft/mssql-docker/issues/899 resolved.
+    runs-on: ubuntu-latest
 
     env:
       COMPOSE_FILE: compose.ci.yaml
@@ -34,26 +34,26 @@ jobs:
       - name: Run tests
         run: docker compose run ci
 
-
-  standardrb:
-    name: Code linting and formatting
-    runs-on: ubuntu-20.04 # TODO: Change back to 'ubuntu-latest' when https://github.com/microsoft/mssql-docker/issues/899 resolved.
-
-    env:
-      COMPOSE_FILE: compose.ci.yaml
-
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - 3.4.1
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Build docker images
-        run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
-
-      - name: Run standardrb
-        run: docker compose run standardrb
+#
+#  standardrb:
+#    name: Code linting and formatting
+#    runs-on: ubuntu-latest
+#
+#    env:
+#      COMPOSE_FILE: compose.ci.yaml
+#
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        ruby:
+#          - 3.4.1
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#
+#      - name: Build docker images
+#        run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
+#
+#      - name: Run standardrb
+#        run: docker compose run standardrb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,26 +34,26 @@ jobs:
       - name: Run tests
         run: docker compose run ci
 
-#
-#  standardrb:
-#    name: Code linting and formatting
-#    runs-on: ubuntu-latest
-#
-#    env:
-#      COMPOSE_FILE: compose.ci.yaml
-#
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        ruby:
-#          - 3.4.1
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Build docker images
-#        run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
-#
-#      - name: Run standardrb
-#        run: docker compose run standardrb
+
+  standardrb:
+    name: Code linting and formatting
+    runs-on: ubuntu-latest
+
+    env:
+      COMPOSE_FILE: compose.ci.yaml
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 3.4.1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build docker images
+        run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
+
+      - name: Run standardrb
+        run: docker compose run standardrb


### PR DESCRIPTION
CI no longer working because of error message:

`
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
`

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/14555834333