### PR TITLE
Fix multiple nil identity columns for merge insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 #### Added
 
-- [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for INDEX INCLUDE.
-- [#1312](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1312) Add support for `insert_all` and `upsert_all`
-- [#1317](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1317) Reverse order of values when upserting
+- [#1301](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1301) Add support for `INDEX INCLUDE`.
+- [#1312](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1312) Add support for `insert_all` and `upsert_all`.
+- [#1317](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1317) Reverse order of values when upserting.
 
 #### Changed
 
@@ -13,6 +13,7 @@
 #### Fixed
 
 - [#1313](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313) Correctly retrieve the SQL Server database version.
-- [#1320](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1320) Fix SQL statement to calculate `updated_at` when upserting
+- [#1320](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1320) Fix SQL statement to calculate `updated_at` when upserting.
+- [#1327](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1327) Fix multiple `nil` identity columns for merge insert.
 
 Please check [8-0-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8-0-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -223,7 +223,7 @@ module ActiveRecord
               if column.is_identity?
                 identity_index += 1
                 table_name = quote(quote_table_name(column.table_name))
-                Arel.sql("IDENT_CURRENT(#{table_name}) + IDENT_INCR(#{table_name}) * #{identity_index}")
+                Arel.sql("IDENT_CURRENT(#{table_name}) + (IDENT_INCR(#{table_name}) * #{identity_index})")
               else
                 connection.default_insert_value(column)
               end


### PR DESCRIPTION
Handle merge inserts that contain multiple `nil` identity columns. Eg:

```ruby
Book.upsert_all [
  { id: nil, name: "New edition 1" },
  { id: nil, name: "New edition 2" },
]
```

Previously the SQL generated would have been:

```sql
MERGE INTO [books] WITH (updlock, holdlock) AS target
using (SELECT *
       FROM   (SELECT [id],
                      [name],
                      [created_at],
                      [updated_at],
                      [updated_on],
                      Row_number()
                        OVER (
                          partition BY [id]
                          ORDER BY [id] DESC ) AS rn_0
               FROM   (VALUES 
                             (Ident_current(N'[books]') + Ident_incr(N'[books]'),
                      N'New edition 2',
                      CURRENT_TIMESTAMP,
                      CURRENT_TIMESTAMP,
                      CURRENT_TIMESTAMP),
                              (Ident_current(N'[books]') + Ident_incr(N'[books]'),
                      N'New edition 1',
                      CURRENT_TIMESTAMP,
                      CURRENT_TIMESTAMP,
                      CURRENT_TIMESTAMP)) AS t1 ([id], [name], [created_at],
                      [updated_at],
                      [updated_on])) AS ranked_source
       WHERE  rn_0 = 1) AS source
ON ( target.[id] = source.[id] )
WHEN matched THEN
  UPDATE SET target.[updated_at] = CASE
                                     WHEN (( source.[name] = target.[name]
                                              OR ( source.[name] IS NULL
                                                   AND target.[name] IS NULL ) )
                                          ) THEN
                                     target.[updated_at]
                                     ELSE CURRENT_TIMESTAMP
                                   END,
             target.[updated_on] = CASE
                                     WHEN (( source.[name] = target.[name]
                                              OR ( source.[name] IS NULL
                                                   AND target.[name] IS NULL ) )
                                          ) THEN
                                     target.[updated_on]
                                     ELSE CURRENT_TIMESTAMP
                                   END,
             target.[name] = source.[name]
WHEN NOT matched BY target THEN
  INSERT ([id],
          [name],
          [created_at],
          [updated_at],
          [updated_on])
  VALUES (source.[id],
          source.[name],
          source.[created_at],
          source.[updated_at],
          source.[updated_on])
output inserted.[id]; 
```

When this is run only the book with title "New edition 1" is created in the table. The reason is that "New edition 2" is first inserted but then "New edition 1" is updated over "New edition 2" since it matches `ON ( target.[id] = source.[id] )`. 

The fix changes the inserted ID columns to the following so that they don't match and both records get inserted:

- Ident_current(N'[books]') + (Ident_incr(N'[books]') * 1)
- Ident_current(N'[books]') + (Ident_incr(N'[books]') * 2)

This fixes the following tests which were added by https://github.com/rails/rails/pull/54962

- InsertAllTest#test_insert_all_implicitly_sets_primary_keys_when_nil
- InsertAllTest#test_upsert_all_implicitly_sets_primary_keys_when_nil