### PR TITLE
Backport error messages for when connection not established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+#### Changed
+
+- [#1393](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1393) Treat TinyTDS `failed dbsqlsend() function` errors as `ConnectionNotEstablished` so they're retried instead of surfaced as `StatementInvalid`.
+- [#1397](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1397) Treat "DBPROCESS is dead or not enabled" as ConnectionNotEstablished.
+
 ## v8.0.10
 
 #### Fixed

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -432,7 +432,7 @@ module ActiveRecord
 
       def translate_exception(exception, message:, sql:, binds:)
         case message
-        when /(SQL Server client is not connected)|(failed to execute statement)/i
+        when /(SQL Server client is not connected)|(failed to execute statement)|(failed dbsqlsend)|(DBPROCESS is dead or not enabled)/i
           ConnectionNotEstablished.new(message, connection_pool: @pool)
         when /(cannot insert duplicate key .* with unique index) | (violation of (unique|primary) key constraint)/i
           RecordNotUnique.new(message, sql: sql, binds: binds, connection_pool: @pool)


### PR DESCRIPTION
Backport:
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1397
- https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1393