### PR TITLE
Enable identity insert on view's base table for fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Run test suite
-    runs-on: ubuntu-20.04 # TODO: Change back to 'ubuntu-latest' when https://github.com/microsoft/mssql-docker/issues/899 resolved.
+    runs-on: ubuntu-latest
 
     env:
       COMPOSE_FILE: docker-compose.ci.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1333](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1333) Enable identity insert on view's base table for fixtures.
+
 ## v7.2.5
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -42,9 +42,6 @@ module ActiveRecord
           log(sql, name, binds, async: async) do |notification_payload|
             with_raw_connection do |conn|
               result = if id_insert_table_name = query_requires_identity_insert?(sql)
-                         # If the table name is a view, we need to get the base table name for enabling identity insert.
-                         id_insert_table_name = view_table_name(id_insert_table_name) if view_exists?(id_insert_table_name)
-
                          with_identity_insert_enabled(id_insert_table_name, conn) do
                            internal_exec_sql_query(sql, conn)
                          end
@@ -194,11 +191,14 @@ module ActiveRecord
         end
 
         def with_identity_insert_enabled(table_name, conn)
-          table_name = quote_table_name(table_name)
-          set_identity_insert(table_name, conn, true)
+          # If the table name is a view, we need to get the base table name for enabling identity insert.
+          table_name = view_table_name(table_name) if view_exists?(table_name)
+          quoted_table_name = quote_table_name(table_name)
+
+          set_identity_insert(quoted_table_name, conn, true)
           yield
         ensure
-          set_identity_insert(table_name, conn, false)
+          set_identity_insert(quoted_table_name, conn, false)
         end
 
         def use_database(database = nil)

--- a/test/cases/view_test_sqlserver.rb
+++ b/test/cases/view_test_sqlserver.rb
@@ -48,11 +48,17 @@ class ViewTestSQLServer < ActiveRecord::TestCase
     end
   end
 
-  describe 'identity insert' do
-    it "identity insert works with views" do
-      assert_difference("SSTestCustomersView.count", 1) do
+  describe "identity insert" do
+    it "creates table record through a view" do
+      assert_difference("SSTestCustomersView.count", 2) do
         SSTestCustomersView.create!(id: 5, name: "Bob")
+        SSTestCustomersView.create!(id: 6, name: "Tim")
       end
+    end
+
+    it "creates table records through a view using fixtures" do
+      ActiveRecord::FixtureSet.create_fixtures(File.join(ARTest::SQLServer.test_root_sqlserver, "fixtures"), ["sst_customers_view"])
+      assert_equal SSTestCustomersView.all.count, 2
     end
   end
 end

--- a/test/fixtures/sst_customers_view.yml
+++ b/test/fixtures/sst_customers_view.yml
@@ -1,0 +1,6 @@
+david:
+  name: "David"
+  balance: 2,004
+aidan:
+  name: "Aidan"
+  balance: 10,191


### PR DESCRIPTION
Fix issue with identity inserts through a view not working for fixtures. 

Fixes https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/1224