### PR TITLE
Foreign keys are expected in reverse order

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -269,7 +269,7 @@ module ActiveRecord
           identifier = SQLServer::Utils.extract_identifiers(table_name)
           fk_info = execute_procedure :sp_fkeys, nil, identifier.schema, nil, identifier.object, identifier.schema
 
-          grouped_fk = fk_info.group_by { |row| row["FK_NAME"] }.values.each { |group| group.sort_by! { |row| row["KEY_SEQ"] } }
+          grouped_fk = fk_info.group_by { |row| row["FK_NAME"] }.values.each { |group| group.sort_by! { |row| row["KEY_SEQ"] } }.reverse
           grouped_fk.map do |group|
             row = group.first
             options = {

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -838,6 +838,34 @@ module ActiveRecord
           nil
         end
       end
+
+      # Foreign key count is the same as PostgreSQL/SQLite.
+      coerce_tests! :test_remove_foreign_key_on_8_0
+      def test_remove_foreign_key_on_8_0_coerced
+        connection.create_table(:sub_testings) do |t|
+          t.references :testing, foreign_key: true, type: :bigint
+          t.references :experiment, foreign_key: { to_table: :testings }, type: :bigint
+        end
+
+        migration = Class.new(ActiveRecord::Migration[8.0]) do
+          def up
+            change_table(:sub_testings) do |t|
+              t.remove_foreign_key :testings
+              t.remove_foreign_key :testings, column: :experiment_id
+            end
+          end
+        end
+
+        assert_raise(StandardError, match: /Table 'sub_testings' has no foreign key for testings$/) {
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        }
+
+        foreign_keys = @connection.foreign_keys("sub_testings")
+        assert_equal 2, foreign_keys.size
+      ensure
+        connection.drop_table(:sub_testings, if_exists: true)
+        ActiveRecord::Base.clear_cache!
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes:

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/16113377465/job/45461734371
```
  3) Failure:
ActiveRecord::Migration::CompatibilityTest#test_remove_foreign_key_on_8_0 [/usr/local/bundle/bundler/gems/rails-4621f7131d2a/activerecord/test/cases/migration/compatibility_test.rb:706]:
StandardError expected but nothing was raised.
```

Test added by https://github.com/rails/rails/pull/55086