### PR TITLE
Move AbstractAdapter#valid_type? to a class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [Rubygems](https://rubygems.org/gems/activerecord-sqlserver-adapter/versions
 
 #### Native Data Type Support
 
-We support every data type supported by FreeTDS. All simplified Rails types in migrations will correspond to a matching SQL Server national (unicode) data type. Always check the `initialize_native_database_types` [(here)](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/lib/active_record/connection_adapters/sqlserver/schema_statements.rb) for an updated list.
+We support every data type supported by FreeTDS. All simplified Rails types in migrations will correspond to a matching SQL Server national (unicode) data type. Always check the `NATIVE_DATABASE_TYPES` [(here)](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/lib/active_record/connection_adapters/sqlserver_adapter.rb) for an updated list.
 
 The following types (`date`, `datetime2`, `datetimeoffset`, `time`) all require TDS version `7.3` with TinyTDS. We recommend using FreeTDS 1.0 or higher which default to using `TDSVER` to `7.3`. The adapter also sets TinyTDS's `tds_version` to this as well if non is specified.
 

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -4,10 +4,6 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module SchemaStatements
-        def native_database_types
-          @native_database_types ||= initialize_native_database_types.freeze
-        end
-
         def create_table(table_name, **options)
           res = super
           clear_cache!
@@ -487,42 +483,6 @@ module ActiveRecord
         end
 
         # === SQLServer Specific ======================================== #
-
-        def initialize_native_database_types
-          {
-            primary_key: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY",
-            primary_key_nonclustered: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED",
-            integer: {name: "int", limit: 4},
-            bigint: {name: "bigint"},
-            boolean: {name: "bit"},
-            decimal: {name: "decimal"},
-            money: {name: "money"},
-            smallmoney: {name: "smallmoney"},
-            float: {name: "float"},
-            real: {name: "real"},
-            date: {name: "date"},
-            datetime: {name: "datetime"},
-            datetime2: {name: "datetime2"},
-            datetimeoffset: {name: "datetimeoffset"},
-            smalldatetime: {name: "smalldatetime"},
-            timestamp: {name: "datetime2(6)"},
-            time: {name: "time"},
-            char: {name: "char"},
-            varchar: {name: "varchar", limit: 8000},
-            varchar_max: {name: "varchar(max)"},
-            text_basic: {name: "text"},
-            nchar: {name: "nchar"},
-            string: {name: "nvarchar", limit: 4000},
-            text: {name: "nvarchar(max)"},
-            ntext: {name: "ntext"},
-            binary_basic: {name: "binary"},
-            varbinary: {name: "varbinary", limit: 8000},
-            binary: {name: "varbinary(max)"},
-            uuid: {name: "uniqueidentifier"},
-            ss_timestamp: {name: "timestamp"},
-            json: {name: "nvarchar(max)"}
-          }
-        end
 
         def column_definitions(table_name)
           identifier = database_prefix_identifier(table_name)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -62,6 +62,40 @@ module ActiveRecord
       self.use_output_inserted = true
       self.exclude_output_inserted_table_names = Concurrent::Map.new { false }
 
+      NATIVE_DATABASE_TYPES = {
+        primary_key: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY",
+        primary_key_nonclustered: "bigint NOT NULL IDENTITY(1,1) PRIMARY KEY NONCLUSTERED",
+        integer: {name: "int", limit: 4},
+        bigint: {name: "bigint"},
+        boolean: {name: "bit"},
+        decimal: {name: "decimal"},
+        money: {name: "money"},
+        smallmoney: {name: "smallmoney"},
+        float: {name: "float"},
+        real: {name: "real"},
+        date: {name: "date"},
+        datetime: {name: "datetime"},
+        datetime2: {name: "datetime2"},
+        datetimeoffset: {name: "datetimeoffset"},
+        smalldatetime: {name: "smalldatetime"},
+        timestamp: {name: "datetime2(6)"},
+        time: {name: "time"},
+        char: {name: "char"},
+        varchar: {name: "varchar", limit: 8000},
+        varchar_max: {name: "varchar(max)"},
+        text_basic: {name: "text"},
+        nchar: {name: "nchar"},
+        string: {name: "nvarchar", limit: 4000},
+        text: {name: "nvarchar(max)"},
+        ntext: {name: "ntext"},
+        binary_basic: {name: "binary"},
+        varbinary: {name: "varbinary", limit: 8000},
+        binary: {name: "varbinary(max)"},
+        uuid: {name: "uniqueidentifier"},
+        ss_timestamp: {name: "timestamp"},
+        json: {name: "nvarchar(max)"}
+      }
+
       class << self
         def dbconsole(config, options = {})
           sqlserver_config = config.configuration_hash
@@ -94,6 +128,10 @@ module ActiveRecord
           Rails.application.class.name.split("::").first
         rescue
           nil # Might not be in a Rails context so we fallback to `nil`.
+        end
+
+        def native_database_types # :nodoc:
+          NATIVE_DATABASE_TYPES
         end
       end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -1850,13 +1850,13 @@ class TransactionIsolationTest < ActiveRecord::TestCase
   # can assert the number of expected isolation level events.
   undef_method :assert_begin_isolation_level_event
   def assert_begin_isolation_level_event(events, isolation: "READ COMMITTED")
-    isolation_events = events.select { _1.match(/SET TRANSACTION ISOLATION LEVEL/) }
+    isolation_events = events.select { |event| event.match(/SET TRANSACTION ISOLATION LEVEL/) }
 
     index_of_reset_starting_isolation_level_event = isolation_events.index("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
     assert index_of_reset_starting_isolation_level_event.present?
     isolation_events.delete_at(index_of_reset_starting_isolation_level_event)
 
-    assert_equal 1, isolation_events.select { _1.match(/SET TRANSACTION ISOLATION LEVEL #{isolation}/) }.size
+    assert_equal 1, isolation_events.count { |event| event.match(/SET TRANSACTION ISOLATION LEVEL #{isolation}/) }
   end
 end
 


### PR DESCRIPTION
Refactor native database types for https://github.com/rails/rails/pull/54875

Fixes (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/14670746703/job/41176483142?pr=1325):

```
  1) Error:
ActiveRecord::AdapterTest#test_invalid_column:
NameError: undefined local variable or method 'native_database_types' for class ActiveRecord::ConnectionAdapters::SQLServerAdapter
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:894:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter.valid_type?'
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/test/cases/adapter_test.rb:57:in 'ActiveRecord::AdapterTest#test_invalid_column'

  2) Error:
ActiveRecord::AdapterTest#test_valid_column:
NameError: undefined local variable or method 'native_database_types' for class ActiveRecord::ConnectionAdapters::SQLServerAdapter
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:894:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter.valid_type?'
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/test/cases/adapter_test.rb:51:in 'block in ActiveRecord::AdapterTest#test_valid_column'
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/test/cases/adapter_test.rb:49:in 'Hash#each_key'
    /usr/local/bundle/bundler/gems/rails-99e27fa586af/activerecord/test/cases/adapter_test.rb:49:in 'ActiveRecord::AdapterTest#test_valid_column'
```