### PR TITLE
Various fixes for CI to pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ end
 
 group :development do
   gem "minitest-spec-rails"
-  gem "mocha"
   gem "pry-byebug", platform: [:mri, :mingw, :x64_mingw]
 end
 

--- a/lib/arel/visitors/sqlserver.rb
+++ b/lib/arel/visitors/sqlserver.rb
@@ -376,9 +376,9 @@ module Arel
         if Arel::Table === core.from
           core.from
         elsif Arel::Nodes::SqlLiteral === core.from
-          Arel::Table.new(core.from)
+          Arel::Table.new(name: core.from)
         elsif Arel::Nodes::JoinSource === core.source
-          (Arel::Nodes::SqlLiteral === core.source.left) ? Arel::Table.new(core.source.left, @engine) : core.source.left.left
+          (Arel::Nodes::SqlLiteral === core.source.left) ? Arel::Table.new(name: core.source.left) : core.source.left.left
         end
       end
 

--- a/test/cases/coerced_tests.rb
+++ b/test/cases/coerced_tests.rb
@@ -2491,6 +2491,17 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     Book.where(author_id: nil, name: nil).delete_all
     Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
   end
+
+  # Need to remove index as SQL Server considers NULLs on a unique-index to be equal unlike PostgreSQL/MySQL/SQLite.
+  coerce_tests! :test_in_order_of_with_column_from_cte
+  def test_in_order_of_with_column_from_cte_coerced
+    connection.remove_index(:books, column: [:author_id, :name])
+
+    original_test_in_order_of_with_column_from_cte
+  ensure
+    Book.where(author_id: nil, name: nil).delete_all
+    Book.lease_connection.add_index(:books, [:author_id, :name], unique: true)
+  end
 end
 
 class QueryLogsTest < ActiveRecord::TestCase
@@ -2715,7 +2726,7 @@ module ActiveRecord
     # Adapter returns an object that is subclass of what is expected in the original test.
     coerce_tests! %r{#associated_table creates the right type caster for joined table with different association name}
     def associated_table_creates_the_right_type_caster_for_joined_table_with_different_association_name_coerced
-      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new("developers"))
+      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new(name: "developers"))
 
       associated_table_metadata = base_table_metadata.associated_table("audit_logs")
 

--- a/test/cases/dbconsole_test_sqlserver.rb
+++ b/test/cases/dbconsole_test_sqlserver.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
+require "cases/helper_sqlserver"
+
 class DbConsole < ActiveRecord::TestCase
   subject { ActiveRecord::ConnectionAdapters::SQLServerAdapter }
 
   it "uses sqlcmd to connect to database" do
-    subject.expects(:find_cmd_and_exec).with("sqlcmd", "-d", "db", "-U", "user", "-P", "secret", "-C", "-S",
-      "tcp:localhost,1433")
+    assert_called_with(subject, :find_cmd_and_exec, ["sqlcmd", "-d", "db", "-U", "user", "-P", "secret", "-C", "-S", "tcp:localhost,1433"]) do
+      config = make_db_config(adapter: "sqlserver", database: "db", username: "user", password: "secret", host: "localhost", port: 1433, trust_server_certificate: true)
 
-    config = make_db_config(adapter: "sqlserver", database: "db", username: "user", password: "secret",
-      host: "localhost", port: 1433, trust_server_certificate: true)
-
-    subject.dbconsole(config)
+      subject.dbconsole(config)
+    end
   end
 
   private

--- a/test/cases/fully_qualified_identifier_test_sqlserver.rb
+++ b/test/cases/fully_qualified_identifier_test_sqlserver.rb
@@ -5,7 +5,7 @@ require "cases/helper_sqlserver"
 class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
   describe "local server" do
     it "should use table name in select projections" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       expected_sql = "SELECT [table].[name] FROM [table]"
       assert_equal expected_sql, table.project(table[:name]).to_sql
     end
@@ -21,39 +21,39 @@ class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
     end
 
     it "should use fully qualified table name in select from clause" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       expected_sql = "SELECT * FROM [my.server].[db].[schema].[table]"
       assert_equal expected_sql, table.project(Arel.star).to_sql
     end
 
     it "should not use fully qualified table name in select projections" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       expected_sql = "SELECT [table].[name] FROM [my.server].[db].[schema].[table]"
       assert_equal expected_sql, table.project(table[:name]).to_sql
     end
 
     it "should not use fully qualified table name in where clause" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"
       quietly { assert_equal expected_sql, table.project(Arel.star).where(table[:id].eq(42)).to_sql }
     end
 
     it "should not use fully qualified table name in order clause" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       expected_sql = "SELECT * FROM [my.server].[db].[schema].[table] ORDER BY [table].[name]"
       assert_equal expected_sql, table.project(Arel.star).order(table[:name]).to_sql
     end
 
     it "should use fully qualified table name in insert statement" do
       manager = Arel::InsertManager.new
-      manager.into Arel::Table.new(:table)
+      manager.into Arel::Table.new(name: :table)
       manager.values = manager.create_values [Arel.sql("*")]
       expected_sql = "INSERT INTO [my.server].[db].[schema].[table] VALUES (*)"
       quietly { assert_equal expected_sql, manager.to_sql }
     end
 
     it "should use fully qualified table name in update statement" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       manager = Arel::UpdateManager.new
       manager.table(table).where(table[:id].eq(42))
       manager.set([[table[:name], "Bob"]])
@@ -62,7 +62,7 @@ class FullyQualifiedIdentifierTestSQLServer < ActiveRecord::TestCase
     end
 
     it "should use fully qualified table name in delete statement" do
-      table = Arel::Table.new(:table)
+      table = Arel::Table.new(name: :table)
       manager = Arel::DeleteManager.new
       manager.from(table).where(table[:id].eq(42))
       expected_sql = "DELETE FROM [my.server].[db].[schema].[table] WHERE [table].[id] = 42"

--- a/test/cases/helper_sqlserver.rb
+++ b/test/cases/helper_sqlserver.rb
@@ -14,7 +14,6 @@ require "support/load_schema_sqlserver"
 require "support/coerceable_test_sqlserver"
 require "support/connection_reflection"
 require "support/query_assertions"
-require "mocha/minitest"
 
 Minitest.after_run do
   puts "\n\n"

--- a/test/cases/lateral_test_sqlserver.rb
+++ b/test/cases/lateral_test_sqlserver.rb
@@ -8,8 +8,8 @@ class LateralTestSQLServer < ActiveRecord::TestCase
   fixtures :posts, :authors
 
   it "uses OUTER APPLY for OUTER JOIN LATERAL" do
-    post = Arel::Table.new(:posts)
-    author = Arel::Table.new(:authors)
+    post = Arel::Table.new(name: :posts)
+    author = Arel::Table.new(name: :authors)
     subselect = post.project(Arel.star).take(1).where(post[:author_id].eq(author[:id])).where(post[:id].eq(42))
 
     one = Arel::Nodes::Quoted.new(1)
@@ -22,8 +22,8 @@ class LateralTestSQLServer < ActiveRecord::TestCase
   end
 
   it "uses CROSS APPLY for INNER JOIN LATERAL" do
-    post = Arel::Table.new(:posts)
-    author = Arel::Table.new(:authors)
+    post = Arel::Table.new(name: :posts)
+    author = Arel::Table.new(name: :authors)
     subselect = post.project(Arel.star).take(1).where(post[:author_id].eq(author[:id])).where(post[:id].eq(42))
 
     sql = author.project(Arel.star).where(author[:name].matches("David")).join(subselect.lateral.as("bar")).to_sql


### PR DESCRIPTION
Fixes:
- Refactor Arel::Table to use keyword name: argument (https://github.com/rails/rails/commit/b1650993b02497ae7d0d8b984d40bc036e62c681)
- Removed mocha gem
- Coerced test