### PR TITLE
Correctly retrieve the SQL Server database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v7.1.11
+## Unreleased
+
+#### Fixed
+
+Correctly retrieve the SQL Server database version.
 
 #### Fixed
 

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -505,7 +505,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        @sqlserver_version ||= execute("SELECT @@version", "SCHEMA").rows.first.first.to_s
       end
 
       private

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -129,6 +129,16 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
   end
 
+  it 'test proper connection before fetching sqlserver_version'
+    connection.disconnect!
+
+    assert_nothing_raised do
+      version = connection.sqlserver_version
+      assert version.is_a?(String)
+      assert version.length > 0
+    end
+  end
+
   describe "with different language" do
     before do
       @default_language = connection.user_options_language


### PR DESCRIPTION
Fixes #1360. Porting changes in https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313 back to `7-1-stable`. This bug impacts `7.1`, `7.2` and `8.0`
