### PR TITLE
Added support for Nulls first and last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Added
 
-- [#1](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/) Added support for Nulls first and last.
+- [#1385](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1385) Added support for Nulls first and last.
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Added
 
+- [#1](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/) Added support for Nulls first and last.
+
 #### Changed
 
 - [#1381](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1381) Fix `change_column` to preserve old column attributes.

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -271,6 +271,25 @@ module Arel
         collect_ctes(o.children, collector)
       end
 
+      def visit_Arel_Nodes_NullsFirst(o, collector)
+        collector << sql_to_order_nulls_position(o, is_first: true)
+        collector << ", "
+        visit o.expr, collector
+      end
+
+      def visit_Arel_Nodes_NullsLast(o, collector)
+        collector << sql_to_order_nulls_position(o, is_first: false)
+        collector << ", "
+        visit o.expr, collector
+      end
+
+      def sql_to_order_nulls_position(o, is_first:)
+        order_column = "".dup
+        visit o.expr.expr, order_column
+
+        "(CASE WHEN #{order_column} IS NULL THEN #{is_first ? 0 : 1} ELSE #{is_first ? 1 : 0} END)"
+      end
+
       # SQLServer ToSql/Visitor (Additions)
 
       def visit_Arel_Nodes_SelectStatement_SQLServer_Lock(collector, options = {})

--- a/test/cases/order_test_sqlserver.rb
+++ b/test/cases/order_test_sqlserver.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper_sqlserver"
 require "models/post"
+require "models/book"
 
 class OrderTestSQLServer < ActiveRecord::TestCase
   fixtures :posts
@@ -149,5 +150,25 @@ class OrderTestSQLServer < ActiveRecord::TestCase
   it "doesn't deduplicate semantically equal orders" do
     sql = Post.order(:id).order("posts.id ASC").to_sql
     assert_equal "SELECT [posts].* FROM [posts] ORDER BY [posts].[id] ASC, posts.id ASC", sql
+  end
+
+  it "support nulls first" do
+    Book.delete_all
+    Book.create!(title: "Hyperion")
+    Book.create!(title: nil)
+    Book.create!(title: "Dune")
+
+    books = Book.order(Book.arel_table[:title].desc.nulls_first)
+    assert_equal([nil, "Hyperion", "Dune"], books.map(&:title))
+  end
+
+  it "support nulls last" do
+    Book.delete_all
+    Book.create!(title: "Hyperion")
+    Book.create!(title: nil)
+    Book.create!(title: "Dune")
+
+    books = Book.order(Book.arel_table[:title].desc.nulls_last)
+    assert_equal(["Hyperion", "Dune", nil], books.map(&:title))
   end
 end


### PR DESCRIPTION
Added support for `.nulls_first()` and `.nulls_last()`. 

ANSI SQL has an option to allow the database to specify where NULLS come out in this sort order:

```
    ORDER BY column ASC NULLS FIRST
```

However, SQL Server does not support this SQL. Instead to implement the equivalent in SQL Server we need to use:

```
ORDER BY CASE WHEN column IS NULL THEN 0 ELSE 1 END, column ASC
```


Refs: 

- https://github.com/rails/rails/pull/42245
- https://dba-presents.com/databases/sql-server/36-order-by-and-nulls-last-in-sql-server