### PR TITLE
Treat "DBPROCESS is dead or not enabled" as ConnectionNotEstablished

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -483,7 +483,7 @@ module ActiveRecord
 
       def translate_exception(exception, message:, sql:, binds:)
         case message
-        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)/i
+        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)|(DBPROCESS is dead or not enabled)/i
           ConnectionNotEstablished.new(message, connection_pool: @pool)
         when /(cannot insert duplicate key .* with unique index) | (violation of (unique|primary) key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -483,7 +483,8 @@ module ActiveRecord
 
       def translate_exception(exception, message:, sql:, binds:)
         case message
-        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)|(DBPROCESS is dead or not enabled)/i
+        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)/i,
+             /(DBPROCESS is dead or not enabled)/i
           ConnectionNotEstablished.new(message, connection_pool: @pool)
         when /(cannot insert duplicate key .* with unique index) | (violation of (unique|primary) key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -41,6 +41,14 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     assert_raise(ActiveRecord::StatementInvalid) { Topic.lease_connection.update("UPDATE XXX") }
   end
 
+  it "translates a dead DBPROCESS TinyTds error into a connection not established error" do
+    exception = TinyTds::Error.new("DBPROCESS is dead or not enabled")
+    translated = connection.send(
+      :translate_exception, exception, message: exception.message, sql: "SELECT 1", binds: []
+    )
+    assert_kind_of ActiveRecord::ConnectionNotEstablished, translated
+  end
+
   it "is has our adapter_name" do
     assert_equal "SQLServer", connection.adapter_name
   end


### PR DESCRIPTION
## Summary

- Adds `DBPROCESS is dead or not enabled` to the pattern list in `translate_exception` so it's classified as `ConnectionNotEstablished` instead of falling through to `StatementInvalid`.

## Why

When the TCP/TLS connection underlying a `TinyTds::Client` is killed while idle, the next query on it fails with `TinyTds::Error: DBPROCESS is dead or not enabled`. Because `translate_exception` didn't match this message against any of its patterns, it fell through to `StatementInvalid` — a plain "your SQL was bad" error rather than a connection error. This means Rails never gets a signal that the connection itself is broken, so the pool checks the same dead connection back in and every subsequent request that gets it fails identically until the process is restarted.

Full analysis, packet-capture evidence, and background on why Rails 8's `verify!`/`active?` self-healing doesn't catch this either (FreeTDS's `dbdead()` is a passive flag) are in #1396.

Fixes #1396.