### PR TITLE
Treat TinyTDS `failed dbsqlsend()` errors as `ConnectionNotEstablished`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,6 @@
 
 #### Fixed
 
+- [#1393](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1393) Treat TinyTDS `failed dbsqlsend() function` errors as `ConnectionNotEstablished` so they're retried instead of surfaced as `StatementInvalid`.
+
 Please check [8-1-stable](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/8-1-stable/CHANGELOG.md) for previous changes.

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -483,7 +483,7 @@ module ActiveRecord
 
       def translate_exception(exception, message:, sql:, binds:)
         case message
-        when /(SQL Server client is not connected)|(failed to execute statement)/i
+        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)/i
           ConnectionNotEstablished.new(message, connection_pool: @pool)
         when /(cannot insert duplicate key .* with unique index) | (violation of (unique|primary) key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)


### PR DESCRIPTION
TinyTDS can raise `failed dbsqlsend() function` when the underlying FreeTDS socket has dropped. This happens when an idle connection gets reaped by network infrastructure or by SQL Server itself.

`translate_exception` doesn't recognize this message right now, so it falls through to `StatementInvalid`. ActiveRecord's connection pool doesn't treat that as reconnectable, so callers get a hard query failure instead of a transparent reconnect and retry.

This is the same failure mode already handled for `"SQL Server client is not connected"` and `"failed to execute statement"`. I added `failed dbsqlsend` to that same pattern so it maps to `ActiveRecord::ConnectionNotEstablished` too.