### PR TITLE
Clean ActiveRecord backtraces as if they are in the source

### DIFF
--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -5,6 +5,7 @@ require "bundler/setup"
 Bundler.require :default, :development
 require "pry"
 require "support/core_ext/query_cache"
+require "support/core_ext/backtrace_cleaner"
 require "support/minitest_sqlserver"
 require "support/test_in_memory_oltp"
 require "support/table_definition_sqlserver"

--- a/test/support/core_ext/backtrace_cleaner.rb
+++ b/test/support/core_ext/backtrace_cleaner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Need to handle `ActiveRecord` lines like they are in the source rather than in the Rails gem.
+module SQLServer
+  module BacktraceCleaner
+    extend ActiveSupport::Concern
+
+    private
+
+    def add_gem_filter
+      gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
+      return if gems_paths.empty?
+
+      gems_regexp = %r{\A(#{gems_paths.join("|")})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
+      gems_result = '\3 (\4) \5'
+
+      add_filter do |line|
+        if line.match?(/activerecord/)
+          line
+        else
+          line.sub(gems_regexp, gems_result)
+        end
+      end
+    end
+
+    def add_gem_silencer
+      add_silencer do |line|
+        ActiveSupport::BacktraceCleaner::FORMATTED_GEMS_PATTERN.match?(line) && !/activerecord/.match?(line)
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveSupport::BacktraceCleaner.prepend(SQLServer::BacktraceCleaner)
+end


### PR DESCRIPTION
Treat ActiveRecord backtraces lines as if they are from the source code rather than from the Rails gem. 

Fixes the following tests. 

https://github.com/aidanharan/rails/pull/4/files#diff-895b194d1cd076295b52cf047d3452420d42f082f4208f4e97e1a9eb87caf0ee
```
1) Failure:
AssociationDeprecationTest::WarnModeTest#test_0001_report warns in :warn mode [/usr/local/bundle/bundler/gems/rails-4621f7131d2a/activerecord/test/cases/associations/deprecation_test.rb:127]:
Expected /The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked \(\/usr\/local\/bundle\/bundler\/gems\/rails-4621f7131d2a\/activerecord\/test\/cases\/associations\/deprecation_test.rb:126:in/ to match "W, [2025-07-07T09:38:38.097702 #30]  WARN -- : The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked ()\n".

  3) Failure:
AssociationDeprecationTest::RaiseModeTest#test_0001_report raises an error in :raise mode [/usr/local/bundle/bundler/gems/rails-4621f7131d2a/activerecord/test/cases/associations/deprecation_test.rb:183]:
Expected /The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked \(\/usr\/local\/bundle\/bundler\/gems\/rails-4621f7131d2a\/activerecord\/test\/cases\/associations\/deprecation_test.rb:182:in/ to match "The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked ()".

  4) Failure:
AssociationDeprecationTest::RaiseBacktraceModeTest#test_0001_report raises an error in :raise mode [/usr/local/bundle/bundler/gems/rails-4621f7131d2a/activerecord/test/cases/associations/deprecation_test.rb:198]:
Expected /The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked \(\/usr\/local\/bundle\/bundler\/gems\/rails-4621f7131d2a\/activerecord\/test\/cases\/associations\/deprecation_test.rb:196:in/ to match "The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked ()".

  5) Failure:
AssociationDeprecationTest::NotifyModeTest#test_0001_report publishes an Active Support notification in :notify mode [/usr/local/bundle/bundler/gems/rails-4621f7131d2a/activerecord/test/cases/associations/deprecation_test.rb:241]:
Expected /The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked \(\/usr\/local\/bundle\/bundler\/gems\/rails-4621f7131d2a\/activerecord\/test\/cases\/associations\/deprecation_test.rb:233:in/ to match "The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked ()".

  6) Failure:
AssociationDeprecationTest::WarnBacktraceModeTest#test_0001_report warns in :warn mode [/usr/local/bundle/bundler/gems/rails-[462](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/actions/runs/16113377465/job/45461734338#step:4:463)1f7131d2a/activerecord/test/cases/associations/deprecation_test.rb:151]:
Expected /The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked \(\/usr\/local\/bundle\/bundler\/gems\/rails-4621f7131d2a\/activerecord\/test\/cases\/associations\/deprecation_test.rb:149:in/ to match "W, [2025-07-07T09:41:27.178952 #30]  WARN -- : The association DATS::Car#deprecated_tyres is deprecated, the method deprecated_tyres was invoked ()\n".
```