### PR TITLE
Fix insert_all/upsert_all for single character, temporary and three part table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Changed
+
+- [#1405](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1405) Fix `insert_all`/`upsert_all` for single character, temporary, non-ASCII and three part table names, and stop an aliased target being included in the `MERGE` table name.
+
 ## v8.1.3
 
 #### Added

--- a/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/schema_statements.rb
@@ -4,6 +4,9 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module SchemaStatements
+        MERGE_TARGET_IDENTIFIER = /(?:\[[^\]]+\]|[a-z0-9_-]+)/i # :nodoc:
+        MERGE_TARGET_TABLE_NAME = /\A\s*MERGE\s+INTO\s+(#{MERGE_TARGET_IDENTIFIER}(?:\s*\.#{MERGE_TARGET_IDENTIFIER}){0,2})\s+(?:AS|WITH|USING)/i # :nodoc:
+
         def create_table(table_name, **options)
           res = super
           clear_cache!
@@ -726,7 +729,7 @@ module ActiveRecord
           elsif s.match?(/^\s*UPDATE\s+.*/i)
             s.match(/UPDATE\s+([^(\s]+)\s*/i)[1]
           elsif s.match?(/^\s*MERGE INTO.*/i)
-            s.match(/^\s*MERGE\s+INTO\s+(\[?[a-z0-9_ -]+\]?\.?\[?[a-z0-9_ -]+\]?)\s+(AS|WITH|USING)/i)[1]
+            s.match(MERGE_TARGET_TABLE_NAME)[1]
           else
             s.match(/FROM[\s|(]+((\[[^(\]]+\])|[^(\s]+)\s*/i)[1]
           end.strip

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -230,6 +230,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       @identity_merge_sql = "MERGE INTO [ships] WITH (UPDLOCK, HOLDLOCK) AS target USING ( SELECT * FROM ( SELECT [id], [name], ROW_NUMBER() OVER ( PARTITION BY [id] ORDER BY [id] DESC ) AS rn_0 FROM ( VALUES (101, N'RSS Sir David Attenborough') ) AS t1 ([id], [name]) ) AS ranked_source WHERE rn_0 = 1 ) AS source ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[name] = source.[name] WHEN NOT MATCHED BY TARGET THEN INSERT ([id], [name]) VALUES (source.[id], source.[name]) OUTPUT INSERTED.[id]"
       @identity_merge_sql_unquoted = "MERGE INTO ships WITH (UPDLOCK, HOLDLOCK) AS target USING ( SELECT * FROM ( SELECT id, name, ROW_NUMBER() OVER ( PARTITION BY id ORDER BY id DESC ) AS rn_0 FROM ( VALUES (101, N'RSS Sir David Attenborough') ) AS t1 (id, name) ) AS ranked_source WHERE rn_0 = 1 ) AS source ON (target.id = source.id) WHEN MATCHED THEN UPDATE SET target.name = source.name WHEN NOT MATCHED BY TARGET THEN INSERT (id, name) VALUES (source.id, source.name) OUTPUT INSERTED.id"
       @identity_merge_sql_unordered = "MERGE INTO [ships] WITH (UPDLOCK, HOLDLOCK) AS target USING ( SELECT * FROM ( SELECT [name], [id], ROW_NUMBER() OVER ( PARTITION BY [id] ORDER BY [id] DESC ) AS rn_0 FROM ( VALUES (101, N'RSS Sir David Attenborough') ) AS t1 ([name], [id]) ) AS ranked_source WHERE rn_0 = 1 ) AS source ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[name] = source.[name] WHEN NOT MATCHED BY TARGET THEN INSERT ([name], [id]) VALUES (source.[name], source.[id]) OUTPUT INSERTED.[id]"
+      @identity_merge_sql_aliased_target = @identity_merge_sql.sub(" WITH (UPDLOCK, HOLDLOCK)", "")
 
       @identity_insert_sql_non_dbo = "INSERT INTO [test].[aliens] ([id],[name]) VALUES(420,'Mork')"
       @identity_insert_sql_non_dbo_unquoted = "INSERT INTO test.aliens ([id],[name]) VALUES(420,'Mork')"
@@ -253,6 +254,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
       assert_equal "[ships]", connection.send(:query_requires_identity_insert?, @identity_merge_sql)
       assert_equal "[ships]", connection.send(:query_requires_identity_insert?, @identity_merge_sql_unquoted)
       assert_equal "[ships]", connection.send(:query_requires_identity_insert?, @identity_merge_sql_unordered)
+      assert_equal "[ships]", connection.send(:query_requires_identity_insert?, @identity_merge_sql_aliased_target)
 
       assert_equal "[test].[aliens]", connection.send(:query_requires_identity_insert?, @identity_insert_sql_non_dbo)
       assert_equal "[test].[aliens]", connection.send(:query_requires_identity_insert?, @identity_insert_sql_non_dbo_unquoted)

--- a/test/cases/schema_test_sqlserver.rb
+++ b/test/cases/schema_test_sqlserver.rb
@@ -122,6 +122,38 @@ class SchemaTestSQLServer < ActiveRecord::TestCase
       it do
         assert_equal "[with_numbers_1234]", connection.send(:get_raw_table_name, "MERGE INTO [with_numbers_1234] AS target")
       end
+
+      it do
+        assert_equal "[dashboards]", connection.send(:get_raw_table_name, "MERGE INTO [dashboards] AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "lock_without_defaults", connection.send(:get_raw_table_name, "MERGE INTO lock_without_defaults AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "[WITH - SPACES]", connection.send(:get_raw_table_name, "MERGE INTO [WITH - SPACES] AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "[with].[select notation]", connection.send(:get_raw_table_name, "MERGE INTO [with].[select notation] AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "[x]", connection.send(:get_raw_table_name, "MERGE INTO [x] WITH (UPDLOCK, HOLDLOCK) AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "[with].[select notation]", connection.send(:get_raw_table_name, "MERGE INTO [with].[select notation] WITH (UPDLOCK, HOLDLOCK) AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "[a].[dbo].[dashboards]", connection.send(:get_raw_table_name, "MERGE INTO [a].[dbo].[dashboards] WITH (UPDLOCK, HOLDLOCK) AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
+
+      it do
+        assert_equal "with .dashboards", connection.send(:get_raw_table_name, "MERGE INTO with .dashboards WITH (UPDLOCK, HOLDLOCK) AS target USING (VALUES (1)) AS source ([id]) ON (target.[id] = source.[id]) WHEN NOT MATCHED THEN INSERT ([id]) VALUES (source.[id]);")
+      end
     end
 
     describe "CREATE VIEW statements" do


### PR DESCRIPTION
Fixes #1402.
Replaces #1403, which targeted `main`.

I used AI assistance to narrow down the cause and to check the patch for
regressions, but everything here was verified by running the reproduction script
and the adapter's test suite against a local SQL Server 2019.

`upsert_all` (and `insert_all` when it takes the `MERGE` path) raises
`NoMethodError` when the `MERGE` table name pattern cannot match the target, and
returns a wrong name when the target carries an alias. See #1402 for the full
analysis of why the two identifier slots behave that way.

`INSERT`, `UPDATE` and `FROM` already handle three part names; only `MERGE` was
limited to two.

## Fix

Replace the pattern with an explicit identifier that matches either a bracket
quoted or a bare name, joined by up to two dots:

```ruby
MERGE_TARGET_IDENTIFIER = /(?:\[[^\]]+\]|[a-z0-9_-]+)/i # :nodoc:
MERGE_TARGET_TABLE_NAME = /\A\s*MERGE\s+INTO\s+(#{MERGE_TARGET_IDENTIFIER}(?:\s*\.#{MERGE_TARGET_IDENTIFIER}){0,2})\s+(?:AS|WITH|USING)/i # :nodoc:
```

Notes on the choices:

- A bracket quoted segment is `\[[^\]]+\]`, so spaces inside brackets are kept
  (`[WITH - SPACES]`) while a space is no longer allowed in a bare name. That is
  what stops an aliased target being captured as part of the table name.
- The dot separator is `\s*\.`, not `\.`, so `MERGE INTO dbo .products` keeps
  working. It parses today and I did not want to change that.
- `{0,2}` allows one, two and three part names, matching the other branches.

## Tests

- `test/cases/schema_test_sqlserver.rb` — 8 cases added to the existing
  `MERGE statements` block (5 -> 13): bracket quoted and bare names, a single
  character name, a name with spaces inside brackets, two and three part names,
  with and without a `WITH (UPDLOCK, HOLDLOCK)` hint, and the space before the
  dot case.
- `test/cases/adapter_test_sqlserver.rb` — one more assertion in the
  `query_requires_identity_insert?` test, using the generated `MERGE` with the
  table hint removed so the aliased target is exercised.

Run against Rails 8.1.3.1 and SQL Server 2019.

Without the change:

```
schema_test_sqlserver.rb     32 runs, 40 assertions, 3 failures, 2 errors
adapter_test_sqlserver.rb    82 runs, 176 assertions, 0 failures, 1 errors, 1 skip
```

With the change:

```
schema_test_sqlserver.rb     32 runs, 42 assertions, 0 failures, 0 errors
adapter_test_sqlserver.rb    82 runs, 184 assertions, 0 failures, 0 errors, 1 skip
insert_all_test_sqlserver.rb  1 runs,   1 assertions, 0 failures, 0 errors
```

`bundle exec standardrb` is clean for the whole repository.

## Branches

Targeting `8-1-stable` as requested in #1403.

The same pattern is present on `main` and `8-0-stable`. The change applies
cleanly to both, and `test/cases/schema_test_sqlserver.rb` is identical across
the three branches. Happy to open follow up PRs for either once you are happy
with this one.
