### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Build docker images
         run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
 
+      # This step should be performed when creating the docker image instead of here.
       - name: Install libresolv
         run: sudo apt-get update && sudo apt-get install -y libc6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
       - name: Build docker images
         run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
 
-      # This step should be performed when creating the docker image instead of here.
-      - name: Install libresolv
-        run: sudo apt-get update && sudo apt-get install -y libc6
-
       - name: Run tests
         run: docker compose run ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build docker images
         run: docker compose build --build-arg TARGET_VERSION=${{ matrix.ruby }}
 
+      - name: Install libresolv
+        run: sudo apt-get update && sudo apt-get install -y libc6
+
       - name: Run tests
         run: docker compose run ci
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "bcrypt"
-gem "pg", "~> 1.3"
+gem "pg", "1.5.9"
 gem "sqlite3", ">= 2.1"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "benchmark-ips"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "bcrypt"
+gem "pg", "~> 1.3"
+gem "sqlite3", ">= 2.1"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "benchmark-ips"
 gem "minitest", ">= 5.15.0"

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
 gem "bcrypt"
-gem "pg", ">= 0.18.0"
-gem "sqlite3", ">= 1.6.6"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "benchmark-ips"
 gem "minitest", ">= 5.15.0"

--- a/compose.ci.yaml
+++ b/compose.ci.yaml
@@ -1,4 +1,3 @@
-version: "2.2"
 services:
   sqlserver:
     image: ghcr.io/rails-sqlserver/mssql-server-linux-rails


### PR DESCRIPTION
Version of 1.6.0 of the "pg" adapter is causing the CI to fail, shown below. Use v1.5.9 for the time being to get around the issue as we are not testing PostgreSQL anyway.

```
/usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- pg_ext (LoadError)
Did you mean?  3.4/pg_ext
	from /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /usr/local/bundle/gems/pg-1.6.0-x86_64-linux/lib/pg.rb:53:in 'block in <module:PG>'
	from /usr/local/bundle/gems/pg-1.6.0-x86_64-linux/lib/pg.rb:40:in 'block in <module:PG>'
	from /usr/local/bundle/gems/pg-1.6.0-x86_64-linux/lib/pg.rb:46:in '<module:PG>'
	from /usr/local/bundle/gems/pg-1.6.0-x86_64-linux/lib/pg.rb:6:in '<top (required)>'
	from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel.replace_require'
	from /usr/local/lib/ruby/3.4.0/bundler/runtime.rb:65:in 'block (2 levels) in Bundler::Runtime#require'
	from /usr/local/lib/ruby/3.4.0/bundler/runtime.rb:60:in 'Array#each'
	from /usr/local/lib/ruby/3.4.0/bundler/runtime.rb:60:in 'block in Bundler::Runtime#require'
	from /usr/local/lib/ruby/3.4.0/bundler/runtime.rb:52:in 'Array#each'
	from /usr/local/lib/ruby/3.4.0/bundler/runtime.rb:52:in 'Bundler::Runtime#require'
	from /usr/local/lib/ruby/3.4.0/bundler.rb:216:in 'Bundler.require'
	from /activerecord-sqlserver-adapter/test/cases/helper_sqlserver.rb:5:in '<top (required)>'
```