### PR TITLE
Correctly retrieve the SQL Server database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Fixed
 
-- [#1366](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1366) Verify connection before retrieving the database version.
+- [#1366](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1366) Correctly retrieve the SQL Server database version.
 
 ## v8.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Fixed
+
+- [#1366](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1366) Verify connection before retrieving the database version.
+
 ## v8.0.8
 
 #### Changed

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -490,16 +490,16 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        @sqlserver_version ||= begin
+          verify!
+          _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        end
       end
 
       private
 
       def connect
-        @sqlserver_version ||= begin
-          verify!
-          _raw_select("SELECT @@version", @raw_connection).first.first.to_s
-        end
+        @raw_connection = self.class.new_client(@connection_parameters)
       end
 
       def configure_connection

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -481,15 +481,12 @@ module ActiveRecord
       end
 
       def version_year
-        @version_year ||= begin
-          if sqlserver_version =~ /vNext/
+        @version_year ||=
+          if /vNext/.match?(sqlserver_version)
             2016
           else
             /SQL Server (\d+)/.match(sqlserver_version).to_a.last.to_s.to_i
           end
-        rescue StandardError
-          2016
-        end
       end
 
       def sqlserver_version
@@ -499,7 +496,10 @@ module ActiveRecord
       private
 
       def connect
-        @raw_connection = self.class.new_client(@connection_parameters)
+        @sqlserver_version ||= begin
+          verify!
+          _raw_select("SELECT @@version", @raw_connection).first.first.to_s
+        end
       end
 
       def configure_connection

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -490,10 +490,7 @@ module ActiveRecord
       end
 
       def sqlserver_version
-        @sqlserver_version ||= begin
-          verify!
-          _raw_select("SELECT @@version", @raw_connection).first.first.to_s
-        end
+        @sqlserver_version ||= execute("SELECT @@version", "SCHEMA").rows.first.first.to_s
       end
 
       private

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -15,6 +15,14 @@ require "support/connection_reflection"
 require "support/query_assertions"
 require "mocha/minitest"
 
+Minitest.after_run do
+  puts "\n\n"
+  puts "=" * 80
+  puts ActiveRecord::Base.lease_connection.send(:sqlserver_version)
+  puts "\nSQL Server Version Year: #{ActiveRecord::Base.lease_connection.get_database_version}"
+  puts "=" * 80
+end
+
 module ActiveSupport
   class TestCase < ::Minitest::Test
     include ARTest::SQLServer::CoerceableTest


### PR DESCRIPTION
Backport of https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1313