### PR TITLE
Support more Azure services by changing language source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Changed
+
+- [#1341](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1341) Support more Azure services by changing language source.
+
 ## v7.2.6
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -228,7 +228,7 @@ module ActiveRecord
 
         def user_options_dateformat
           if sqlserver_azure?
-            select_value "SELECT [dateformat] FROM [sys].[syslanguages] WHERE [langid] = @@LANGID", "SCHEMA"
+            select_value "SELECT [dateformat] FROM [sys].[syslanguages] WHERE [name] = @@LANGUAGE", "SCHEMA"
           else
             user_options["dateformat"]
           end


### PR DESCRIPTION
…UAGE.

Hey Team,

Proposing this change to expand the support across other Azure SQL solutions, including Azure Synapse.

According to https://learn.microsoft.com/en-us/sql/t-sql/functions/langid-transact-sql?view=sql-server-ver17&viewFallbackFrom=azure-sqldw-latest < `@@LANGID` is supported by SQL Server, Azure SQL Database and Azure SQL Managed Instance, whereas https://learn.microsoft.com/en-us/sql/t-sql/functions/language-transact-sql?view=sql-server-ver17 adds Azure Synapse Analytics and Analytics Platform System.