### PR TITLE
Correctly retrieve the SQL Server database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/) Correctly retrieve the SQL Server database version.
+
 ## v8.0.8
 
 #### Changed
@@ -5,6 +11,7 @@
 - [#1342](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1342) Support more Azure services by changing language source.
 
 #### Fixed
+
 - [#1345](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1345) Maintain index options during `change_column` operations.
 - [#1357](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1357) Support cross database inserts.
 

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -481,19 +481,16 @@ module ActiveRecord
       end
 
       def version_year
-        @version_year ||= begin
-          if sqlserver_version =~ /vNext/
+        @version_year ||=
+          if /vNext/.match?(sqlserver_version)
             2016
           else
             /SQL Server (\d+)/.match(sqlserver_version).to_a.last.to_s.to_i
           end
-        rescue StandardError
-          2016
-        end
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        @sqlserver_version ||= execute("SELECT @@version", "SCHEMA").rows.first.first.to_s
       end
 
       private

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -135,6 +135,16 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     end
   end
 
+  it 'valid connection before fetching SQL Server version' do
+  connection.disconnect!
+
+  assert_nothing_raised do
+    version = connection.sqlserver_version
+    assert version.is_a?(String)
+    assert version.length > 0
+  end
+end
+
   describe "with different language" do
     before do
       @default_language = connection.user_options_language

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -15,6 +15,14 @@ require "support/connection_reflection"
 require "support/query_assertions"
 require "mocha/minitest"
 
+Minitest.after_run do
+  puts "\n\n"
+  puts "=" * 80
+  puts ActiveRecord::Base.lease_connection.send(:sqlserver_version)
+  puts "\nSQL Server Version Year: #{ActiveRecord::Base.lease_connection.get_database_version}"
+  puts "=" * 80
+end
+
 module ActiveSupport
   class TestCase < ::Minitest::Test
     include ARTest::SQLServer::CoerceableTest


### PR DESCRIPTION
Backport of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313